### PR TITLE
feat: improve font loader cache invalidation and add font manager tests

### DIFF
--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-renderer",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "AutoCAD MText renderer based on Three.js",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",

--- a/packages/mtext-renderer/src/font/defaultFontLoader.ts
+++ b/packages/mtext-renderer/src/font/defaultFontLoader.ts
@@ -28,7 +28,12 @@ export class DefaultFontLoader implements FontLoader {
     return this._baseUrl
   }
   set baseUrl(value: string) {
+    if (this._baseUrl === value) {
+      return
+    }
     this._baseUrl = value
+    this._avaiableFonts = []
+    this._avaiableFontMap.clear()
     this.onFontUrlChanged(value)
   }
 

--- a/packages/mtext-renderer/test/font/defaultFontLoader.test.ts
+++ b/packages/mtext-renderer/test/font/defaultFontLoader.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/font/fontManager', () => ({
+  FontManager: {
+    instance: {
+      isFontLoaded: vi.fn().mockReturnValue(false),
+      loadFonts: vi.fn().mockResolvedValue([])
+    }
+  }
+}))
+
+import { DefaultFontLoader } from '../../src/font/defaultFontLoader'
+import { FontManager } from '../../src/font/fontManager'
+import { FontInfo } from '../../src/font/fontLoader'
+
+const oldFonts: FontInfo[] = [
+  {
+    name: ['OldFont', 'old'],
+    file: 'old.shx',
+    type: 'shx',
+    url: ''
+  }
+]
+
+const newFonts: FontInfo[] = [
+  {
+    name: ['NewFont'],
+    file: 'new.shx',
+    type: 'shx',
+    url: ''
+  }
+]
+
+function jsonResponse(fonts: FontInfo[]) {
+  return {
+    json: vi.fn().mockResolvedValue(fonts.map(font => ({ ...font })))
+  }
+}
+
+describe('DefaultFontLoader', () => {
+  beforeEach(() => {
+    vi.mocked(FontManager.instance.isFontLoaded).mockReturnValue(false)
+    vi.mocked(FontManager.instance.loadFonts).mockResolvedValue([])
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse(oldFonts))
+        .mockResolvedValueOnce(jsonResponse(newFonts))
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('loads font metadata and assigns font URLs from baseUrl', async () => {
+    const loader = new DefaultFontLoader()
+    loader.baseUrl = 'https://cdn.example.com/fonts/'
+
+    const fonts = await loader.getAvailableFonts()
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://cdn.example.com/fonts/fonts.json'
+    )
+    expect(fonts).toEqual([
+      {
+        name: ['OldFont', 'old'],
+        file: 'old.shx',
+        type: 'shx',
+        url: 'https://cdn.example.com/fonts/old.shx'
+      }
+    ])
+  })
+
+  it('uses cached metadata while baseUrl stays the same', async () => {
+    const loader = new DefaultFontLoader()
+    loader.baseUrl = 'https://cdn.example.com/fonts/'
+
+    await loader.getAvailableFonts()
+    await loader.getAvailableFonts()
+
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  it('reloads metadata from the new baseUrl after baseUrl changes', async () => {
+    const loader = new DefaultFontLoader()
+    loader.baseUrl = 'https://old.example.com/fonts/'
+
+    await loader.getAvailableFonts()
+    loader.baseUrl = 'https://new.example.com/fonts/'
+    const fonts = await loader.getAvailableFonts()
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      'https://old.example.com/fonts/fonts.json'
+    )
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://new.example.com/fonts/fonts.json'
+    )
+    expect(fonts).toEqual([
+      {
+        name: ['NewFont'],
+        file: 'new.shx',
+        type: 'shx',
+        url: 'https://new.example.com/fonts/new.shx'
+      }
+    ])
+  })
+
+  it('notifies when baseUrl changes', () => {
+    const loader = new DefaultFontLoader()
+    const onFontUrlChanged = vi.spyOn(loader, 'onFontUrlChanged')
+
+    loader.baseUrl = 'https://cdn.example.com/fonts/'
+    loader.baseUrl = 'https://cdn.example.com/fonts/'
+
+    expect(onFontUrlChanged).toHaveBeenCalledOnce()
+    expect(onFontUrlChanged).toHaveBeenCalledWith(
+      'https://cdn.example.com/fonts/'
+    )
+  })
+
+  it('returns empty statuses and does not fetch when no font names are provided', async () => {
+    const loader = new DefaultFontLoader()
+
+    await expect(loader.load([])).resolves.toEqual([])
+
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('loads requested fonts by name and preserves NotFound statuses', async () => {
+    vi.mocked(FontManager.instance.loadFonts).mockResolvedValue([
+      {
+        fontName: 'old',
+        url: 'https://cdn.example.com/fonts/old.shx',
+        status: 'Success'
+      }
+    ])
+    const loader = new DefaultFontLoader()
+    loader.baseUrl = 'https://cdn.example.com/fonts/'
+
+    const statuses = await loader.load(['old', 'MissingFont'])
+
+    expect(FontManager.instance.loadFonts).toHaveBeenCalledWith([
+      {
+        name: ['OldFont', 'old'],
+        file: 'old.shx',
+        type: 'shx',
+        url: 'https://cdn.example.com/fonts/old.shx'
+      }
+    ])
+    expect(statuses).toEqual([
+      {
+        fontName: 'old',
+        url: 'https://cdn.example.com/fonts/old.shx',
+        status: 'Success'
+      },
+      {
+        fontName: 'missingfont',
+        url: '',
+        status: 'NotFound'
+      }
+    ])
+  })
+
+  it('returns success immediately for already loaded requested fonts', async () => {
+    vi.mocked(FontManager.instance.isFontLoaded).mockReturnValue(true)
+    const loader = new DefaultFontLoader()
+    loader.baseUrl = 'https://cdn.example.com/fonts/'
+
+    const statuses = await loader.load(['old'])
+
+    expect(statuses).toEqual([
+      {
+        fontName: 'old',
+        url: 'https://cdn.example.com/fonts/old.shx',
+        status: 'Success'
+      }
+    ])
+  })
+
+  it('throws a contextual error when font metadata cannot be loaded', async () => {
+    vi.mocked(fetch).mockReset().mockRejectedValueOnce(new Error('network down'))
+    const loader = new DefaultFontLoader()
+    loader.baseUrl = 'https://cdn.example.com/fonts/'
+
+    await expect(loader.getAvailableFonts()).rejects.toThrow(
+      "Filed to get avaiable font from 'https://cdn.example.com/fonts/fonts.json'"
+    )
+  })
+})

--- a/packages/mtext-renderer/test/font/fontManager.test.ts
+++ b/packages/mtext-renderer/test/font/fontManager.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/cache', () => ({
+  FontCacheManager: {
+    instance: {
+      get: vi.fn().mockResolvedValue(undefined),
+      set: vi.fn().mockResolvedValue(undefined),
+      getAll: vi.fn().mockResolvedValue([])
+    }
+  }
+}))
+
+vi.mock('../../src/font/fontFactory', () => ({
+  FontFactory: {
+    instance: {
+      createFont: vi.fn()
+    }
+  }
+}))
+
+import { FontManager } from '../../src/font/fontManager'
+import { FontCacheManager } from '../../src/cache'
+import { FontFactory } from '../../src/font/fontFactory'
+import { FontInfo, FontLoader, FontLoadStatus } from '../../src/font/fontLoader'
+
+function createFontLoader(baseUrl: string): FontLoader {
+  let currentBaseUrl = baseUrl
+  return {
+    load: vi.fn<FontLoader['load']>().mockResolvedValue([] as FontLoadStatus[]),
+    getAvailableFonts: vi
+      .fn<FontLoader['getAvailableFonts']>()
+      .mockResolvedValue([] as FontInfo[]),
+    get baseUrl() {
+      return currentBaseUrl
+    },
+    set baseUrl(value: string) {
+      currentBaseUrl = value
+    }
+  }
+}
+
+function createFakeFont(overrides: Record<string, unknown> = {}) {
+  return {
+    names: new Set<string>(),
+    type: 'shx',
+    unsupportedChars: { '?': 1 },
+    hasChar: vi.fn().mockReturnValue(false),
+    getCharShape: vi.fn(),
+    getScaleFactor: vi.fn().mockReturnValue(1),
+    getNotFoundTextShape: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('FontManager', () => {
+  beforeEach(() => {
+    const manager = FontManager.instance as any
+    manager.release()
+    manager.fontMapping = {}
+    manager.missedFonts = {}
+    manager.unsupportedChars = {}
+    manager.fileNames = []
+    manager.enableFontCache = true
+    manager.defaultFont = 'simkai'
+  })
+
+  afterEach(() => {
+    FontManager.instance.release()
+    vi.clearAllMocks()
+  })
+
+  it('delegates baseUrl get and set to the configured font loader', () => {
+    const loader = createFontLoader('https://old.example.com/fonts/')
+    const manager = FontManager.instance
+
+    manager.setFontLoader(loader)
+    manager.baseUrl = 'https://new.example.com/fonts/'
+
+    expect(manager.baseUrl).toBe('https://new.example.com/fonts/')
+    expect(loader.baseUrl).toBe('https://new.example.com/fonts/')
+  })
+
+  it('gets available fonts through the configured font loader', async () => {
+    const fonts: FontInfo[] = [
+      {
+        name: ['TestFont'],
+        file: 'test.shx',
+        type: 'shx',
+        url: 'https://cdn.example.com/fonts/test.shx'
+      }
+    ]
+    const loader = createFontLoader('https://cdn.example.com/fonts/')
+    vi.mocked(loader.getAvailableFonts).mockResolvedValue(fonts)
+    const manager = FontManager.instance
+
+    manager.setFontLoader(loader)
+    const result = await manager.getAvailableFonts()
+
+    expect(loader.getAvailableFonts).toHaveBeenCalledOnce()
+    expect(result).toBe(fonts)
+  })
+
+  it('loads fonts by names through the configured font loader', async () => {
+    const loader = createFontLoader('https://cdn.example.com/fonts/')
+    vi.mocked(loader.load).mockResolvedValue([
+      {
+        fontName: 'simkai',
+        url: 'https://cdn.example.com/fonts/simkai.shx',
+        status: 'Success'
+      }
+    ])
+    const manager = FontManager.instance
+    manager.setFontLoader(loader)
+
+    const result = await manager.loadDefaultFont()
+
+    expect(loader.load).toHaveBeenCalledWith(['simkai'])
+    expect(result).toEqual([
+      {
+        fontName: 'simkai',
+        url: 'https://cdn.example.com/fonts/simkai.shx',
+        status: 'Success'
+      }
+    ])
+  })
+
+  it('finds mapped replacement fonts when the requested font is missing', () => {
+    const manager = FontManager.instance as any
+    manager.loadedFontMap.set('replacement', createFakeFont())
+    FontManager.instance.setFontMapping({ Missing: 'replacement' })
+
+    expect(FontManager.instance.findAndReplaceFont('Missing')).toBe(
+      'replacement'
+    )
+    expect(FontManager.instance.findAndReplaceFont('Unknown')).toBe('simkai')
+  })
+
+  it('finds fonts by name, strips common font extensions, and records misses', () => {
+    const manager = FontManager.instance as any
+    const listener = vi.fn()
+    const font = createFakeFont()
+    manager.loadedFontMap.set('arial', font)
+    FontManager.instance.events.fontNotFound.addEventListener(listener)
+
+    expect(FontManager.instance.getFontByName('arial.shx')).toBe(font)
+    expect(FontManager.instance.getFontByName('missing.ttf')).toBeUndefined()
+
+    expect(FontManager.instance.missedFonts).toEqual({ missing: 1 })
+    expect(listener).toHaveBeenCalledWith({ fontName: 'missing', count: 1 })
+    FontManager.instance.events.fontNotFound.removeEventListener(listener)
+  })
+
+  it('finds fonts by character and falls back by character when a named font is missing', () => {
+    const shape = { width: 1 }
+    const manager = FontManager.instance as any
+    const font = createFakeFont({
+      hasChar: vi.fn((char: string) => char === 'A'),
+      getCharShape: vi.fn().mockReturnValue(shape)
+    })
+    manager.loadedFontMap.set('fallback', font)
+
+    expect(FontManager.instance.getFontByChar('A')).toBe(font)
+    expect(FontManager.instance.getCharShape('A', 'missing', 12)).toBe(shape)
+    expect(font.getCharShape).toHaveBeenCalledWith('A', 12)
+  })
+
+  it('returns font metadata helpers from loaded fonts', () => {
+    const notFoundShape = { width: 2 }
+    const manager = FontManager.instance as any
+    manager.loadedFontMap.set(
+      'arial',
+      createFakeFont({
+        type: 'mesh',
+        getScaleFactor: vi.fn().mockReturnValue(0.75),
+        getNotFoundTextShape: vi.fn().mockReturnValue(notFoundShape)
+      })
+    )
+
+    expect(FontManager.instance.isFontLoaded('Arial')).toBe(true)
+    expect(FontManager.instance.getFontScaleFactor('arial')).toBe(0.75)
+    expect(FontManager.instance.getFontType('arial')).toBe('mesh')
+    expect(FontManager.instance.getNotFoundTextShape(12)).toBe(notFoundShape)
+    expect(FontManager.instance.getUnsupportedChar()).toEqual({ '?': 1 })
+  })
+
+  it('releases all fonts or a single requested font', () => {
+    const manager = FontManager.instance as any
+    manager.loadedFontMap.set('arial', createFakeFont())
+    manager.loadedFontMap.set('romans', createFakeFont())
+
+    expect(FontManager.instance.release('arial')).toBe(true)
+    expect(FontManager.instance.isFontLoaded('arial')).toBe(false)
+    expect(FontManager.instance.release('missing')).toBe(false)
+    expect(FontManager.instance.release()).toBe(true)
+    expect(manager.loadedFontMap.size).toBe(0)
+  })
+
+  it('loads font files, creates fonts, caches them, and reports statuses', async () => {
+    const manager = FontManager.instance as any
+    const buffer = new ArrayBuffer(8)
+    const font = createFakeFont()
+    manager.loader = {
+      loadAsync: vi.fn().mockResolvedValue(buffer)
+    }
+    vi.mocked(FontFactory.instance.createFont).mockReturnValue(font as any)
+
+    const statuses = await FontManager.instance.loadFonts({
+      name: ['RomanS', 'RomansAlt'],
+      file: 'romans.shx',
+      type: 'shx',
+      url: 'https://cdn.example.com/fonts/romans.shx'
+    })
+
+    expect(manager.loader.loadAsync).toHaveBeenCalledWith(
+      'https://cdn.example.com/fonts/romans.shx'
+    )
+    expect(FontFactory.instance.createFont).toHaveBeenCalledWith({
+      name: 'romans',
+      alias: ['RomanS', 'RomansAlt'],
+      type: 'shx',
+      encoding: undefined,
+      data: buffer
+    })
+    expect(FontCacheManager.instance.set).toHaveBeenCalledWith('romans', {
+      name: 'romans',
+      alias: ['RomanS', 'RomansAlt'],
+      type: 'shx',
+      encoding: undefined,
+      data: buffer
+    })
+    expect(font.names).toEqual(new Set(['RomanS', 'RomansAlt']))
+    expect(FontManager.instance.isFontLoaded('romans')).toBe(true)
+    expect(statuses).toEqual([
+      {
+        fontName: 'romans',
+        url: 'https://cdn.example.com/fonts/romans.shx',
+        status: 'Success'
+      }
+    ])
+  })
+
+  it('loads fonts from cache without requesting the font URL', async () => {
+    const manager = FontManager.instance as any
+    const font = createFakeFont()
+    const cachedFontData = {
+      name: 'romans',
+      alias: ['Romans'],
+      type: 'shx' as const,
+      encoding: undefined,
+      data: new ArrayBuffer(4)
+    }
+    manager.loader = {
+      loadAsync: vi.fn()
+    }
+    vi.mocked(FontCacheManager.instance.get).mockResolvedValue(cachedFontData)
+    vi.mocked(FontFactory.instance.createFont).mockReturnValue(font as any)
+
+    const statuses = await FontManager.instance.loadFonts({
+      name: ['Romans'],
+      file: 'romans.shx',
+      type: 'shx',
+      url: 'https://cdn.example.com/fonts/romans.shx'
+    })
+
+    expect(manager.loader.loadAsync).not.toHaveBeenCalled()
+    expect(FontFactory.instance.createFont).toHaveBeenCalledWith(cachedFontData)
+    expect(FontManager.instance.isFontLoaded('romans')).toBe(true)
+    expect(statuses[0].status).toBe('Success')
+  })
+})


### PR DESCRIPTION
## Summary

- Invalidate cached available-font metadata when `DefaultFontLoader.baseUrl` changes.
- Skip redundant `baseUrl` change handling when the value is unchanged.
- Add Vitest coverage for `DefaultFontLoader` metadata loading, caching, reload behavior, and font load statuses.
- Add Vitest coverage for `FontManager` loader delegation, fallback lookup, cache loading, release behavior, and font metadata helpers.
- Bump `@mlightcad/mtext-renderer` from `0.10.7` to `0.10.8`.

## Testing

- Added unit tests for font loading and font manager behavior.
