### PR TITLE
fix: handle ACI color assignment in WebWorkerRenderer

### DIFF
--- a/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
+++ b/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
@@ -658,6 +658,8 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
     const color = new MTextColor()
     if (baseByLayer && resolvedColor === base.byLayerColor) {
       color.aci = 256
+    } else if (base.color.isAci && base.color.aci !== null) {
+      color.aci = base.color.aci
     } else {
       color.rgbValue = resolvedColor
     }


### PR DESCRIPTION
## Description

### Problem

The ACI value was only being set when the `ByLayer` condition was met:

```ts
if (baseByLayer && resolvedColor === base.byLayerColor) {
  color.aci = 256
} else {
  color.rgbValue = resolvedColor
}
```
In all other cases, `rgbValue` was set and `aci` remained `null`.

This caused most entities to lose their original ACI value.

---

### Impact

Since `aci` was not preserved, features that rely on ACI (e.g. foreground detection in the cad-viewer) stopped working correctly.

---

### Solution

Preserve ACI when the original color is ACI-based, instead of always falling back to RGB.
```ts
if (baseByLayer && resolvedColor === base.byLayerColor) {
  color.aci = 256
} else if (base.color.isAci && base.color.aci !== null) {
  color.aci = base.color.aci
} else {
  color.rgbValue = resolvedColor
}
```

### Result

ACI values are preserved

RGB is only used when needed

Foreground detection works correctly again