### PR TITLE
fix: fix issue on rendering text using font verdana

### DIFF
--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-renderer",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "AutoCAD MText renderer based on Three.js",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",

--- a/packages/mtext-renderer/src/font/meshFont.ts
+++ b/packages/mtext-renderer/src/font/meshFont.ts
@@ -207,31 +207,43 @@ export class MeshFont extends BaseFont {
       return
     }
 
-    const glyph = this.opentypeFont.charToGlyph(char)
-    if (!glyph || !glyph.path) return
+    // Notes:
+    // Please don't use method `hasChar`. Its implementation is as follows.
+    // ```
+    // return this.encoding.charToGlyphIndex(n) !== null;
+    // ```
+    // Method `charToGlyphIndex` returns undefined if not found. However, it
+    // uses '!==null' to check whether it is found or not.
+    //
+    // I checked opentype.js source code and found it was fixed. However, it
+    // isn't included in latest released (1.3.4) yet.
+    if (this.opentypeFont.charToGlyphIndex(char) > 0) {
+      const glyph = this.opentypeFont.charToGlyph(char)
+      if (!glyph || !glyph.path) return
 
-    const round = Math.round
-    const token = {
-      ha: round(glyph.advanceWidth ?? 0),
-      x_min: round(glyph.xMin ?? 0),
-      x_max: round(glyph.xMax ?? 0),
-      o: ''
+      const round = Math.round
+      const token = {
+        ha: round(glyph.advanceWidth ?? 0),
+        x_min: round(glyph.xMin ?? 0),
+        x_max: round(glyph.xMax ?? 0),
+        o: ''
+      }
+
+      glyph.path.commands.forEach((command: GlyphCommand) => {
+        let t = command.type.toLowerCase()
+        if (t === 'c') t = 'b'
+        token.o += t + ' '
+        if (command.x !== undefined && command.y !== undefined)
+          token.o += round(command.x) + ' ' + round(command.y) + ' '
+        if (command.x1 !== undefined && command.y1 !== undefined)
+          token.o += round(command.x1) + ' ' + round(command.y1) + ' '
+        if (command.x2 !== undefined && command.y2 !== undefined)
+          token.o += round(command.x2) + ' ' + round(command.y2) + ' '
+      })
+
+      this.data.glyphs[char] = token
+      this.glyphCache.set(char, token)
     }
-
-    glyph.path.commands.forEach((command: GlyphCommand) => {
-      let t = command.type.toLowerCase()
-      if (t === 'c') t = 'b'
-      token.o += t + ' '
-      if (command.x !== undefined && command.y !== undefined)
-        token.o += round(command.x) + ' ' + round(command.y) + ' '
-      if (command.x1 !== undefined && command.y1 !== undefined)
-        token.o += round(command.x1) + ' ' + round(command.y1) + ' '
-      if (command.x2 !== undefined && command.y2 !== undefined)
-        token.o += round(command.x2) + ' ' + round(command.y2) + ' '
-    })
-
-    this.data.glyphs[char] = token
-    this.glyphCache.set(char, token)
   }
 
   /**


### PR DESCRIPTION
There is one bug on opentype.js. Method 'charToGlyph' will not return null or undefined if one character isn't found in one font. So
Chinse character is rendered as "▯" if one font doesn't contain this character instead of falling back to the default font. For example, font Verdana contains only ascii characters.

Actually there is one bug in method 'hasChar' too. So I checked opentype.js source code and found it was fixed. However, it isn't included in latest released (1.3.4) yet. So I use method 'charToGlyphIndex' to work around this issue.