### PR TITLE
fix: propagate style manager override to both renderers

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.29.5",
     "@intlify/eslint-plugin-vue-i18n": "^3.0.0",
+    "@eslint/js": "^9.9.1",
     "@nx/js": "19.3.1",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^20.14.9",

--- a/packages/mtext-renderer/src/worker/unifiedRenderer.ts
+++ b/packages/mtext-renderer/src/worker/unifiedRenderer.ts
@@ -40,11 +40,18 @@ export class UnifiedRenderer {
   }
 
   /**
-   * Sets one new style manager to override the default style manager
+   * Sets one new style manager to override the default style manager.
+   *
+   * Both renderers receive the override so that `syncRenderMText`
+   * (which always uses `mainThreadRenderer`) and `asyncRenderMText`
+   * (which may use either renderer) produce materials from the same
+   * manager.
+   *
    * @param value - New style manager
    */
   setStyleManager(value: StyleManager) {
-    this.renderer.styleManager = value
+    this.mainThreadRenderer.styleManager = value
+    this.webWorkerRenderer.styleManager = value
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.5
         version: 2.29.7(@types/node@20.17.46)
+      '@eslint/js':
+        specifier: ^9.9.1
+        version: 9.28.0
       '@intlify/eslint-plugin-vue-i18n':
         specifier: ^3.0.0
         version: 3.2.0(eslint@9.28.0)
@@ -1065,24 +1068,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@19.3.1':
     resolution: {integrity: sha512-JMuBbg2Zqdz4N7i+hiJGr2QdsDarDZ8vyzzeoevFq3b8nhZfqKh/lno7+Y0WkXNpH7aT05GHaUA1r1NXf/5BeQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@19.3.1':
     resolution: {integrity: sha512-cVmDMtolaqK7PziWxvjus1nCyj2wMNM+N0/4+rBEjG4v47gTtBxlZJoxK02jApdV+XELehsTjd0Z/xVfO4Rl1Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@19.3.1':
     resolution: {integrity: sha512-UGujK/TLMz9TNJ6+6HLhoOV7pdlgPVosSyeNZcoXCHOg/Mg9NGM7Hgk9jDodtcAY+TP6QMDJIMVGuXBsCE7NLQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@19.3.1':
     resolution: {integrity: sha512-q+2aaRXarh/+HOOW/JXRwEnEEwPdGipsfzXBPDuDDJ7aOYKuyG7g1DlSERKdzI/aEBP+joneZbcbZHaDcEv2xw==}
@@ -1154,56 +1161,67 @@ packages:
     resolution: {integrity: sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.41.1':
     resolution: {integrity: sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.41.1':
     resolution: {integrity: sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.41.1':
     resolution: {integrity: sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.41.1':
     resolution: {integrity: sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.41.1':
     resolution: {integrity: sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.41.1':
     resolution: {integrity: sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.41.1':
     resolution: {integrity: sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.41.1':
     resolution: {integrity: sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.41.1':
     resolution: {integrity: sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.41.1':
     resolution: {integrity: sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.41.1':
     resolution: {integrity: sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                        
  - `setStyleManager` only set the override on the active renderer (determined by default mode). Since `syncRenderMText` always uses `mainThreadRenderer` regardless of mode, when default mode was `'worker'` the main-thread renderer kept the `DefaultStyleManager` — producing materials without `materialKey`.                                     
  - This caused MText glyphs inside mirrored block references to be invisible in consuming viewers (e.g. cad-viewer), because `getBackSideVariant` could not resolve the material key for the BackSide swap.                                                                                                                                            
  - Now both `mainThreadRenderer` and `webWorkerRenderer` receive the override.                                                                                                                                                                                                                                                                         
  - Also adds missing `@eslint/js` dev dependency.                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                        
  ## Context
                                                                                                                                                                                                                                                                                                                                                        
  Related to [mlightcad/cad-viewer#183](https://github.com/mlightcad/cad-viewer/issues/183). The cad-viewer's side-aware material cache (PR [#206](https://github.com/mlightcad/cad-viewer/pull/206)) already handles mirrored fills correctly, but MText glyphs bypassed it because `syncRenderMText` was using a renderer that never received the style manager override.                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                        
  ## Test plan
                                                                                                                                                                                                                                                                                                                                                        
  - [ ] Open a DWG with MText inside mirrored block references (negative-determinant transforms)
  - [ ] Verify MText glyphs render correctly in mirrored blocks                                                                                                                                                                                                                                                                                         
  - [ ] Verify MText in non-mirrored blocks is unaffected      
  - [ ] Verify async render path still works as before