### PR TITLE
fix: Considering special cases, the first word should not wrap when it goes beyond the width of the MText.

### DIFF
--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -662,7 +662,13 @@ export class MTextProcessor {
     }
     // 2. If word would overflow, start a new line first (no indent for wrapped lines)
     if (this.hOffset + wordWidth > (this.maxLineWidth || Infinity)) {
-      this.startNewLine() // Do not apply indent for wrapped lines
+      // SPECIAL CASE:
+      // If this is the first word of the current paragraph (no rendered objects yet), do not wrap.
+      if (this._vOffset <= 0 && this._currentLineObjects.length <= 0) {
+        // Do nothing
+      } else {
+        this.startNewLine() // Start a new line for wrapped words
+      }
     }
     // 3. Render the word character by character
     for (let i = 0; i < word.length; i++) {


### PR DESCRIPTION
Fixed mlightcad/cad-viewer#61

Cause:
If the first word exceeds the width set by MText, it will also wrap the line, which will cause the word render position to be offset downwards from the expected position.

Therefore, we detect the first word of this paragraph and give special treatment.