### PR TITLE
feat: update dependency @mlightcad/mtext-parser and refine github ci/cd pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,12 +3,15 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [ main ]
+    tags:
+      - 'v*'
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -18,16 +21,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v2
         with:
           version: 9
       
       # Cache node_modules
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
+          registry-url: https://registry.npmjs.org
        
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -40,6 +46,22 @@ jobs:
         
       - name: Build the package
         run: pnpm build
+
+      - name: Publish packages to npm
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          cp README.md packages/mtext-renderer/README.md
+          pnpm publish:renderer
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "nx run-many -t lint",
     "lint:fix": "nx run-many -t lint:fix",
     "preview": "nx run @mlightcad/mtext-renderer-example:preview",
-    "publish-renderer": "pnpm -r publish --filter mtext-renderer --no-git-checks",
+    "publish:renderer": "pnpm -r publish --filter mtext-renderer --no-git-checks",
     "test": "pnpm --filter @mlightcad/mtext-renderer test"
   },
   "engines": {

--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-renderer",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "AutoCAD MText renderer based on Three.js",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",
@@ -42,7 +42,7 @@
     "3d-text"
   ],
   "dependencies": {
-    "@mlightcad/mtext-parser": "^1.3.2",
+    "@mlightcad/mtext-parser": "^1.3.3",
     "@mlightcad/shx-parser": "^1.3.2",
     "iconv-lite": "^0.7.0",
     "idb": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
   packages/mtext-renderer:
     dependencies:
       '@mlightcad/mtext-parser':
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: ^1.3.3
+        version: 1.3.3
       '@mlightcad/shx-parser':
         specifier: ^1.3.2
         version: 1.3.2
@@ -992,8 +992,8 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
-  '@mlightcad/mtext-parser@1.3.2':
-    resolution: {integrity: sha512-lOmuLCDs2oKrYcxx0EP82gfXrEprg0e1G5gaQSCXqePldIA8WAh5zfvynAkQJkmKKISA2jHcgz/8X3Xxyzbjog==}
+  '@mlightcad/mtext-parser@1.3.3':
+    resolution: {integrity: sha512-vJDDeaOnNWQ+Oj8lDmibOt+vqvhYp89COTW29De3IL5FcfsLjXW/UUqyIVuEY2xxIxYnml8YwKwH482KyYeDHg==}
 
   '@mlightcad/shx-parser@1.3.2':
     resolution: {integrity: sha512-j84hqbWOVMDuepLEjVsYvxeiCXOVxHyJhl4gM4HtgXZ6ChgTLsuSnqs2bNOt2SwriTvFOsv3QLsOu2iJh857JA==}
@@ -4457,7 +4457,7 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
-  '@mlightcad/mtext-parser@1.3.2': {}
+  '@mlightcad/mtext-parser@1.3.3': {}
 
   '@mlightcad/shx-parser@1.3.2': {}
 

--- a/tools/release.mjs
+++ b/tools/release.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+
+function run(cmd) {
+  return execSync(cmd, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function fail(msg) {
+  console.error(`❌ ${msg}`);
+  process.exit(1);
+}
+
+/**
+ * Parse vX.Y.Z
+ */
+function parseVersion(tag) {
+  const m = tag.match(/^v(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+  };
+}
+
+/**
+ * Find latest vX.Y.Z tag (sorted by semver, not by time)
+ */
+function findLatestTag() {
+  const output = run('git tag --list "v*.*.*"');
+  if (!output) return null;
+
+  const tags = output
+    .split('\n')
+    .map(t => ({ tag: t, v: parseVersion(t) }))
+    .filter(t => t.v !== null);
+
+  if (tags.length === 0) return null;
+
+  tags.sort((a, b) => {
+    if (a.v.major !== b.v.major) return b.v.major - a.v.major;
+    if (a.v.minor !== b.v.minor) return b.v.minor - a.v.minor;
+    return b.v.patch - a.v.patch;
+  });
+
+  return tags[0].tag;
+}
+
+/**
+ * Main
+ */
+let version = process.argv[2];
+
+if (!version) {
+  const latestTag = findLatestTag();
+  if (!latestTag) {
+    fail('No existing vX.Y.Z tag found, please specify a version explicitly.');
+  }
+
+  const v = parseVersion(latestTag);
+  version = `${v.major}.${v.minor}.${v.patch + 1}`;
+
+  console.log(`ℹ️  No version provided, auto-incrementing patch: ${latestTag} → v${version}`);
+}
+
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  fail(`Invalid version "${version}". Expected format: X.Y.Z`);
+}
+
+const tag = `v${version}`;
+
+/**
+ * Safety checks
+ */
+try {
+  run(`git rev-parse --verify refs/tags/${tag}`);
+  fail(`Tag ${tag} already exists.`);
+} catch {
+  // tag does not exist → OK
+}
+
+try {
+  const branch = run('git branch --show-current');
+  if (branch !== 'main') {
+    fail(`Current branch is "${branch}". Please release from "main".`);
+  }
+} catch {
+  // non-fatal
+}
+
+const status = run('git status --porcelain');
+if (status) {
+  fail('Working tree is not clean. Please commit or stash changes.');
+}
+
+/**
+ * Create & push annotated tag
+ */
+console.log(`🚀 Creating tag ${tag}`);
+
+run(`git tag -a ${tag} -m "release: release ${tag}"`);
+run(`git push origin ${tag}`);
+
+console.log(`✅ Release tag ${tag} pushed successfully`);


### PR DESCRIPTION
## Summary

This PR updates package dependency versions and refines the GitHub CI/CD workflow to support tag-driven release automation.

## Changes

- Bump `@mlightcad/mtext-renderer` version:
  - `0.10.1` -> `0.10.2`
- Upgrade dependency:
  - `@mlightcad/mtext-parser` `^1.3.2` -> `^1.3.3`
  - Update `pnpm-lock.yaml` accordingly
- Refine workflow `.github/workflows/ci-cd.yml`:
  - Trigger on tag push (`v*`)
  - Add `workflow_dispatch`
  - Upgrade Node setup action to `actions/setup-node@v4`
  - Set `fetch-depth: 0` for full git history
  - Add npm registry config for publish
  - Add npm publish step for tag builds
  - Add GitHub Release creation step for tag builds
  - Change `contents` permission from `read` to `write`
- Rename root script:
  - `publish-renderer` -> `publish:renderer`
- Add release helper script:
  - `tools/release.mjs`
  - Supports auto patch version increment from latest `vX.Y.Z` tag
  - Enforces release safety checks (on `main`, clean workspace, tag not existing)

## Why

- Align package release flow with GitHub tag-based automation.
- Ensure dependency update is published with a consistent release process.
- Reduce manual release errors via scripted checks.

## Impact

- Normal PR/main CI behavior remains unchanged for lint/test/build/deploy.
- Tag push (e.g. `v0.10.2`) now additionally:
  - publishes package to npm
  - creates GitHub Release

## Notes

- npm publish requires repository secret: `NPM_TOKEN`.
- `tools/release.mjs` can be used to create and push release tags safely.
