### PR TITLE
refactor: extract and export MTEXT layout constants

### DIFF
--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-renderer",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "description": "AutoCAD MText renderer based on Three.js",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",

--- a/packages/mtext-renderer/src/renderer/constants.ts
+++ b/packages/mtext-renderer/src/renderer/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Scale applied with `lineSpaceFactor` when computing the extra vertical gap
+ * between MTEXT lines in {@link MTextProcessor}.
+ */
+export const LINE_SPACING_SCALE_FACTOR = 1.666666
+
+/**
+ * Vertical compensation needed after switching normal glyph placement from
+ * top-anchored to baseline-anchored coordinates.
+ */
+export const STACK_VERTICAL_SHIFT_FACTOR = 0.3

--- a/packages/mtext-renderer/src/renderer/index.ts
+++ b/packages/mtext-renderer/src/renderer/index.ts
@@ -1,4 +1,5 @@
 export * from './colorUtils'
+export * from './constants'
 export * from './mtext'
 export * from './styleManager'
 export * from './types'

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -11,6 +11,10 @@ import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js
 import { getColorByIndex } from '../common'
 import { FontManager } from '../font'
 import { resolveMTextColor } from './colorUtils'
+import {
+  LINE_SPACING_SCALE_FACTOR,
+  STACK_VERTICAL_SHIFT_FACTOR
+} from './constants'
 import { StyleManager } from './styleManager'
 import {
   CharBox,
@@ -25,13 +29,8 @@ import {
 const tempVector = /*@__PURE__*/ new THREE.Vector3()
 
 /**
- * Scale applied with `lineSpaceFactor` when computing the extra vertical gap
- * between MTEXT lines in {@link MTextProcessor}.
+ * Options for formatting MText.
  */
-const LINE_SPACING_SCALE_FACTOR = 1.666666
-// Vertical compensation needed after switching normal glyph placement from
-// top-anchored to baseline-anchored coordinates.
-const STACK_VERTICAL_SHIFT_FACTOR = 0.3
 export interface MTextFormatOptions {
   /**
    * Font size.
@@ -727,7 +726,8 @@ export class MTextProcessor {
   ) {
     if (!paragraph) return
     if ('align' in paragraph) {
-      this._currentHorizontalAlignment = paragraph.align as MTextParagraphAlignment
+      this._currentHorizontalAlignment =
+        paragraph.align as MTextParagraphAlignment
     }
     if (typeof paragraph.indent === 'number') {
       this._currentIndent = paragraph.indent * this.defaultFontSize


### PR DESCRIPTION
## Summary

Moves `LINE_SPACING_SCALE_FACTOR` and `STACK_VERTICAL_SHIFT_FACTOR` out of `mtextProcessor.ts` into a dedicated `constants` module, re-exports them from the renderer package entry, and bumps the package version to **0.10.13**.

## Changes

- Add `packages/mtext-renderer/src/renderer/constants.ts` with documented constants for:
  - extra vertical gap between MTEXT lines (`lineSpaceFactor` scaling)
  - vertical compensation for stack layout after baseline-anchored glyph placement
- Import those constants in `MTextProcessor` instead of defining them inline
- Export `constants` from `packages/mtext-renderer/src/renderer/index.ts`
- Bump `@mlightcad/mtext-renderer` version **0.10.12 → 0.10.13**

## Motivation

Centralizes layout tuning values in one place, makes them part of the public API surface for integrators who need alignment with renderer behavior, and keeps `mtextProcessor` focused on processing logic.