### PR TITLE
fix: fix MText anchor positioning with font scale factors

### DIFF
--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-renderer",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "AutoCAD MText renderer based on Three.js",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",

--- a/packages/mtext-renderer/src/renderer/mtext.ts
+++ b/packages/mtext-renderer/src/renderer/mtext.ts
@@ -260,7 +260,10 @@ export class MText extends THREE.Object3D {
    * @returns The created Three.js object, or undefined if creation fails
    */
   private loadMText(mtextData: MTextData, style: TextStyle) {
-    const { object, height } = this.createMTextGroup(mtextData, style)
+    const { object, height: layoutHeight } = this.createMTextGroup(
+      mtextData,
+      style
+    )
     if (!object) {
       return undefined
     }
@@ -280,9 +283,16 @@ export class MText extends THREE.Object3D {
     // is computed from the *real* rendered glyph extent — independent of
     // font, kerning, or character composition.
     let width = mtextData.width
+    let height = layoutHeight
+    object.updateWorldMatrix(true, true)
+    const bbox = new THREE.Box3().setFromObject(object)
+    if (!bbox.isEmpty()) {
+      const measuredHeight = bbox.max.y - bbox.min.y
+      if (Number.isFinite(measuredHeight) && measuredHeight > 0) {
+        height = measuredHeight
+      }
+    }
     if (!Number.isFinite(width)) {
-      object.updateWorldMatrix(true, true)
-      const bbox = new THREE.Box3().setFromObject(object)
       const measured = bbox.max.x - bbox.min.x
       width = Number.isFinite(measured) && measured > 0 ? measured : 0
     }

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -358,6 +358,20 @@ export class MTextProcessor {
   }
 
   /**
+   * The drawing-space text height used for layout calculations.
+   *
+   * `currentFontSize` includes a font-specific scale factor so glyph outlines
+   * from different font formats render at comparable visual sizes.  That scale
+   * must not leak into CAD layout metrics such as line height and attachment
+   * offsets, otherwise middle/bottom aligned text shifts vertically depending
+   * on the active font.
+   */
+  get currentLayoutFontSize() {
+    const scaleFactor = this._currentContext.fontScaleFactor || 1
+    return this._currentContext.fontSize / scaleFactor
+  }
+
+  /**
    * The height of current line of texts
    */
   get currentLineHeight() {
@@ -978,7 +992,7 @@ export class MTextProcessor {
     const currentHOffset = this._hOffset
     const currentVOffset = this._vOffset
     const currentWordSpace = this._currentContext.charTrackingFactor.value
-    const currentFontSize = this._currentContext.fontSize
+    const currentLayoutFontSize = this.currentLayoutFontSize
     const currentFontSizeScaleFactor = this._currentContext.fontSizeScaleFactor
 
     // First pass: calculate widths
@@ -1021,8 +1035,8 @@ export class MTextProcessor {
 
         this._hOffset = currentHOffset
         this._vOffset = this.convertTopAlignedVOffset(
-          currentVOffset + currentFontSize * 0.1,
-          this.currentFontSize
+          currentVOffset + currentLayoutFontSize * 0.1,
+          this.currentLayoutFontSize
         )
         for (let i = 0; i < numerator.length; i++) {
           this.processChar(
@@ -1049,8 +1063,8 @@ export class MTextProcessor {
 
         this._hOffset = currentHOffset
         this._vOffset = this.convertTopAlignedVOffset(
-          currentVOffset - currentFontSize * 0.6,
-          this.currentFontSize
+          currentVOffset - currentLayoutFontSize * 0.6,
+          this.currentLayoutFontSize
         )
         for (let i = 0; i < denominator.length; i++) {
           this.processChar(
@@ -1081,8 +1095,8 @@ export class MTextProcessor {
 
       this._hOffset = currentHOffset + numeratorOffset
       this._vOffset = this.convertTopAlignedVOffset(
-        currentVOffset + this.currentFontSize * 0.3,
-        this.currentFontSize
+        currentVOffset + this.currentLayoutFontSize * 0.3,
+        this.currentLayoutFontSize
       )
       for (let i = 0; i < numerator.length; i++) {
         this.processChar(
@@ -1117,8 +1131,8 @@ export class MTextProcessor {
 
       this._hOffset = currentHOffset + denominatorOffset
       this._vOffset = this.convertTopAlignedVOffset(
-        currentVOffset - this.currentFontSize * 0.6,
-        this.currentFontSize
+        currentVOffset - this.currentLayoutFontSize * 0.6,
+        this.currentLayoutFontSize
       )
       for (let i = 0; i < denominator.length; i++) {
         this.processChar(
@@ -1140,12 +1154,12 @@ export class MTextProcessor {
         const lineVertices = new Float32Array([
           currentHOffset,
           currentVOffset -
-            this.currentFontSize * 0.8 +
+            this.currentLayoutFontSize * 0.8 +
             this.defaultFontSize * STACK_VERTICAL_SHIFT_FACTOR,
           0,
           currentHOffset + fractionWidth,
           currentVOffset -
-            this.currentFontSize * 0.8 +
+            this.currentLayoutFontSize * 0.8 +
             this.defaultFontSize * STACK_VERTICAL_SHIFT_FACTOR,
           0
         ])
@@ -1180,7 +1194,7 @@ export class MTextProcessor {
 
     const y =
       currentVOffset -
-      this.currentFontSize * 0.8 +
+      this.currentLayoutFontSize * 0.8 +
       this.defaultFontSize * STACK_VERTICAL_SHIFT_FACTOR
     const box = new THREE.Box3(
       new THREE.Vector3(startX, y, 0),
@@ -1227,12 +1241,12 @@ export class MTextProcessor {
       const charY =
         this.flowDirection == MTextFlowDirection.BOTTOM_TO_TOP
           ? this._vOffset
-          : this._vOffset - this.defaultFontSize
+          : this._vOffset - this.currentLayoutFontSize
       const box = new THREE.Box3(
         new THREE.Vector3(charX, charY, 0),
         new THREE.Vector3(
           charX + this._currentContext.blankWidth,
-          charY + this.currentFontSize,
+          charY + this.currentLayoutFontSize,
           0
         )
       )
@@ -1349,9 +1363,9 @@ export class MTextProcessor {
     const charY =
       this.flowDirection == MTextFlowDirection.BOTTOM_TO_TOP
         ? this.vOffset
-        : this.vOffset - this.defaultFontSize
+        : this.vOffset - this.currentLayoutFontSize
     const charWidth = shape.width * this.currentWidthFactor
-    const charHeight = this.currentFontSize
+    const charHeight = this.currentLayoutFontSize
 
     geometry.translate(charX, charY, 0)
 
@@ -1476,11 +1490,11 @@ export class MTextProcessor {
     }
     this._currentContext.fontFace.family =
       this.fontManager.findAndReplaceFont(processedFontName)
+    this.calcuateLineParams()
     this._currentContext.blankWidth = this.calculateBlankWidthForFont(
       this._currentContext.fontFace.family,
-      this._currentContext.fontSize
+      this.currentLayoutFontSize
     )
-    this.calcuateLineParams()
   }
 
   /**

--- a/packages/mtext-renderer/test/renderer/mtext.anchor.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.anchor.test.ts
@@ -1,0 +1,99 @@
+import * as THREE from 'three'
+import { describe, expect, it, vi } from 'vitest'
+
+import { MText } from '../../src/renderer/mtext'
+import {
+  createDefaultColorSettings,
+  MTextAttachmentPoint,
+  TextStyle
+} from '../../src/renderer/types'
+
+function createShapeGeometry(width: number, height: number) {
+  const shape = new THREE.Shape()
+  shape.moveTo(0, 0)
+  shape.lineTo(width, 0)
+  shape.lineTo(width, height)
+  shape.lineTo(0, height)
+  shape.lineTo(0, 0)
+  return new THREE.ShapeGeometry(shape)
+}
+
+function createGeometryBox(object: THREE.Object3D) {
+  const box = new THREE.Box3()
+  const childBox = new THREE.Box3()
+
+  object.updateWorldMatrix(true, true)
+  object.traverse(child => {
+    if (!('geometry' in child)) return
+
+    const geometry = child.geometry as THREE.BufferGeometry
+    if (!geometry.boundingBox) {
+      geometry.computeBoundingBox()
+    }
+    if (!geometry.boundingBox) return
+
+    child.updateWorldMatrix(true, false)
+    childBox.copy(geometry.boundingBox).applyMatrix4(child.matrixWorld)
+    box.union(childBox)
+  })
+
+  return box
+}
+
+describe('MText attachment anchoring', () => {
+  it('centers visible glyph geometry using layout height instead of scaled font size', () => {
+    const fontScaleFactor = 2
+    const textHeight = 24
+    const style: TextStyle = {
+      name: 'default',
+      standardFlag: 0,
+      fixedTextHeight: 0,
+      widthFactor: 1,
+      obliqueAngle: 0,
+      textGenerationFlag: 0,
+      lastHeight: textHeight,
+      font: 'fake',
+      bigFont: ''
+    }
+    const styleManager = {
+      unsupportedTextStyles: {},
+      getMeshBasicMaterial: vi
+        .fn()
+        .mockReturnValue(new THREE.MeshBasicMaterial()),
+      getLineBasicMaterial: vi
+        .fn()
+        .mockReturnValue(new THREE.LineBasicMaterial())
+    }
+    const fontManager = {
+      getFontScaleFactor: () => fontScaleFactor,
+      getFontType: () => 'mesh',
+      findAndReplaceFont: (name: string) => name,
+      getCharShape: (_char: string, _fontName: string, size: number) => ({
+        width: 10,
+        toGeometry: () =>
+          createShapeGeometry(10, size / fontScaleFactor)
+      }),
+      getNotFoundTextShape: () => undefined
+    }
+
+    const mtext = new MText(
+      {
+        text: 'A',
+        height: textHeight,
+        width: 100,
+        position: { x: 0, y: 0, z: 0 },
+        attachmentPoint: MTextAttachmentPoint.MiddleCenter
+      },
+      style,
+      styleManager as any,
+      fontManager as any,
+      createDefaultColorSettings()
+    )
+
+    mtext.syncDraw()
+    const box = createGeometryBox(mtext)
+
+    expect(box.min.y).toBeCloseTo(-textHeight / 2, 6)
+    expect(box.max.y).toBeCloseTo(textHeight / 2, 6)
+  })
+})

--- a/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
@@ -109,7 +109,8 @@ type FakeFontType = 'mesh' | 'shx'
 
 function createProcessor(
   fontType: FakeFontType = 'mesh',
-  optionsOverride: Partial<MTextFormatOptions> = {}
+  optionsOverride: Partial<MTextFormatOptions> = {},
+  fontScaleFactor = 1
 ) {
   const style: TextStyle = {
     name: 'default',
@@ -145,7 +146,7 @@ function createProcessor(
   }
 
   const fontManager = {
-    getFontScaleFactor: () => 1,
+    getFontScaleFactor: () => fontScaleFactor,
     getFontType: () => fontType,
     findAndReplaceFont: (name: string) => name,
     getCharShape: (char: string) => {
@@ -517,6 +518,38 @@ describe('MTextProcessor format state', () => {
     expect(lines).toHaveLength(1)
     expect(lines[0].height).toBeCloseTo(processor.currentLineHeight, 3)
     expect(lines[0].y).toBeCloseTo(-6, 3)
+  })
+
+  it('keeps glyph placement height separate from scaled line advance', () => {
+    const { processor } = createProcessor('mesh', {}, 2)
+
+    const obj = processor.processText([
+      { type: TOKEN_WORD, ctx: null, data: 'A' }
+    ] as any)
+    const lines = getLineLayouts(obj)
+
+    expect(processor.currentFontSize).toBeCloseTo(48, 3)
+    expect(processor.currentLayoutFontSize).toBeCloseTo(24, 3)
+    expect(processor.currentLineHeight).toBeCloseTo(72, 3)
+    expect(processor.totalHeight).toBeCloseTo(48, 3)
+    expect(lines[0].height).toBeCloseTo(72, 3)
+    expect(lines[0].y).toBeCloseTo(12, 3)
+  })
+
+  it('preserves scaled line advance for multiline text', () => {
+    const { processor } = createProcessor('mesh', {}, 2)
+
+    const obj = processor.processText([
+      { type: TOKEN_WORD, ctx: null, data: 'A' },
+      { type: TOKEN_NEW_PARAGRAPH, ctx: null, data: null },
+      { type: TOKEN_WORD, ctx: null, data: 'B' }
+    ] as any)
+    const lines = getLineLayouts(obj)
+
+    expect(lines).toHaveLength(2)
+    expect(lines[0].height).toBeCloseTo(72, 3)
+    expect(lines[1].height).toBeCloseTo(72, 3)
+    expect(lines[0].y - lines[1].y).toBeCloseTo(72, 3)
   })
 
   it('stores line layouts for explicit empty lines', () => {


### PR DESCRIPTION
## Summary

- Separate MText layout font size from scaled glyph render size so CAD layout metrics are not affected by font-specific scale factors.
- Use measured rendered geometry height when applying MText attachment anchoring.
- Update blank width, stacked fraction offsets, glyph boxes, and layout calculations to use the unscaled layout font size where appropriate.
- Add tests for attachment anchoring and scaled-font layout behavior.

## Testing

- Added coverage in `mtext.anchor.test.ts`
- Updated coverage in `mtext.processor.test.ts`
