### PR TITLE
fix: fix stack divider positioning with scaled font metrics

### DIFF
--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-renderer",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "description": "AutoCAD MText renderer based on Three.js",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -992,7 +992,7 @@ export class MTextProcessor {
     const currentHOffset = this._hOffset
     const currentVOffset = this._vOffset
     const currentWordSpace = this._currentContext.charTrackingFactor.value
-    const currentLayoutFontSize = this.currentLayoutFontSize
+    const currentStackFontSize = this.currentFontSize
     const currentFontSizeScaleFactor = this._currentContext.fontSizeScaleFactor
 
     // First pass: calculate widths
@@ -1035,8 +1035,8 @@ export class MTextProcessor {
 
         this._hOffset = currentHOffset
         this._vOffset = this.convertTopAlignedVOffset(
-          currentVOffset + currentLayoutFontSize * 0.1,
-          this.currentLayoutFontSize
+          currentVOffset + currentStackFontSize * 0.1,
+          this.currentFontSize
         )
         for (let i = 0; i < numerator.length; i++) {
           this.processChar(
@@ -1063,8 +1063,8 @@ export class MTextProcessor {
 
         this._hOffset = currentHOffset
         this._vOffset = this.convertTopAlignedVOffset(
-          currentVOffset - currentLayoutFontSize * 0.6,
-          this.currentLayoutFontSize
+          currentVOffset - currentStackFontSize * 0.6,
+          this.currentFontSize
         )
         for (let i = 0; i < denominator.length; i++) {
           this.processChar(
@@ -1095,8 +1095,8 @@ export class MTextProcessor {
 
       this._hOffset = currentHOffset + numeratorOffset
       this._vOffset = this.convertTopAlignedVOffset(
-        currentVOffset + this.currentLayoutFontSize * 0.3,
-        this.currentLayoutFontSize
+        currentVOffset + this.currentFontSize * 0.3,
+        this.currentFontSize
       )
       for (let i = 0; i < numerator.length; i++) {
         this.processChar(
@@ -1131,8 +1131,8 @@ export class MTextProcessor {
 
       this._hOffset = currentHOffset + denominatorOffset
       this._vOffset = this.convertTopAlignedVOffset(
-        currentVOffset - this.currentLayoutFontSize * 0.6,
-        this.currentLayoutFontSize
+        currentVOffset - this.currentFontSize * 0.6,
+        this.currentFontSize
       )
       for (let i = 0; i < denominator.length; i++) {
         this.processChar(
@@ -1154,12 +1154,12 @@ export class MTextProcessor {
         const lineVertices = new Float32Array([
           currentHOffset,
           currentVOffset -
-            this.currentLayoutFontSize * 0.8 +
+            this.currentFontSize * 0.8 +
             this.defaultFontSize * STACK_VERTICAL_SHIFT_FACTOR,
           0,
           currentHOffset + fractionWidth,
           currentVOffset -
-            this.currentLayoutFontSize * 0.8 +
+            this.currentFontSize * 0.8 +
             this.defaultFontSize * STACK_VERTICAL_SHIFT_FACTOR,
           0
         ])
@@ -1194,7 +1194,7 @@ export class MTextProcessor {
 
     const y =
       currentVOffset -
-      this.currentLayoutFontSize * 0.8 +
+      this.currentFontSize * 0.8 +
       this.defaultFontSize * STACK_VERTICAL_SHIFT_FACTOR
     const box = new THREE.Box3(
       new THREE.Vector3(startX, y, 0),

--- a/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
@@ -361,6 +361,27 @@ describe('MTextProcessor format state', () => {
     expect(chars).toContain(STACK_DIVIDER_CHAR)
   })
 
+  it('positions stack divider with scaled font metrics', () => {
+    const { processor } = createProcessor('mesh', {}, 2)
+    ;(processor as any)._options.collectCharBoxes = true
+
+    const obj = processor.processText([
+      {
+        type: TOKEN_STACK,
+        ctx: null,
+        data: ['1', '2', '/']
+      }
+    ] as any)
+
+    const divider = getAllCharBoxes(obj).find(
+      entry => entry.char === STACK_DIVIDER_CHAR
+    )
+
+    expect(divider).toBeDefined()
+    expect(divider?.box.min.y).toBeCloseTo(-31.2, 3)
+    expect(divider?.box.max.y).toBeCloseTo(-31.2, 3)
+  })
+
   it('treats superscript stack as CHAR and does not add divider marker', () => {
     const { processor } = createProcessor('mesh')
     ;(processor as any)._options.collectCharBoxes = true


### PR DESCRIPTION
## Description
Fix incorrect stack divider positioning when using scaled font sizes in fraction and stack formatting.

## Changes
- **Variable Naming**: Renamed `currentLayoutFontSize` to `currentStackFontSize` for better clarity about the variable's purpose
- **Font Size References**: Updated all references from `this.currentLayoutFontSize` to `this.currentFontSize` in the MTextProcessor's fraction and stack processing logic
- **Font Metrics**: Ensured consistent use of the actual current font size throughout vertical offset calculations for stacked content

## Affected Areas
- Fraction formatting (numerator and denominator positioning)
- Stack divider line positioning
- Vertical offset calculations in scaled font contexts

## Testing
- Added new test case `positions stack divider with scaled font metrics` to verify correct positioning with scaled fonts
- Test validates that stack divider y-position is calculated correctly when processor has a 2x font scale factor

## Version
- Bump version from 0.10.9 to 0.10.10