### PR TITLE
feat: improve MText color handling with color settings and material reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ classDiagram
 
 ```typescript
 import * as THREE from 'three';
-import { FontManager, MText, StyleManager } from '@mlightcad/mtext-renderer';
+import { FontManager, MText, MTextColor, StyleManager } from '@mlightcad/mtext-renderer';
 
 // Initialize core components
 const fontManager = FontManager.instance;
@@ -349,6 +349,13 @@ const mtextContent = {
   position: new THREE.Vector3(0, 0, 0),
 };
 
+const colorSettings = {
+  layer: '0',
+  color: new MTextColor(256),
+  byLayerColor: 0xffffff,
+  byBlockColor: 0xffffff,
+};
+
 // Create MText instance with style
 const mtext = new MText(
   mtextContent,
@@ -362,10 +369,10 @@ const mtext = new MText(
     lastHeight: 0.1,
     font: 'Standard',
     bigFont: '',
-    color: 0xffffff,
   },
   styleManager,
-  fontManager
+  fontManager,
+  colorSettings
 );
 
 // Build geometry and load fonts on demand
@@ -381,7 +388,14 @@ scene.add(mtext);
 // Ensure required fonts are loaded beforehand
 await fontManager.loadFontsByNames(['simsun']);
 
-const mtext = new MText(mtextContent, textStyle, styleManager, fontManager);
+const colorSettings = {
+  layer: '0',
+  color: new MTextColor(256),
+  byLayerColor: 0xffffff,
+  byBlockColor: 0xffffff,
+};
+
+const mtext = new MText(mtextContent, textStyle, styleManager, fontManager, colorSettings);
 
 // Build geometry synchronously (no awaits here)
 mtext.syncDraw();
@@ -393,16 +407,23 @@ scene.add(mtext);
 ### Using MainThreadRenderer
 
 ```typescript
-import { MainThreadRenderer } from '@mlightcad/mtext-renderer';
+import { MainThreadRenderer, MTextColor } from '@mlightcad/mtext-renderer';
 
 // Create main thread renderer
 const renderer = new MainThreadRenderer();
+
+const colorSettings = {
+  layer: '0',
+  color: new MTextColor(256),
+  byLayerColor: 0xffffff,
+  byBlockColor: 0xffffff,
+};
 
 // Render MText content asynchronously (fonts are loaded on demand)
 const mtextObject = await renderer.asyncRenderMText(
   mtextContent,
   textStyle,
-  { byLayerColor: 0xffffff, byBlockColor: 0xffffff }
+  colorSettings
 );
 
 // Add to scene
@@ -413,7 +434,7 @@ scene.add(mtextObject);
 const syncObject = renderer.syncRenderMText(
   mtextContent,
   textStyle,
-  { byLayerColor: 0xffffff, byBlockColor: 0xffffff }
+  colorSettings
 );
 scene.add(syncObject);
 ```
@@ -421,10 +442,17 @@ scene.add(syncObject);
 ### Using WebWorkerRenderer
 
 ```typescript
-import { WebWorkerRenderer } from '@mlightcad/mtext-renderer';
+import { WebWorkerRenderer, MTextColor } from '@mlightcad/mtext-renderer';
 
 // Create worker renderer with custom pool size
 const workerRenderer = new WebWorkerRenderer({ poolSize: 4 }); // 4 workers
+
+const colorSettings = {
+  layer: '0',
+  color: new MTextColor(256),
+  byLayerColor: 0xffffff,
+  byBlockColor: 0xffffff,
+};
 
 // Optionally preload fonts once via a coordinator to avoid duplicate concurrent loads
 // await workerRenderer.loadFonts(['simsun', 'arial']);
@@ -433,7 +461,7 @@ const workerRenderer = new WebWorkerRenderer({ poolSize: 4 }); // 4 workers
 const mtextObject = await workerRenderer.asyncRenderMText(
   mtextContent,
   textStyle,
-  { byLayerColor: 0xffffff, byBlockColor: 0xffffff }
+  colorSettings
 );
 
 // Add to scene
@@ -448,16 +476,23 @@ Note: Synchronous rendering is not supported in worker mode.
 ### Using UnifiedRenderer
 
 ```typescript
-import { UnifiedRenderer } from '@mlightcad/mtext-renderer';
+import { UnifiedRenderer, MTextColor } from '@mlightcad/mtext-renderer';
 
 // Create unified renderer with default mode 'main' (optional worker config as second param)
 const unifiedRenderer = new UnifiedRenderer('main');
+
+const colorSettings = {
+  layer: '0',
+  color: new MTextColor(256),
+  byLayerColor: 0xffffff,
+  byBlockColor: 0xffffff,
+};
 
 // Render using default mode (main) asynchronously (fonts loaded on demand)
 let mtextObject = await unifiedRenderer.asyncRenderMText(
   mtextContent,
   textStyle,
-  { byLayerColor: 0xffffff, byBlockColor: 0xffffff }
+  colorSettings
 );
 
 scene.add(mtextObject);
@@ -470,7 +505,7 @@ unifiedRenderer.setDefaultMode('worker');
 mtextObject = await unifiedRenderer.asyncRenderMText(
   heavyMtextContent,
   textStyle,
-  { byLayerColor: 0xffffff, byBlockColor: 0xffffff },
+  colorSettings,
   'worker'
 );
 

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -85,7 +85,7 @@ class MTextRendererExample {
     // Initialize unified renderer (default to main thread)
     this.unifiedRenderer = new UnifiedRenderer('main', {
       workerUrl: new URL(
-        '../../mtext-renderer/src/worker/index.ts',
+        '../../mtext-renderer/src/worker/mtextWorker.ts',
         import.meta.url
       )
     })

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -2,6 +2,7 @@ import {
   CharBox,
   CharBoxType,
   LineLayout,
+  MTextColor,
   MTextData,
   MTextObject,
   RenderMode,
@@ -33,6 +34,7 @@ class MTextRendererExample {
   private renderModeSelect: HTMLSelectElement
   private byLayerColorInput: HTMLInputElement
   private byBlockColorInput: HTMLInputElement
+  private readonly defaultLayerName = '0'
 
   // Example texts
   private readonly exampleTexts = {
@@ -436,8 +438,7 @@ class MTextRendererExample {
           textGenerationFlag: 0,
           lastHeight: 24,
           font: this.fontSelect.value,
-          bigFont: '',
-          color: 0xffffff
+          bigFont: ''
         }
       }
     })
@@ -626,10 +627,12 @@ class MTextRendererExample {
     return Number.isFinite(parsed) ? parsed : fallback
   }
 
-  private getColorSettings(): { byLayerColor: number; byBlockColor: number } {
+  private getColorSettings() {
     return {
       byLayerColor: this.parseColorInput(this.byLayerColorInput, 0xffffff),
-      byBlockColor: this.parseColorInput(this.byBlockColorInput, 0xffffff)
+      byBlockColor: this.parseColorInput(this.byBlockColorInput, 0xffffff),
+      layer: this.defaultLayerName,
+      color: new MTextColor(256)
     }
   }
 
@@ -738,8 +741,7 @@ class MTextRendererExample {
           textGenerationFlag: 0,
           lastHeight: 24,
           font: this.fontSelect.value,
-          bigFont: '',
-          color: 0xffffff
+          bigFont: ''
         }
 
         // Render MText using unified renderer

--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-renderer",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "AutoCAD MText renderer based on Three.js",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",

--- a/packages/mtext-renderer/src/renderer/colorUtils.ts
+++ b/packages/mtext-renderer/src/renderer/colorUtils.ts
@@ -1,0 +1,20 @@
+import { getColorByIndex } from '../common'
+import { ColorSettings } from './types'
+
+export function resolveMTextColor(colorSettings: ColorSettings): number {
+  const color = colorSettings.color
+  const aci = color.aci
+  if (aci === 0) {
+    return colorSettings.byBlockColor
+  }
+  if (aci === 256) {
+    return colorSettings.byLayerColor
+  }
+  if (aci !== null && aci !== undefined) {
+    return getColorByIndex(aci)
+  }
+  if (color.rgbValue !== null) {
+    return color.rgbValue
+  }
+  return colorSettings.byLayerColor
+}

--- a/packages/mtext-renderer/src/renderer/colorUtils.ts
+++ b/packages/mtext-renderer/src/renderer/colorUtils.ts
@@ -1,20 +1,24 @@
 import { getColorByIndex } from '../common'
 import { ColorSettings } from './types'
 
+function normalizeColorNumber(color: number): number {
+  return Math.max(0, Math.min(0xffffff, Math.round(color)))
+}
+
 export function resolveMTextColor(colorSettings: ColorSettings): number {
   const color = colorSettings.color
   const aci = color.aci
   if (aci === 0) {
-    return colorSettings.byBlockColor
+    return normalizeColorNumber(colorSettings.byBlockColor)
   }
   if (aci === 256) {
-    return colorSettings.byLayerColor
+    return normalizeColorNumber(colorSettings.byLayerColor)
   }
   if (aci !== null && aci !== undefined) {
     return getColorByIndex(aci)
   }
   if (color.rgbValue !== null) {
-    return color.rgbValue
+    return normalizeColorNumber(color.rgbValue)
   }
-  return colorSettings.byLayerColor
+  return normalizeColorNumber(colorSettings.byLayerColor)
 }

--- a/packages/mtext-renderer/src/renderer/defaultStyleManager.ts
+++ b/packages/mtext-renderer/src/renderer/defaultStyleManager.ts
@@ -1,7 +1,8 @@
 import * as THREE from 'three'
 
+import { resolveMTextColor } from './colorUtils'
 import { StyleManager } from './styleManager'
-import { StyleTraits } from './types'
+import { ColorSettings } from './types'
 
 /**
  * Class to manage basic text style
@@ -11,21 +12,23 @@ export class DefaultStyleManager implements StyleManager {
   private meshBasicMaterials: { [key: string]: THREE.Material } = {}
   public unsupportedTextStyles: Record<string, number> = {}
 
-  getMeshBasicMaterial(traits: StyleTraits): THREE.Material {
-    const key = this.buildKey(traits)
+  getMeshBasicMaterial(colorSettings: ColorSettings): THREE.Material {
+    const key = this.buildKey(colorSettings)
     if (!this.meshBasicMaterials[key]) {
+      const color = resolveMTextColor(colorSettings)
       this.meshBasicMaterials[key] = new THREE.MeshBasicMaterial({
-        color: traits.color
+        color
       })
     }
     return this.meshBasicMaterials[key]
   }
 
-  getLineBasicMaterial(traits: StyleTraits): THREE.Material {
-    const key = this.buildKey(traits)
+  getLineBasicMaterial(colorSettings: ColorSettings): THREE.Material {
+    const key = this.buildKey(colorSettings)
     if (!this.lineBasicMaterials[key]) {
+      const color = resolveMTextColor(colorSettings)
       this.lineBasicMaterials[key] = new THREE.LineBasicMaterial({
-        color: traits.color
+        color
       })
     }
     return this.lineBasicMaterials[key]
@@ -35,9 +38,11 @@ export class DefaultStyleManager implements StyleManager {
    * Builds a stable material key from traits.
    * Key differs for shader vs basic, ByLayer vs ByEntity.
    */
-  protected buildKey(traits: StyleTraits): string {
-    return traits.isByLayer && traits.layer
-      ? `layer_${traits.layer}_${traits.color}`
-      : `entity_${traits.color}`
+  protected buildKey(colorSettings: ColorSettings): string {
+    const isByLayer = colorSettings.color.aci === 256
+    const resolvedColor = resolveMTextColor(colorSettings)
+    return isByLayer && colorSettings.layer
+      ? `layer_${colorSettings.layer}_${resolvedColor}`
+      : `entity_${resolvedColor}`
   }
 }

--- a/packages/mtext-renderer/src/renderer/index.ts
+++ b/packages/mtext-renderer/src/renderer/index.ts
@@ -1,3 +1,4 @@
+export * from './colorUtils'
 export * from './mtext'
 export * from './styleManager'
 export * from './types'

--- a/packages/mtext-renderer/src/renderer/mtext.ts
+++ b/packages/mtext-renderer/src/renderer/mtext.ts
@@ -376,13 +376,14 @@ export class MText extends THREE.Object3D {
       }
     }
 
-    const defaultFontSize = mtextData.height || 0
+    const defaultFontSize = mtextData.height || style.fixedTextHeight || 0
+    const defaultWidthFactor = mtextData.widthFactor || style.widthFactor || 1.0
     const defaultLineSpaceFactor = mtextData.lineSpaceFactor || 0.3
     const flowDirection =
       mtextData.drawingDirection ?? MTextFlowDirection.LEFT_TO_RIGHT
     const textLineFormatOptions: MTextFormatOptions = {
       fontSize: defaultFontSize,
-      widthFactor: mtextData.widthFactor ?? 1,
+      widthFactor: defaultWidthFactor,
       lineSpaceFactor: defaultLineSpaceFactor,
       horizontalAlignment: horizontalAlignment,
       maxWidth: maxWidth,
@@ -396,7 +397,7 @@ export class MText extends THREE.Object3D {
     const context = new MTextContext()
     context.fontFace.family = style.font
     context.capHeight = {
-      value: mtextData.height ?? style.fixedTextHeight,
+      value: defaultFontSize,
       isRelative: false
     }
     // Absolute value (\Wvalue;)
@@ -406,7 +407,7 @@ export class MText extends THREE.Object3D {
     // – Multiplies the current width factor by the specified value, scaling it relative to
     // the existing width setting.
     context.widthFactor = {
-      value: mtextData.widthFactor ?? style.widthFactor,
+      value: defaultWidthFactor,
       isRelative: false
     }
     context.align = verticalAlignment

--- a/packages/mtext-renderer/src/renderer/mtext.ts
+++ b/packages/mtext-renderer/src/renderer/mtext.ts
@@ -15,6 +15,7 @@ import {
   CharBox,
   CharBoxType,
   ColorSettings,
+  createDefaultColorSettings,
   LineLayout,
   MTextAttachmentPoint,
   MTextData,
@@ -90,10 +91,7 @@ export class MText extends THREE.Object3D {
     style: TextStyle,
     styleManager: StyleManager,
     fontManager: FontManager,
-    colorSettings: ColorSettings = {
-      byLayerColor: 0xffffff,
-      byBlockColor: 0xffffff
-    }
+    colorSettings: ColorSettings = createDefaultColorSettings()
   ) {
     super()
     this._style = style
@@ -101,7 +99,9 @@ export class MText extends THREE.Object3D {
     this._fontManager = fontManager
     this._colorSettings = {
       byLayerColor: colorSettings.byLayerColor,
-      byBlockColor: colorSettings.byBlockColor
+      byBlockColor: colorSettings.byBlockColor,
+      layer: colorSettings.layer,
+      color: colorSettings.color.copy()
     }
     this._box = new THREE.Box3()
     this._layoutData = undefined
@@ -413,6 +413,7 @@ export class MText extends THREE.Object3D {
     context.paragraph.align = horizontalAlignment
     const textLine = new MTextProcessor(
       style,
+      this._colorSettings,
       this.styleManager,
       this.fontManager,
       textLineFormatOptions

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -10,10 +10,12 @@ import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js
 
 import { getColorByIndex } from '../common'
 import { FontManager } from '../font'
+import { resolveMTextColor } from './colorUtils'
 import { StyleManager } from './styleManager'
 import {
   CharBox,
   CharBoxType,
+  ColorSettings,
   LineLayout,
   MTextFlowDirection,
   STACK_DIVIDER_CHAR,
@@ -172,6 +174,7 @@ class RenderContext extends MTextContext {
  */
 export class MTextProcessor {
   private _style: TextStyle
+  private _colorSettings: ColorSettings
   private _styleManager: StyleManager
   private _fontManager: FontManager
   private _options: MTextFormatOptions
@@ -213,11 +216,13 @@ export class MTextProcessor {
    */
   constructor(
     style: TextStyle,
+    colorSettings: ColorSettings,
     styleManager: StyleManager,
     fontManager: FontManager,
     options: MTextFormatOptions
   ) {
     this._style = style
+    this._colorSettings = colorSettings
     this._styleManager = styleManager
     this._fontManager = fontManager
     this._options = options
@@ -240,7 +245,7 @@ export class MTextProcessor {
       )
     })
     // Set initial color
-    this._currentContext.setColorFromHex(style.color)
+    this._currentContext.setColorFromHex(this.resolveBaseColor())
     // Set initial font face
     this._currentContext.fontFace.family = this.textStyle.font.toLowerCase()
     // Set initial width factor
@@ -1756,18 +1761,14 @@ export class MTextProcessor {
     charBoxType: CharBoxType
   ) {
     const meshGroup = new THREE.Group()
-    const color = this._currentContext.getColorAsHex()
 
-    const meshMaterial = this.styleManager.getMeshBasicMaterial({
-      layer: this._style.layer,
-      isByLayer: this._style.isByLayer,
-      color
-    })
-    const lineMaterial = this.styleManager.getLineBasicMaterial({
-      layer: this._style.layer,
-      isByLayer: this._style.isByLayer,
-      color
-    })
+    const materialColorSettings = this.getMaterialColorSettings()
+    const meshMaterial = this.styleManager.getMeshBasicMaterial(
+      materialColorSettings
+    )
+    const lineMaterial = this.styleManager.getLineBasicMaterial(
+      materialColorSettings
+    )
 
     const shouldCollectCharBoxes = this._options.collectCharBoxes !== false
 
@@ -1822,5 +1823,18 @@ export class MTextProcessor {
 
   private changeFontHeight(value: number) {
     this.calcuateLineParams(value)
+  }
+
+  private resolveBaseColor(): number {
+    return resolveMTextColor(this._colorSettings)
+  }
+
+  private getMaterialColorSettings(): ColorSettings {
+    return {
+      byLayerColor: this._colorSettings.byLayerColor,
+      byBlockColor: this._colorSettings.byBlockColor,
+      layer: this._colorSettings.layer,
+      color: this._currentContext.color.copy()
+    }
   }
 }

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -636,7 +636,7 @@ export class MTextProcessor {
       }
     } else {
       this._currentContext.widthFactor = {
-        value: widthFactor.value * 0.93,
+        value: widthFactor.value * 0.85,
         isRelative: false
       }
     }

--- a/packages/mtext-renderer/src/renderer/styleManager.ts
+++ b/packages/mtext-renderer/src/renderer/styleManager.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 
-import { StyleTraits } from './types'
+import { ColorSettings } from './types'
 
 /**
  * Class to manage materials used by texts
@@ -12,12 +12,12 @@ export interface StyleManager {
    * @param traits - Traits to define one mesh basic material
    * @returns - One reusable material for mesh type font.
    */
-  getMeshBasicMaterial(traits: StyleTraits): THREE.Material
+  getMeshBasicMaterial(colorSettings: ColorSettings): THREE.Material
 
   /**
    * Gets one reusable material for line type font. If not found in cache, just create one.
    * @param traits - Traits to define one line basic material
    * @returns - One reusable material for line type font.
    */
-  getLineBasicMaterial(traits: StyleTraits): THREE.Material
+  getLineBasicMaterial(colorSettings: ColorSettings): THREE.Material
 }

--- a/packages/mtext-renderer/src/renderer/types.ts
+++ b/packages/mtext-renderer/src/renderer/types.ts
@@ -1,3 +1,4 @@
+import { MTextColor } from '@mlightcad/mtext-parser'
 import * as THREE from 'three'
 
 /**
@@ -125,22 +126,32 @@ export enum CharBoxType {
  */
 export const STACK_DIVIDER_CHAR = '\uE000'
 
-export interface StyleTraits {
-  /**
-   * Optional layer name. Material is identified by layer and color. So it means different
-   * materials are created for the same color and differnt layer.
-   */
+/**
+ * Defines color settings for text rendering, including layer/material resolution
+ * and ByLayer/ByBlock fallback colors.
+ */
+export interface ColorSettings {
+  /** The color value to use when text is set to "by layer" color mode */
+  byLayerColor: number
+  /** The color value to use when text is set to "by block" color mode */
+  byBlockColor: number
+  /** Optional layer name used when resolving materials */
   layer?: string
   /**
-   * The color of material
+   * Default text color. Use `MTextColor.aci === 256` to indicate ByLayer.
    */
-  color: number
-  /**
-   * One flag to indicate whether the color is by layer. If it is true, it means that the
-   * material become invalid once layer color changed.
-   */
-  isByLayer?: boolean
+  color: MTextColor
 }
+
+/**
+ * Create default color settings (ByLayer + white fallback).
+ */
+export const createDefaultColorSettings = (): ColorSettings => ({
+  byLayerColor: 0xffffff,
+  byBlockColor: 0xffffff,
+  layer: '0',
+  color: new MTextColor()
+})
 
 /**
  * Represents the data structure for multiline text (MText) entities.
@@ -176,7 +187,7 @@ export interface MTextData {
  * This interface contains properties that control various aspects of text rendering including font,
  * dimensions, and display characteristics.
  */
-export interface TextStyle extends StyleTraits {
+export interface TextStyle {
   /** The unique name identifier for this text style */
   name: string
   /** Flag indicating standard text style settings. Controls various text generation behaviors */
@@ -197,16 +208,4 @@ export interface TextStyle extends StyleTraits {
   bigFont: string
   /** Optional extended font settings or alternative font specification */
   extendedFont?: string
-}
-
-/**
- * Defines the default color settings for special color modes in text rendering.
- * These settings are used to resolve color values when text uses layer-dependent
- * or block-dependent coloring.
- */
-export interface ColorSettings {
-  /** The color value to use when text is set to "by layer" color mode */
-  byLayerColor: number
-  /** The color value to use when text is set to "by block" color mode */
-  byBlockColor: number
 }

--- a/packages/mtext-renderer/src/worker/mainThreadRenderer.ts
+++ b/packages/mtext-renderer/src/worker/mainThreadRenderer.ts
@@ -2,7 +2,12 @@ import { FontManager } from '../font'
 import { DefaultStyleManager } from '../renderer/defaultStyleManager'
 import { MText } from '../renderer/mtext'
 import { StyleManager } from '../renderer/styleManager'
-import { ColorSettings, MTextData, TextStyle } from '../renderer/types'
+import {
+  ColorSettings,
+  createDefaultColorSettings,
+  MTextData,
+  TextStyle
+} from '../renderer/types'
 import { MTextBaseRenderer, MTextObject } from './baseRenderer'
 
 /**
@@ -45,10 +50,7 @@ export class MainThreadRenderer implements MTextBaseRenderer {
   async asyncRenderMText(
     mtextContent: MTextData,
     textStyle: TextStyle,
-    colorSettings: ColorSettings = {
-      byLayerColor: 0xffffff,
-      byBlockColor: 0xffffff
-    }
+    colorSettings: ColorSettings = createDefaultColorSettings()
   ): Promise<MTextObject> {
     await this.ensureInitialized()
     const mtext = new MText(
@@ -70,10 +72,7 @@ export class MainThreadRenderer implements MTextBaseRenderer {
   syncRenderMText(
     mtextContent: MTextData,
     textStyle: TextStyle,
-    colorSettings: ColorSettings = {
-      byLayerColor: 0xffffff,
-      byBlockColor: 0xffffff
-    }
+    colorSettings: ColorSettings = createDefaultColorSettings()
   ): MTextObject {
     const mtext = new MText(
       mtextContent,

--- a/packages/mtext-renderer/src/worker/mtextWorker.ts
+++ b/packages/mtext-renderer/src/worker/mtextWorker.ts
@@ -1,3 +1,4 @@
+import { MTextColor } from '@mlightcad/mtext-parser'
 import * as THREE from 'three'
 
 import { FontManager } from '../font'
@@ -49,6 +50,7 @@ self.addEventListener('message', async (event: MessageEvent<WorkerMessage>) => {
           textStyle: TextStyle
           colorSettings: ColorSettings
         }
+        const normalizedColorSettings = normalizeColorSettings(colorSettings)
 
         // Create MText instance and draw (loads fonts on demand)
         let mtext = new MText(
@@ -56,7 +58,7 @@ self.addEventListener('message', async (event: MessageEvent<WorkerMessage>) => {
           textStyle,
           styleManager,
           fontManager,
-          colorSettings
+          normalizedColorSettings
         )
         await mtext.asyncDraw()
         mtext.updateMatrixWorld(true)
@@ -132,6 +134,39 @@ self.addEventListener('message', async (event: MessageEvent<WorkerMessage>) => {
     } as WorkerResponse)
   }
 })
+
+function normalizeColorSettings(colorSettings: ColorSettings): ColorSettings {
+  const fallback: ColorSettings = {
+    byLayerColor: 0xffffff,
+    byBlockColor: 0xffffff,
+    layer: '0',
+    color: new MTextColor()
+  }
+
+  const base = colorSettings ?? fallback
+  const incomingColor = base.color as unknown
+  if (incomingColor instanceof MTextColor) {
+    return base
+  }
+
+  const revived = new MTextColor()
+  if (incomingColor && typeof incomingColor === 'object') {
+    const partial = incomingColor as { aci?: number; rgbValue?: number }
+    if (typeof partial.aci === 'number') {
+      revived.aci = partial.aci
+    }
+    if (typeof partial.rgbValue === 'number') {
+      revived.rgbValue = partial.rgbValue
+    }
+  }
+
+  return {
+    byLayerColor: base.byLayerColor,
+    byBlockColor: base.byBlockColor,
+    layer: base.layer,
+    color: revived
+  }
+}
 
 // Serialize MText object for transfer to main thread using JSON and transferable objects
 function serializeMText(mtext: MText): {

--- a/packages/mtext-renderer/src/worker/unifiedRenderer.ts
+++ b/packages/mtext-renderer/src/worker/unifiedRenderer.ts
@@ -1,5 +1,10 @@
 import { StyleManager } from '../renderer'
-import { ColorSettings, MTextData, TextStyle } from '../renderer/types'
+import {
+  ColorSettings,
+  createDefaultColorSettings,
+  MTextData,
+  TextStyle
+} from '../renderer/types'
 import { MTextBaseRenderer, MTextObject } from './baseRenderer'
 import { MainThreadRenderer } from './mainThreadRenderer'
 import { WebWorkerRenderer, WebWorkerRendererConfig } from './webWorkerRenderer'
@@ -75,15 +80,13 @@ export class UnifiedRenderer {
 
   /**
    * Render MText using the current mode asynchronously.
+   * @param colorSettings - Optional color context (ByLayer, ByBlock colors).
    * @param mode - Rendering mode used. If undefined, the default rendering mode is used.
    */
   async asyncRenderMText(
     mtextContent: MTextData,
     textStyle: TextStyle,
-    colorSettings: ColorSettings = {
-      byLayerColor: 0xffffff,
-      byBlockColor: 0xffffff
-    },
+    colorSettings: ColorSettings = createDefaultColorSettings(),
     mode?: RenderMode
   ): Promise<MTextObject> {
     if (mode) {
@@ -102,14 +105,12 @@ export class UnifiedRenderer {
   /**
    * Render MText using the current mode synchronously. Main thread render is always used
    * for this function because web worker renderer doesn't support rendering synchronously.
+   * @param colorSettings - Optional color context (ByLayer, ByBlock colors).
    */
   syncRenderMText(
     mtextContent: MTextData,
     textStyle: TextStyle,
-    colorSettings: ColorSettings = {
-      byLayerColor: 0xffffff,
-      byBlockColor: 0xffffff
-    }
+    colorSettings: ColorSettings = createDefaultColorSettings()
   ): MTextObject {
     return this.mainThreadRenderer.syncRenderMText(
       mtextContent,

--- a/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
+++ b/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
@@ -1,3 +1,4 @@
+import { MTextColor } from '@mlightcad/mtext-parser'
 import * as THREE from 'three'
 
 import { FontManager } from '../font'
@@ -8,6 +9,7 @@ import {
   CharBox,
   CharBoxType,
   ColorSettings,
+  createDefaultColorSettings,
   LineLayout,
   MTextData,
   MTextLayout,
@@ -411,10 +413,7 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
   async asyncRenderMText(
     mtextContent: MTextData,
     textStyle: TextStyle,
-    colorSettings: ColorSettings = {
-      byLayerColor: 0xffffff,
-      byBlockColor: 0xffffff
-    }
+    colorSettings: ColorSettings = createDefaultColorSettings()
   ): Promise<MTextObject> {
     await this.ensureInitialized()
 
@@ -426,7 +425,7 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
       data: { mtextContent, textStyle, colorSettings }
     })
 
-    return this.reconstructMText(serialized, textStyle)
+    return this.reconstructMText(serialized, colorSettings)
   }
 
   /**
@@ -436,10 +435,7 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
   syncRenderMText(
     _mtextContent: MTextData,
     _textStyle: TextStyle,
-    _colorSettings: ColorSettings = {
-      byLayerColor: 0xffffff,
-      byBlockColor: 0xffffff
-    }
+    _colorSettings: ColorSettings = createDefaultColorSettings()
   ): MTextObject {
     throw new Error(
       'Fuction \'syncRenderMText\' isn\'t supported in \'WebWorkerRenderer\'!'
@@ -480,8 +476,9 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
    */
   reconstructMText(
     serializedData: SerializedMText,
-    textStyle: TextStyle
+    colorSettings: ColorSettings
   ): MTextObject {
+    const baseByLayer = colorSettings.color.aci === 256
     const group = new THREE.Group()
 
     // Reconstruct all child objects
@@ -529,10 +526,13 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
       // Create material using StyleManager for proper material reuse
       let material: THREE.Material
       if (childData.type === 'mesh') {
+        const materialColorSettings = this.buildMaterialColorSettings(
+          colorSettings,
+          childData.material.color,
+          baseByLayer
+        )
         material = this.defaultStyleManager.getMeshBasicMaterial({
-          layer: textStyle.layer,
-          isByLayer: textStyle.isByLayer,
-          color: childData.material.color
+          ...materialColorSettings
         })
         // Apply additional properties if they differ from defaults
         if (childData.material.transparent !== undefined) {
@@ -545,10 +545,13 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
           material.side = childData.material.side as THREE.Side
         }
       } else {
+        const materialColorSettings = this.buildMaterialColorSettings(
+          colorSettings,
+          childData.material.color,
+          baseByLayer
+        )
         material = this.defaultStyleManager.getLineBasicMaterial({
-          layer: textStyle.layer,
-          isByLayer: textStyle.isByLayer,
-          color: childData.material.color
+          ...materialColorSettings
         })
         // Apply additional properties if they differ from defaults
         if (childData.material.transparent !== undefined) {
@@ -645,6 +648,26 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
     }
 
     return mtextObject
+  }
+
+  private buildMaterialColorSettings(
+    base: ColorSettings,
+    resolvedColor: number,
+    baseByLayer: boolean
+  ): ColorSettings {
+    const color = new MTextColor()
+    if (baseByLayer && resolvedColor === base.byLayerColor) {
+      color.aci = 256
+    } else {
+      color.rgbValue = resolvedColor
+    }
+
+    return {
+      byLayerColor: base.byLayerColor,
+      byBlockColor: base.byBlockColor,
+      layer: base.layer,
+      color
+    }
   }
 
   private deserializeCharBoxes(serialized: SerializedCharBox[]): CharBox[] {

--- a/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import * as THREE from 'three'
+import { MTextColor } from '@mlightcad/mtext-parser'
 
 vi.mock('@mlightcad/mtext-parser', () => {
   class FakeColor {
@@ -58,6 +59,7 @@ vi.mock('@mlightcad/mtext-parser', () => {
   }
 
   return {
+    MTextColor: FakeColor,
     MTextContext,
     MTextParagraphAlignment: {
       DEFAULT: 0,
@@ -118,8 +120,7 @@ function createProcessor(
     textGenerationFlag: 0,
     lastHeight: 24,
     font: 'simkai',
-    bigFont: '',
-    color: 0xffffff
+    bigFont: ''
   }
 
   const options: MTextFormatOptions = {
@@ -134,6 +135,13 @@ function createProcessor(
     removeFontExtension: true,
     collectCharBoxes: false,
     ...optionsOverride
+  }
+
+  const colorSettings = {
+    byBlockColor: options.byBlockColor,
+    byLayerColor: options.byLayerColor,
+    layer: '0',
+    color: new MTextColor(256)
   }
 
   const fontManager = {
@@ -169,6 +177,7 @@ function createProcessor(
 
   const processor = new MTextProcessor(
     style,
+    colorSettings as any,
     styleManager as any,
     fontManager as any,
     options


### PR DESCRIPTION
## Summary
This PR refactors MText color handling to use a unified `ColorSettings` model (including `MTextColor`) and ensures consistent color resolution across main-thread and worker renderers.

## Changes
- Add `ColorSettings` with `MTextColor`, default creation helper, and layer-aware material keys.
- Introduce `resolveMTextColor` and update `DefaultStyleManager` to resolve ByLayer/ByBlock colors.
- Pass color settings through `MTextProcessor` and renderer APIs (main, unified, worker).
- Update worker reconstruction to preserve ByLayer semantics.
- Update README examples and bump package version to `0.10.5`.
- Export colorUtils from the renderer index.