### PR TITLE
fix: render SHX text at AutoCAD's cap-height (TEXT.height) scale

### DIFF
--- a/packages/mtext-renderer/src/font/shxFont.ts
+++ b/packages/mtext-renderer/src/font/shxFont.ts
@@ -69,10 +69,37 @@ export class ShxFont extends BaseFont {
   }
 
   /**
-   * SHX font always has fixed scale factor 1.
-   * @returns Always return value 1
+   * Scale factor that converts AutoCAD's `TEXT.height` (cap-height in the SHX
+   * convention) into the em-box-scaled size expected by `generateShapes`.
+   *
+   * SHX glyphs are defined with `baseUp` units of cap-height (height of an
+   * uppercase letter above the baseline) and `height` units of total em-box
+   * (cap-height + descender + headroom for accents). AutoCAD's DXF group 40
+   * for TEXT/ATTRIB/MTEXT is the cap-height — the historical SHX convention
+   * since the format's introduction in AutoCAD R2 (1985), kept by AutoCAD
+   * when TrueType support was added in the early 1990s so that DWGs portable
+   * across font formats render at consistent visual sizes.
+   *
+   * Returning `1` (the previous behavior) meant SHX glyphs were rendered at
+   * `baseUp / height` of the expected size — typically ~0.75 for western
+   * fonts like `romans.shx`/`complex.shx` where `baseUp=21, height=28`.
+   * Multiplying by `height / baseUp` restores the cap-height interpretation.
+   *
+   * Mirrors the behavior already in place for mesh fonts (see
+   * `meshFontParser.ts` where `scaleFactor = unitsPerEm / glyph('A').yMax`),
+   * isolated to the glyph render path only — `mtextProcessor.currentLayoutFontSize`
+   * divides by this factor to keep layout metrics (line height, attachment
+   * offsets, blank width) on the original cap-height scale.
+   *
+   * @returns `height / baseUp` when both are populated and positive; `1`
+   *   otherwise (e.g. exotic BIGFONT/symbol fonts without standard metrics),
+   *   matching the prior behavior as a safe fallback.
    */
   getScaleFactor() {
+    const { height, baseUp } = this.data.content
+    if (baseUp > 0 && height > 0) {
+      return height / baseUp
+    }
     return 1
   }
 


### PR DESCRIPTION
## Summary

SHX font glyphs render at ~0.75x the size declared by `TEXT.height` (DXF group 40), making CAD text visibly smaller than AutoCAD. Root cause: `ShxFont.getScaleFactor()` returned `1` hardcoded, interpreting `size` as the total em-box (`baseUp + baseDown + headroom for accents`) while AutoCAD has always interpreted `TEXT.height` as **cap-height** (`baseUp`). Returning `height / baseUp` (e.g. `28/21 ≈ 1.333` for western SHX fonts like `romans.shx`) restores the cap-height convention.

## Why this is the right fix

- **Same shape as the mesh font path.** `meshFontParser.ts:25-26` already does the equivalent for TrueType: `scaleFactor = unitsPerEm / glyph('A').yMax`. SHX fonts expose the equivalent information explicitly via `data.content.baseUp` and `data.content.height` — no empirical glyph probing needed.
- **No regression on layout metrics.** `mtextProcessor.currentLayoutFontSize` divides by `fontScaleFactor` to recover the cap-height-scaled value used by line height, attachment offsets, and blank-width calculations. The existing JSDoc on that getter (lines 365-368) calls out this exact invariant — the change rides on a contract the codebase already enforces.
- **Safe fallback.** When `baseUp` or `height` are not populated (exotic BIGFONT/symbol fonts), returns `1` — identical to the previous behavior.

## Validation

DWG with ATTRIBs and single-line texts using `romans.shx` and `complex.shx` (both fonts have `baseUp=21, height=28`). Renderer instrumentation logged `measured / declared`:

| Sample | Font | Ratio (before fix) |
|---|---|---|
| ATTRIB "M1" | romans.shx | 0.7500000121 |
| ATTRIB "P6" | romans.shx | 0.7500000121 |
| ATTRIB "P7" | romans.shx | 0.7500000121 |
| TEXT "SW" | complex.shx | 0.7500 |

`0.7500 ≡ baseUp / height ≡ 21 / 28` — exact match with the hypothesis. After applying the fix, SHX glyphs render at the expected size in side-by-side comparison with AutoCAD.

## Out of scope (separate follow-up)

Mesh font (TrueType) cap-height/em-size mismatch is a related but separate bug with its own ratio characteristics (e.g. ~0.68 for Arial Narrow in the same DWG) and a different code path (`meshFontParser.ts` + `threeFont.ts`). Will be addressed in a follow-up that prefers `sCapHeight` from the OS/2 table over the `glyph('A').yMax` heuristic when available — keeping the empirical heuristic as a fallback for fonts that don't populate that field (typically CJK).

## Test plan

- [x] Western SHX (`romans.shx`, `complex.shx`) — visual and numerical confirmation in a production-style DWG
- [ ] CJK SHX — expected no regression (no `baseUp`/`height` population → falls back to `1`)
- [ ] BIGFONT — expected no regression (same fallback)

## Test file
[test-file.dwg](https://drive.google.com/file/d/1un7-SBKcueYphRX5bfXvO-uKQot_a32I/view?usp=sharing)