### PR TITLE
fix: fix MText DXF attachment-point anchoring and extents; add attachment demo grid

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,10 +24,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9
-      
+      - uses: pnpm/action-setup@v4
+
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "release": "node tools/release.mjs",
     "test": "pnpm --filter @mlightcad/mtext-renderer test"
   },
+  "packageManager": "pnpm@10.33.4",
   "engines": {
-    "pnpm": ">=8"
+    "pnpm": ">=10"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.5",

--- a/packages/example/index.html
+++ b/packages/example/index.html
@@ -170,6 +170,7 @@
             <button class="example-btn" data-example="paragraph">Paragraph</button>
             <button class="example-btn" data-example="stacking">Stacking</button>
             <button class="example-btn" data-example="multiple">Multiple MText</button>
+            <button class="example-btn" data-example="attachmentGrid">Attachment Points</button>
         </div>
         <div id="status"></div>
     </div>

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -2,6 +2,7 @@ import {
   CharBox,
   CharBoxType,
   LineLayout,
+  MTextAttachmentPoint,
   MTextColor,
   MTextData,
   MTextObject,
@@ -53,7 +54,9 @@ class MTextRendererExample {
       '{\\pql;Left aligned paragraph.}\\P{\\pqc;Center aligned paragraph.}\\P{\\pqr;Right aligned paragraph.}\\P{\\pqc;Center again.}\\P{\\pql;Back to left.}',
     paragraph:
       '{\\pql;\\P{\\pqi;\\pxi2;\\pxl5;\\pxr5;This paragraph has an indent of 2 units, left margin of 5 units, and right margin of 5 units. The first line is indented.}\\P{\\pqi;\\pxi2;\\pxl5;\\pxr5;This is the second line of the same paragraph, showing the effect of margins.}}',
-    multiple: 'multiple' // Special marker for multiple MText rendering
+    multiple: 'multiple', // Special marker for multiple MText rendering
+    /** DXF group 71 attachment points 1–12; renders a grid with insertion crosshairs */
+    attachmentGrid: 'attachmentGrid'
   }
 
   constructor() {
@@ -190,8 +193,8 @@ class MTextRendererExample {
           const content =
             this.exampleTexts[exampleType as keyof typeof this.exampleTexts]
 
-          if (content === 'multiple') {
-            // For multiple MText, don't update the textarea but render directly
+          if (content === 'multiple' || content === 'attachmentGrid') {
+            // Preset grids: don't overwrite the textarea
             await this.renderMText(content)
           } else {
             // For regular examples, update textarea and render
@@ -276,29 +279,15 @@ class MTextRendererExample {
   }
 
   /**
-   * Draws a bounding box for the text using the given position, max width, and the height from the box property.
-   * @param box The bounding box of the MText (for height)
-   * @param position The position (THREE.Vector3) of the text box (min corner)
-   * @param maxWidth The maximum width of the text box
+   * Draws a bounding box from the renderer-computed MText extents.
    */
-  private createMTextBox(
-    box: THREE.Box3,
-    position: THREE.Vector3,
-    maxWidth?: number
-  ): THREE.LineSegments {
-    // Remove existing box if any
-    if (this.mtextBox) {
-      this.scene.remove(this.mtextBox)
-    }
-
-    // The min and max y/z come from the box, x is from position and maxWidth
+  private createMTextBox(box: THREE.Box3): THREE.LineSegments {
+    const minX = box.min.x
+    const maxX = box.max.x
     const minY = box.min.y
     const maxY = box.max.y
     const minZ = box.min.z
     const maxZ = box.max.z
-    const minX = position.x
-    const maxX =
-      maxWidth !== undefined && maxWidth > 0 ? minX + maxWidth : box.max.x
 
     const vertices = [
       // Bottom face
@@ -388,15 +377,178 @@ class MTextRendererExample {
       linewidth: 1
     })
     this.mtextBox = new THREE.LineSegments(geometry, material)
-
-    // Apply the same transformation as the MText object
-    if (this.currentMText) {
-      this.mtextBox.position.copy(this.currentMText.position)
-      this.mtextBox.rotation.copy(this.currentMText.rotation)
-      this.mtextBox.scale.copy(this.currentMText.scale)
-    }
-
     return this.mtextBox
+  }
+
+  /**
+   * Small cross at the insertion point (DXF alignment anchor) for visual checks.
+   */
+  private createInsertionCrosshair(
+    x: number,
+    y: number,
+    arm = 22,
+    z = 0.03
+  ): THREE.LineSegments {
+    const vertices = new Float32Array([
+      x - arm,
+      y,
+      z,
+      x + arm,
+      y,
+      z,
+      x,
+      y - arm,
+      z,
+      x,
+      y + arm,
+      z
+    ])
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3))
+    const material = new THREE.LineBasicMaterial({
+      color: 0xff3333,
+      depthTest: false,
+      transparent: true,
+      opacity: 0.95
+    })
+    const lines = new THREE.LineSegments(geometry, material)
+    lines.renderOrder = 1000
+    return lines
+  }
+
+  /**
+   * Twelve MText samples on a 3×4 grid (DXF attachment 1–9 then 10–12).
+   * Each entity shares the same insertion coordinates as the red crosshair;
+   * only {@link MTextData.attachmentPoint} changes so you can compare layout.
+   */
+  private createAttachmentPointTestData(): {
+    mtextData: MTextData
+    textStyle: TextStyle
+  }[] {
+    const cellW = 330
+    const cellH = 175
+    const originX = 60
+    const originY = 610
+
+    const cells: {
+      attachmentPoint: MTextAttachmentPoint
+      title: string
+      subtitle: string
+      col: number
+      row: number
+    }[] = [
+      {
+        attachmentPoint: MTextAttachmentPoint.TopLeft,
+        title: '1 TopLeft',
+        subtitle: 'GC71=1',
+        col: 0,
+        row: 0
+      },
+      {
+        attachmentPoint: MTextAttachmentPoint.TopCenter,
+        title: '2 TopCenter',
+        subtitle: 'GC71=2',
+        col: 1,
+        row: 0
+      },
+      {
+        attachmentPoint: MTextAttachmentPoint.TopRight,
+        title: '3 TopRight',
+        subtitle: 'GC71=3',
+        col: 2,
+        row: 0
+      },
+      {
+        attachmentPoint: MTextAttachmentPoint.MiddleLeft,
+        title: '4 MiddleLeft',
+        subtitle: 'GC71=4',
+        col: 0,
+        row: 1
+      },
+      {
+        attachmentPoint: MTextAttachmentPoint.MiddleCenter,
+        title: '5 MiddleCenter',
+        subtitle: 'GC71=5',
+        col: 1,
+        row: 1
+      },
+      {
+        attachmentPoint: MTextAttachmentPoint.MiddleRight,
+        title: '6 MiddleRight',
+        subtitle: 'GC71=6',
+        col: 2,
+        row: 1
+      },
+      {
+        attachmentPoint: MTextAttachmentPoint.BottomLeft,
+        title: '7 BottomLeft',
+        subtitle: 'GC71=7',
+        col: 0,
+        row: 2
+      },
+      {
+        attachmentPoint: MTextAttachmentPoint.BottomCenter,
+        title: '8 BottomCenter',
+        subtitle: 'GC71=8',
+        col: 1,
+        row: 2
+      },
+      {
+        attachmentPoint: MTextAttachmentPoint.BottomRight,
+        title: '9 BottomRight',
+        subtitle: 'GC71=9',
+        col: 2,
+        row: 2
+      },
+      {
+        attachmentPoint: MTextAttachmentPoint.BaselineLeft,
+        title: '10 BaselineL',
+        subtitle: 'GC71=10',
+        col: 0,
+        row: 3
+      },
+      {
+        attachmentPoint: MTextAttachmentPoint.BaselineCenter,
+        title: '11 BaselineC',
+        subtitle: 'GC71=11',
+        col: 1,
+        row: 3
+      },
+      {
+        attachmentPoint: MTextAttachmentPoint.BaselineRight,
+        title: '12 BaselineR',
+        subtitle: 'GC71=12',
+        col: 2,
+        row: 3
+      }
+    ]
+
+    return cells.map(({ attachmentPoint, title, subtitle, col, row }) => {
+      const cx = originX + col * cellW + cellW / 2
+      const cy = originY - row * cellH - cellH / 2
+      const text = `{\\C1;${title}}\\P{\\C3;${subtitle}}\\P{\\C2;+ anchor}\\P{\\C7;sample}`
+
+      return {
+        mtextData: {
+          text,
+          height: 10,
+          width: 170,
+          position: new THREE.Vector3(cx, cy, 0),
+          attachmentPoint
+        },
+        textStyle: {
+          name: 'Standard',
+          standardFlag: 0,
+          fixedTextHeight: 10,
+          widthFactor: 1,
+          obliqueAngle: 0,
+          textGenerationFlag: 0,
+          lastHeight: 10,
+          font: this.fontSelect.value,
+          bigFont: ''
+        }
+      }
+    })
   }
 
   private createMultipleMTextData(): {
@@ -660,11 +812,15 @@ class MTextRendererExample {
       let renderTime: number
       const colorSettings = this.getColorSettings()
 
-      if (content === 'multiple') {
-        // Render multiple MText objects
-        const multipleData = this.createMultipleMTextData()
+      const multiData =
+        content === 'multiple'
+          ? this.createMultipleMTextData()
+          : content === 'attachmentGrid'
+            ? this.createAttachmentPointTestData()
+            : null
 
-        const renderPromises = multipleData.map(({ mtextData, textStyle }) => {
+      if (multiData) {
+        const renderPromises = multiData.map(({ mtextData, textStyle }) => {
           return this.unifiedRenderer.asyncRenderMText(
             mtextData,
             textStyle,
@@ -678,7 +834,18 @@ class MTextRendererExample {
         const group = new THREE.Group()
         let combinedBox: THREE.Box3 | null = null
 
-        mtextObjects.forEach((mtextObj, index) => {
+        if (content === 'attachmentGrid') {
+          for (const { mtextData } of multiData) {
+            group.add(
+              this.createInsertionCrosshair(
+                mtextData.position.x,
+                mtextData.position.y
+              )
+            )
+          }
+        }
+
+        mtextObjects.forEach(mtextObj => {
           this.attachCharBoxOverlay(mtextObj)
           this.attachLineBoxOverlay(mtextObj)
           group.add(mtextObj)
@@ -698,15 +865,7 @@ class MTextRendererExample {
             mtextObj.box &&
             !mtextObj.box.isEmpty()
           ) {
-            const box = this.createMTextBox(
-              mtextObj.box,
-              new THREE.Vector3(
-                multipleData[index].mtextData.position.x,
-                multipleData[index].mtextData.position.y,
-                multipleData[index].mtextData.position.z
-              ),
-              multipleData[index].mtextData.width
-            )
+            const box = this.createMTextBox(mtextObj.box)
             group.add(box)
           }
         })
@@ -722,7 +881,9 @@ class MTextRendererExample {
         this.scene.add(this.currentMText)
 
         renderTime = performance.now() - startTime
-        this.statusDiv.textContent = `Rendered ${mtextObjects.length}/${multipleData.length} MText objects in ${renderTime.toFixed(2)}ms (${this.renderModeSelect.value} thread)`
+        const label =
+          content === 'attachmentGrid' ? 'attachment-point grid' : 'MText batch'
+        this.statusDiv.textContent = `Rendered ${mtextObjects.length}/${multiData.length} (${label}) in ${renderTime.toFixed(2)}ms (${this.renderModeSelect.value} thread)`
       } else {
         // Render single MText object
         const mtextContent: MTextData = {
@@ -761,15 +922,7 @@ class MTextRendererExample {
           this.currentMText.box &&
           !this.currentMText.box.isEmpty()
         ) {
-          const box = this.createMTextBox(
-            this.currentMText.box,
-            new THREE.Vector3(
-              mtextContent.position.x,
-              mtextContent.position.y,
-              mtextContent.position.z
-            ),
-            mtextContent.width
-          )
+          const box = this.createMTextBox(this.currentMText.box)
           this.scene.add(box)
         }
 

--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-renderer",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "description": "AutoCAD MText renderer based on Three.js",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",

--- a/packages/mtext-renderer/src/renderer/mtext.ts
+++ b/packages/mtext-renderer/src/renderer/mtext.ts
@@ -36,6 +36,60 @@ const tempMatrix = /*@__PURE__*/ new THREE.Matrix4()
 const AxisX = /*@__PURE__*/ new THREE.Vector3(1, 0, 0)
 
 /**
+ * Axis-aligned rectangle (plus baseline) describing the **logical MText frame**
+ * used to compute attachment-point offsets in {@link MText.loadMText}.
+ *
+ * @remarks
+ * Values are expressed in the same local space as the object returned from layout:
+ * X typically spans the declared column width (or measured glyph width when width is
+ * non-finite), and Y spans the visible frame height. The frame height prefers the
+ * world-space geometry bounding box when it is non-empty so that inter-line leading
+ * from line layout does not inflate vertical padding above the first line; otherwise
+ * it falls back to the processor’s `totalHeight`.
+ *
+ * For {@link MTextFlowDirection.BOTTOM_TO_TOP}, the Y interval is built downward from
+ * the geometry minimum so vertical anchoring matches inverted flow.
+ */
+interface AnchorMetrics {
+  /** Left edge of the anchoring frame (drawing units). */
+  minX: number
+  /** Right edge of the anchoring frame (drawing units). */
+  maxX: number
+  /** Bottom edge of the anchoring frame (drawing units). */
+  minY: number
+  /** Top edge of the anchoring frame (drawing units). */
+  maxY: number
+  /**
+   * Y coordinate of the **first text line’s bottom** in line-layout space when at
+   * least one {@link LineLayout} entry exists; otherwise equals `minY`. Used by
+   * baseline attachment points ({@link MTextAttachmentPoint.BaselineLeft}, etc.).
+   */
+  baselineY: number
+}
+
+/**
+ * World-oriented 2D extents of laid-out text **after** the anchor translation from
+ * {@link MText.calculateAnchorPoint} has been applied, stored on the root group as
+ * `userData.logicalBounds` for consumers that need a stable box without per-glyph union.
+ *
+ * @remarks
+ * Coordinates are still in the group’s local space immediately after anchoring; the
+ * owning {@link THREE.Object3D} may then be rotated/translated by insertion point and
+ * rotation from `MTextData`. These bounds align with the same min/max X/Y used when
+ * expanding {@link MText.box} via {@link MText.updateBoxFromObject}.
+ */
+interface LogicalBounds {
+  /** Minimum X of the logically anchored text span. */
+  minX: number
+  /** Maximum X of the logically anchored text span. */
+  maxX: number
+  /** Minimum Y of the logically anchored text span. */
+  minY: number
+  /** Maximum Y of the logically anchored text span. */
+  maxY: number
+}
+
+/**
  * Represents an AutoCAD MText object in Three.js.
  * This class extends THREE.Object3D to provide MText rendering capabilities,
  * including text layout, alignment, and transformation.
@@ -173,10 +227,11 @@ export class MText extends THREE.Object3D {
         minY: Infinity,
         maxY: -Infinity,
         minZ: Infinity,
-        maxZ: -Infinity
+        maxZ: -Infinity,
+        hasLogicalBounds: false
       }
       this.updateBoxFromObject(obj, lineBounds)
-      if (lineBounds.hasLine) {
+      if (lineBounds.hasLine && !lineBounds.hasLogicalBounds) {
         if (this.box.isEmpty()) {
           this.box.min.set(lineBounds.minX, lineBounds.minY, lineBounds.minZ)
           this.box.max.set(lineBounds.maxX, lineBounds.maxY, lineBounds.maxZ)
@@ -283,25 +338,29 @@ export class MText extends THREE.Object3D {
     // is computed from the *real* rendered glyph extent — independent of
     // font, kerning, or character composition.
     let width = mtextData.width
-    let height = layoutHeight
     object.updateWorldMatrix(true, true)
     const bbox = new THREE.Box3().setFromObject(object)
-    if (!bbox.isEmpty()) {
-      const measuredHeight = bbox.max.y - bbox.min.y
-      if (Number.isFinite(measuredHeight) && measuredHeight > 0) {
-        height = measuredHeight
-      }
-    }
     if (!Number.isFinite(width)) {
       const measured = bbox.max.x - bbox.min.x
       width = Number.isFinite(measured) && measured > 0 ? measured : 0
     }
-    const anchorPoint = this.calculateAnchorPoint(
+    const anchorMetrics = this.measureAnchorMetrics(
+      object,
       width,
-      height,
-      mtextData.attachmentPoint,
+      layoutHeight,
+      bbox,
       mtextData.drawingDirection
     )
+    const anchorPoint = this.calculateAnchorPoint(
+      anchorMetrics,
+      mtextData.attachmentPoint
+    )
+    object.userData.logicalBounds = {
+      minX: anchorMetrics.minX + anchorPoint.x,
+      maxX: anchorMetrics.maxX + anchorPoint.x,
+      minY: anchorMetrics.minY + anchorPoint.y,
+      maxY: anchorMetrics.maxY + anchorPoint.y
+    } satisfies LogicalBounds
 
     const translateCharBoxEntries = (entries: CharBox[] | undefined) => {
       if (!entries || entries.length === 0) return
@@ -326,13 +385,12 @@ export class MText extends THREE.Object3D {
       if ('geometry' in obj) {
         const geometry = obj.geometry as THREE.BufferGeometry
         geometry.translate(anchorPoint.x, anchorPoint.y, 0)
-      } else {
-        // Char-box-only placeholder objects (e.g., trailing empty lines)
-        // need the same anchor translation as geometry-bearing objects.
-        translateCharBoxEntries(
-          obj.userData?.layout?.chars as CharBox[] | undefined
-        )
       }
+      // Char-box metadata is stored alongside geometry for normal glyphs and
+      // on placeholder objects for spaces/empty lines, so translate it for both.
+      translateCharBoxEntries(
+        obj.userData?.layout?.chars as CharBox[] | undefined
+      )
       translateLineLayouts(
         obj.userData?.lineLayouts as LineLayout[] | undefined
       )
@@ -499,76 +557,185 @@ export class MText extends THREE.Object3D {
   }
 
   /**
-   * Calculates the anchor point for text positioning based on alignment and flow direction.
-   * @param width - The width of the text
-   * @param height - The height of the text
-   * @param attachmentPoint - The attachment point for text alignment
-   * @param flowDirection - The text flow direction
-   * @returns The calculated anchor point coordinates
+   * Measures the logical text frame used by attachment-point anchoring.
+   *
+   * @remarks
+   * Line-layout boxes include inter-line leading that is useful for hit testing, but
+   * that leading must not become extra padding above the first rendered line when
+   * aligning to top/middle/bottom attachment points. This method therefore prefers the
+   * visible geometry height from `geometryBox` when it is non-empty, and only falls
+   * back to `layoutHeight` when there are no measurable glyphs (e.g. empty or
+   * whitespace-only runs).
+   *
+   * @param object - Root group produced by layout; traversed for {@link LineLayout}
+   *   metadata to locate the first line baseline.
+   * @param width - Column width used for horizontal anchoring when finite and
+   *   positive; if not, horizontal extents are taken from `geometryBox`.
+   * @param layoutHeight - Total laid-out height from {@link MTextProcessor} when
+   *   geometry height is unavailable or zero.
+   * @param geometryBox - Axis-aligned bounds of rendered primitives under `object`,
+   *   typically from {@link THREE.Box3.setFromObject}.
+   * @param flowDirection - Optional flow; when {@link MTextFlowDirection.BOTTOM_TO_TOP},
+   *   the vertical frame is anchored from the geometry minimum upward.
+   * @returns Metrics consumed by {@link MText.calculateAnchorPoint}.
+   */
+  private measureAnchorMetrics(
+    object: THREE.Object3D,
+    width: number,
+    layoutHeight: number,
+    geometryBox: THREE.Box3,
+    flowDirection?: MTextFlowDirection
+  ): AnchorMetrics {
+    const lineBounds = {
+      hasLine: false,
+      minY: Infinity,
+      maxY: -Infinity,
+      baselineY: 0
+    }
+    let firstBaselineCaptured = false
+
+    object.traverse(obj => {
+      const lines = obj.userData?.lineLayouts as LineLayout[] | undefined
+      if (!lines || lines.length === 0) return
+
+      lines.forEach(line => {
+        const minY = line.y - line.height / 2
+        const maxY = line.y + line.height / 2
+        lineBounds.hasLine = true
+        lineBounds.minY = Math.min(lineBounds.minY, minY)
+        lineBounds.maxY = Math.max(lineBounds.maxY, maxY)
+        if (!firstBaselineCaptured) {
+          lineBounds.baselineY = minY
+          firstBaselineCaptured = true
+        }
+      })
+    })
+
+    const geometryHeight = geometryBox.isEmpty()
+      ? 0
+      : geometryBox.max.y - geometryBox.min.y
+    const frameHeight =
+      Number.isFinite(geometryHeight) && geometryHeight > 0
+        ? geometryHeight
+        : Number.isFinite(layoutHeight) && layoutHeight > 0
+          ? layoutHeight
+          : 0
+
+    let minX = 0
+    let maxX = Number.isFinite(width) && width > 0 ? width : 0
+    if (maxX <= minX && !geometryBox.isEmpty()) {
+      minX = geometryBox.min.x
+      maxX = geometryBox.max.x
+    }
+
+    let minY = 0
+    let maxY = 0
+    if (flowDirection == MTextFlowDirection.BOTTOM_TO_TOP) {
+      minY = geometryBox.isEmpty() ? 0 : geometryBox.min.y
+      maxY = minY + frameHeight
+    } else {
+      maxY = geometryBox.isEmpty() ? 0 : geometryBox.max.y
+      minY = maxY - frameHeight
+    }
+    const baselineY = lineBounds.hasLine ? lineBounds.baselineY : minY
+
+    return { minX, maxX, minY, maxY, baselineY }
+  }
+
+  /**
+   * Computes the 2D translation that maps the logical frame described by `metrics`
+   * so that the chosen AutoCAD-style attachment point coincides with the insertion
+   * origin (before rotation/insertion-point transforms applied later in
+   * {@link MText.loadMText}).
+   *
+   * @remarks
+   * The returned vector is **added** to vertex positions and char-box metadata via
+   * `geometry.translate` / `CharBox.box.translate` / line `y` offsets. For `undefined`
+   * attachment, behavior matches {@link MTextAttachmentPoint.TopLeft}.
+   *
+   * @param metrics - Pre-anchoring frame from {@link MText.measureAnchorMetrics}.
+   * @param attachmentPoint - DWG attachment constant; determines which corner, edge
+   *   center, or baseline of the frame is pinned to `(0,0)` in anchored space.
+   * @returns Translation `(x, y)` in drawing units applied uniformly to the laid-out
+   *   group and its layout sidecars.
    */
   private calculateAnchorPoint(
-    width: number,
-    height: number,
-    attachmentPoint?: MTextAttachmentPoint,
-    flowDirection?: MTextFlowDirection
+    metrics: AnchorMetrics,
+    attachmentPoint?: MTextAttachmentPoint
   ): Point2d {
+    const centerX = (metrics.minX + metrics.maxX) / 2
+    const centerY = (metrics.minY + metrics.maxY) / 2
     let anchorX = 0,
       anchorY = 0
     switch (attachmentPoint) {
       case undefined:
       case MTextAttachmentPoint.TopLeft:
-        anchorX = 0
-        anchorY = 0
+        anchorX = -metrics.minX
+        anchorY = -metrics.maxY
         break
       case MTextAttachmentPoint.TopCenter:
-        anchorX -= width / 2
-        anchorY = 0
+        anchorX = -centerX
+        anchorY = -metrics.maxY
         break
       case MTextAttachmentPoint.TopRight:
-        anchorX -= width
-        anchorY = 0
+        anchorX = -metrics.maxX
+        anchorY = -metrics.maxY
         break
       case MTextAttachmentPoint.MiddleLeft:
-        anchorX = 0
-        anchorY += height / 2
+        anchorX = -metrics.minX
+        anchorY = -centerY
         break
       case MTextAttachmentPoint.MiddleCenter:
-        anchorX -= width / 2
-        anchorY += height / 2
+        anchorX = -centerX
+        anchorY = -centerY
         break
       case MTextAttachmentPoint.MiddleRight:
-        anchorX -= width
-        anchorY += height / 2
+        anchorX = -metrics.maxX
+        anchorY = -centerY
         break
       case MTextAttachmentPoint.BottomLeft:
-      case MTextAttachmentPoint.BaselineLeft:
-        // Baseline ≈ Bottom for SHX/single-line text where descender is
-        // negligible. Treating them identically keeps the public API
-        // expressive without requiring per-font descender metrics.
-        anchorX = 0
-        anchorY += height
+        anchorX = -metrics.minX
+        anchorY = -metrics.minY
         break
       case MTextAttachmentPoint.BottomCenter:
-      case MTextAttachmentPoint.BaselineCenter:
-        anchorX -= width / 2
-        anchorY += height
+        anchorX = -centerX
+        anchorY = -metrics.minY
         break
       case MTextAttachmentPoint.BottomRight:
-      case MTextAttachmentPoint.BaselineRight:
-        anchorX -= width
-        anchorY += height
+        anchorX = -metrics.maxX
+        anchorY = -metrics.minY
         break
-    }
-    if (flowDirection == MTextFlowDirection.BOTTOM_TO_TOP) {
-      anchorY -= height
+      case MTextAttachmentPoint.BaselineLeft:
+        anchorX = -metrics.minX
+        anchorY = -metrics.baselineY
+        break
+      case MTextAttachmentPoint.BaselineCenter:
+        anchorX = -centerX
+        anchorY = -metrics.baselineY
+        break
+      case MTextAttachmentPoint.BaselineRight:
+        anchorX = -metrics.maxX
+        anchorY = -metrics.baselineY
+        break
     }
     return { x: anchorX, y: anchorY }
   }
 
   /**
-   * Recursively calculates bounding boxes for an object and its children.
-   * @param object - The Three.js object to process
-   * @param boxes - Array to store the calculated bounding boxes
+   * Walks a laid-out MText subgraph and accumulates world-space character hit boxes and
+   * soft line rectangles for {@link MText.createLayoutData} (raycasting, cursors, debug).
+   *
+   * @remarks
+   * - When `userData.layout.chars` is present, entries are transformed with
+   *   {@link buildCharBoxesFromObject} and appended to `chars`, then recursion stops
+   *   for that branch (char metadata is authoritative).
+   * - When only mesh/line geometry exists, a single synthetic {@link CharBox} wrapping
+   *   the geometry AABB may be emitted.
+   * - `userData.lineLayouts` rows are converted to world-space center `y` and height.
+   *
+   * @param object - Node to traverse (typically the root group from {@link MText.loadMText}).
+   * @param chars - Output collection; receives merged {@link CharBox} entries in world space.
+   * @param lines - Output collection; receives {@link LineLayout} summaries per line break.
    */
   private getLayout(
     object: THREE.Object3D,
@@ -635,6 +802,28 @@ export class MText extends THREE.Object3D {
     }
   }
 
+  /**
+   * Depth-first union of this MText’s {@link MText.box} from layout metadata and mesh
+   * geometry, while optionally tracking coarse line AABB in `lineBounds`.
+   *
+   * @remarks
+   * Priority order per node:
+   * 1. If `userData.logicalBounds` exists (set in {@link MText.loadMText}), union that
+   *    axis-aligned rectangle transformed by `matrixWorld` — this reflects anchored
+   *    logical extents even when individual glyphs are expensive to union.
+   * 2. Else if `userData.lineLayouts` exists, expand `lineBounds` from the world-space
+   *    top/bottom of each line strip (used as a fallback when no logical bounds were
+   *    written, e.g. legacy paths).
+   * 3. Else if `userData.layout.chars` exists, union each transformed char AABB.
+   * 4. Else for mesh/line primitives, union non-decoration geometry bounds.
+   * 5. Always recurse into children.
+   *
+   * @param object - Current scene graph node.
+   * @param lineBounds - Mutable accumulator: `hasLine`/`min*`/`max*` track the union of
+   *   line-layout strips in world space; `hasLogicalBounds` flips true when any child
+   *   contributed `logicalBounds` so {@link MText.syncDraw} can avoid double-counting
+   *   vertical extent from line strips alone.
+   */
   private updateBoxFromObject(
     object: THREE.Object3D,
     lineBounds: {
@@ -645,9 +834,23 @@ export class MText extends THREE.Object3D {
       maxY: number
       minZ: number
       maxZ: number
+      hasLogicalBounds: boolean
     }
   ) {
     object.updateWorldMatrix(false, false)
+
+    const logicalBounds = object.userData?.logicalBounds as
+      | LogicalBounds
+      | undefined
+    if (logicalBounds) {
+      lineBounds.hasLogicalBounds = true
+      const box = new THREE.Box3(
+        new THREE.Vector3(logicalBounds.minX, logicalBounds.minY, 0),
+        new THREE.Vector3(logicalBounds.maxX, logicalBounds.maxY, 0)
+      )
+      box.applyMatrix4(object.matrixWorld)
+      this.box.union(box)
+    }
 
     const objectLineLayouts = object.userData?.lineLayouts as
       | LineLayout[]
@@ -740,6 +943,13 @@ export class MText extends THREE.Object3D {
       }
     })
   }
+  /**
+   * Normalizes a font file reference to the lowercase stem used by
+   * {@link FontManager.loadFontsByNames} (strip extension).
+   *
+   * @param fontFileName - Style font path such as `arial.ttf` or extension-less name.
+   * @returns Lowercase name without the last extension segment, or `undefined` if empty.
+   */
   private getFontName(fontFileName: string) {
     if (fontFileName) {
       const lastDotIndex = fontFileName.lastIndexOf('.')

--- a/packages/mtext-renderer/test/renderer/mtext.anchor.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.anchor.test.ts
@@ -41,7 +41,7 @@ function createGeometryBox(object: THREE.Object3D) {
 }
 
 describe('MText attachment anchoring', () => {
-  it('centers visible glyph geometry using layout height instead of scaled font size', () => {
+  it('centers visible glyph geometry instead of line-layout leading', () => {
     const fontScaleFactor = 2
     const textHeight = 24
     const style: TextStyle = {
@@ -92,7 +92,140 @@ describe('MText attachment anchoring', () => {
     mtext.syncDraw()
     const box = createGeometryBox(mtext)
 
-    expect(box.min.y).toBeCloseTo(-textHeight / 2, 6)
-    expect(box.max.y).toBeCloseTo(textHeight / 2, 6)
+    expect(mtext.box.min.x).toBeCloseTo(-50, 4)
+    expect(mtext.box.max.x).toBeCloseTo(50, 4)
+    expect(mtext.box.min.y).toBeCloseTo(-12, 4)
+    expect(mtext.box.max.y).toBeCloseTo(12, 4)
+    expect(box.min.y).toBeCloseTo(-12, 4)
+    expect(box.max.y).toBeCloseTo(12, 4)
+  })
+
+  it.each([
+    [MTextAttachmentPoint.TopLeft, 0, 100, -24, 0],
+    [MTextAttachmentPoint.TopCenter, -50, 50, -24, 0],
+    [MTextAttachmentPoint.TopRight, -100, 0, -24, 0],
+    [MTextAttachmentPoint.MiddleLeft, 0, 100, -12, 12],
+    [MTextAttachmentPoint.MiddleCenter, -50, 50, -12, 12],
+    [MTextAttachmentPoint.MiddleRight, -100, 0, -12, 12],
+    [MTextAttachmentPoint.BottomLeft, 0, 100, 0, 24],
+    [MTextAttachmentPoint.BottomCenter, -50, 50, 0, 24],
+    [MTextAttachmentPoint.BottomRight, -100, 0, 0, 24],
+    [MTextAttachmentPoint.BaselineLeft, 0, 100, 0, 24],
+    [MTextAttachmentPoint.BaselineCenter, -50, 50, 0, 24],
+    [MTextAttachmentPoint.BaselineRight, -100, 0, 0, 24]
+  ])(
+    'anchors attachment point %i to the insertion point',
+    (attachmentPoint, minX, maxX, minY, maxY) => {
+      const textHeight = 24
+      const style: TextStyle = {
+        name: 'default',
+        standardFlag: 0,
+        fixedTextHeight: 0,
+        widthFactor: 1,
+        obliqueAngle: 0,
+        textGenerationFlag: 0,
+        lastHeight: textHeight,
+        font: 'fake',
+        bigFont: ''
+      }
+      const styleManager = {
+        unsupportedTextStyles: {},
+        getMeshBasicMaterial: vi
+          .fn()
+          .mockReturnValue(new THREE.MeshBasicMaterial()),
+        getLineBasicMaterial: vi
+          .fn()
+          .mockReturnValue(new THREE.LineBasicMaterial())
+      }
+      const fontManager = {
+        getFontScaleFactor: () => 1,
+        getFontType: () => 'mesh',
+        findAndReplaceFont: (name: string) => name,
+        getCharShape: (_char: string, _fontName: string, size: number) => ({
+          width: 10,
+          toGeometry: () => createShapeGeometry(10, size)
+        }),
+        getNotFoundTextShape: () => undefined
+      }
+
+      const mtext = new MText(
+        {
+          text: 'A',
+          height: textHeight,
+          width: 100,
+          position: { x: 0, y: 0, z: 0 },
+          attachmentPoint
+        },
+        style,
+        styleManager as any,
+        fontManager as any,
+        createDefaultColorSettings()
+      )
+
+      mtext.syncDraw()
+
+      expect(mtext.box.min.x).toBeCloseTo(minX, 4)
+      expect(mtext.box.max.x).toBeCloseTo(maxX, 4)
+      expect(mtext.box.min.y).toBeCloseTo(minY, 4)
+      expect(mtext.box.max.y).toBeCloseTo(maxY, 4)
+    }
+  )
+
+  it('keeps char-box layout aligned with anchored geometry', () => {
+    const textHeight = 24
+    const style: TextStyle = {
+      name: 'default',
+      standardFlag: 0,
+      fixedTextHeight: 0,
+      widthFactor: 1,
+      obliqueAngle: 0,
+      textGenerationFlag: 0,
+      lastHeight: textHeight,
+      font: 'fake',
+      bigFont: ''
+    }
+    const styleManager = {
+      unsupportedTextStyles: {},
+      getMeshBasicMaterial: vi
+        .fn()
+        .mockReturnValue(new THREE.MeshBasicMaterial()),
+      getLineBasicMaterial: vi
+        .fn()
+        .mockReturnValue(new THREE.LineBasicMaterial())
+    }
+    const fontManager = {
+      getFontScaleFactor: () => 1,
+      getFontType: () => 'mesh',
+      findAndReplaceFont: (name: string) => name,
+      getCharShape: (_char: string, _fontName: string, size: number) => ({
+        width: 10,
+        toGeometry: () => createShapeGeometry(10, size)
+      }),
+      getNotFoundTextShape: () => undefined
+    }
+
+    const mtext = new MText(
+      {
+        text: 'A',
+        height: textHeight,
+        width: 100,
+        position: { x: 0, y: 0, z: 0 },
+        attachmentPoint: MTextAttachmentPoint.MiddleCenter
+      },
+      style,
+      styleManager as any,
+      fontManager as any,
+      createDefaultColorSettings()
+    )
+
+    mtext.syncDraw()
+    const geometryBox = createGeometryBox(mtext)
+    const layout = mtext.createLayoutData()
+
+    expect(layout.chars).toHaveLength(1)
+    expect(layout.chars[0].box.min.x).toBeCloseTo(geometryBox.min.x, 6)
+    expect(layout.chars[0].box.max.x).toBeCloseTo(geometryBox.max.x, 6)
+    expect(layout.chars[0].box.min.y).toBeCloseTo(geometryBox.min.y, 6)
+    expect(layout.chars[0].box.max.y).toBeCloseTo(geometryBox.max.y, 6)
   })
 })


### PR DESCRIPTION
## Summary

Aligns MText with AutoCAD-style DXF group 71 **attachment points** (1–12): anchoring uses measured layout metrics (including baseline), bounding boxes prefer **logical bounds** when present, and the example app gains an **attachment grid** preset for visual regression.

## Changes

### Renderer (`mtext.ts`)

- Rework attachment-point math so the insertion point matches each `MTextAttachmentPoint` using glyph/layout metrics (`minX` / `maxX` / `centerX` / `baselineY`) instead of coarse width/height heuristics.
- Extend `updateBoxFromObject` to union **`userData.logicalBounds`** (transformed to world space) and track `hasLogicalBounds`, so `MText.box` reflects anchored logical extents without double-counting line strips.
- Document `getLayout`, `updateBoxFromObject`, and related helpers for layout metadata and hit testing.

### Tests (`mtext.anchor.test.ts`)

- Update centering expectations to match anchored geometry and `mtext.box`.
- Add `it.each` coverage for all 12 attachment points (expected `mtext.box` min/max).
- Add a test that **char-box layout** stays aligned with anchored geometry.

### Example app

- New **“Attachment Points”** preset: 3×4 grid of samples (GC71=1…12) with shared insertion coordinates and red **insertion crosshairs**.
- `createMTextBox` now draws from **renderer-computed** `THREE.Box3` extents instead of reconstructing X from position + `maxWidth`.

### Tooling

- Root `package.json`: `packageManager` pinned to **pnpm@10.33.4**; `engines.pnpm` raised to **>=10**.

## How to verify

- `pnpm test` (or package-scoped test for `@mlightcad/mtext-renderer`).
- Run the example, choose **Attachment Points**, and confirm each cell’s text sits correctly relative to the crosshair for GC71 1–12.