### PR TITLE
fix: correct SHX CJK advance, space width, and oblique layout in MText

### DIFF
--- a/packages/mtext-renderer/src/font/shxFont.ts
+++ b/packages/mtext-renderer/src/font/shxFont.ts
@@ -45,18 +45,31 @@ export class ShxFont extends BaseFont {
     return this.font.hasChar(code)
   }
 
+  /**
+   * Horizontal advance for the space character (ASCII 32) at the given size.
+   * Uses the SHX glyph pen advance when defined; otherwise falls back to half the
+   * text height (common for AutoCAD SHX fonts).
+   */
+  getSpaceAdvance(size: number) {
+    const spaceShape = this.getCharShape(' ', size)
+    if (spaceShape) {
+      return spaceShape.width
+    }
+    return size * 0.5
+  }
+
   generateShapes(text: string, size: number) {
     const shapes: ShxTextShape[] = []
     let hOffset = 0.0
     for (let i = 0; i < text.length; i++) {
       const char = text[i]
       if (char === ' ') {
-        hOffset += size
+        hOffset += this.getSpaceAdvance(size)
         continue
       }
       const shape = this.getCharShape(char, size)
       if (!shape) {
-        hOffset += size
+        hOffset += this.getSpaceAdvance(size)
         this.addUnsupportedChar(char)
         // const notFund = this.getNotFoundTextShape(size);
         // notFund && shapes.push(notFund);

--- a/packages/mtext-renderer/src/font/shxTextShape.ts
+++ b/packages/mtext-renderer/src/font/shxTextShape.ts
@@ -27,14 +27,30 @@ export class ShxTextShape extends BaseTextShape {
     this.shape = shape
     this.font = font
     this.code = code
-    // According to ChatGPT, the advance width of one SHX font character equals the
-    // X position of the final pen location when the character definition ends.
-    // In other words, advanceWidth = finalPenX
-    if (font.data.header.fontType === ShxFontType.BIGFONT) {
-      this.width = this.calcWidth()
-    } else {
-      this.width = shape.lastPoint?.x ?? this.calcWidth()
+    this.width = this.resolveAdvanceWidth(shape)
+  }
+
+  /**
+   * Resolves horizontal advance for SHX glyphs.
+   *
+   * - Unicode / shapes fonts: prefer the pen-down end X (lastPoint), which matches
+   *   AutoCAD's advance for single-byte SHX.
+   * - Big fonts (CJK): advance is the scaled font cell width (content.width /
+   *   content.height * fontSize). Glyph bbox or lastPoint can be narrower than the
+   *   cell; using only bbox caused successive Han characters to overlap visually.
+   */
+  private resolveAdvanceWidth(shape: ShxShape): number {
+    const bboxWidth = this.calcWidth()
+    const penAdvance = shape.lastPoint?.x ?? 0
+
+    if (this.font.data.header.fontType === ShxFontType.BIGFONT) {
+      const { width: cellWidth, height: cellHeight } = this.font.data.content
+      const scaledCellWidth =
+        cellHeight > 0 ? (cellWidth / cellHeight) * this.fontSize : 0
+      return Math.max(bboxWidth, penAdvance, scaledCellWidth)
     }
+
+    return penAdvance > 0 ? penAdvance : bboxWidth
   }
 
   protected calcWidth() {

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -414,6 +414,15 @@ export class MTextProcessor {
     return this._currentContext.widthFactor.value
   }
 
+  /** Horizontal advance for one space, including tracking and width factor. */
+  get currentBlankAdvance() {
+    return (
+      this._currentContext.blankWidth *
+      this.currentWordSpace *
+      this.currentWidthFactor
+    )
+  }
+
   /**
    * All of THREE.js objects in current line. It contains objects in all of sections of this line.
    */
@@ -979,7 +988,7 @@ export class MTextProcessor {
             shape.width * this.currentWordSpace * this.currentWidthFactor
         }
       } else {
-        wordWidth += this._currentContext.blankWidth
+        wordWidth += this.currentBlankAdvance
       }
     }
     // 2. If word would overflow, start a new line first (no indent for wrapped lines)
@@ -1271,7 +1280,7 @@ export class MTextProcessor {
       const box = new THREE.Box3(
         new THREE.Vector3(charX, charY, 0),
         new THREE.Vector3(
-          charX + this._currentContext.blankWidth,
+          charX + this.currentBlankAdvance,
           charY + this.currentLayoutFontSize,
           0
         )
@@ -1293,7 +1302,7 @@ export class MTextProcessor {
         })
       }
     }
-    this._hOffset += this._currentContext.blankWidth
+    this._hOffset += this.currentBlankAdvance
   }
 
   private recordVisualLineBreak(
@@ -1341,12 +1350,14 @@ export class MTextProcessor {
 
     const geometry = shape.toGeometry()
     geometry.scale(this.currentWidthFactor, 1, 1)
+    const charHeight = this.currentLayoutFontSize
 
     // Apply oblique/skew transformation if needed (oblique or italic)
     let obliqueAngle = this._currentContext.oblique
     if (this._currentContext.italic) {
       obliqueAngle += 15 // Simulate italic with a 15 degree skew
     }
+    let obliqueExtraAdvance = 0
     if (obliqueAngle) {
       const angleRad = (obliqueAngle * Math.PI) / 180
       const skewMatrix = new THREE.Matrix4()
@@ -1369,6 +1380,8 @@ export class MTextProcessor {
         1
       )
       geometry.applyMatrix4(skewMatrix)
+      // Skew shifts the top of the glyph forward; include that in line advance.
+      obliqueExtraAdvance = Math.tan(angleRad) * charHeight
     }
 
     // Simulate bold for mesh fonts by stroking the geometry
@@ -1391,17 +1404,20 @@ export class MTextProcessor {
         ? this.vOffset
         : this.vOffset - this.currentLayoutFontSize
     const charWidth = shape.width * this.currentWidthFactor
-    const charHeight = this.currentLayoutFontSize
 
     geometry.translate(charX, charY, 0)
 
+    const horizontalAdvance =
+      shape.width * this.currentWidthFactor +
+      obliqueExtraAdvance * this.currentWidthFactor
     if (
       this.currentHorizontalAlignment == MTextParagraphAlignment.DISTRIBUTED
     ) {
-      this._hOffset += shape.width * this.currentWidthFactor
+      this._hOffset += horizontalAdvance
     } else {
       this._hOffset +=
-        shape.width * this.currentWordSpace * this.currentWidthFactor
+        shape.width * this.currentWordSpace * this.currentWidthFactor +
+        obliqueExtraAdvance * this.currentWidthFactor
     }
     geometries.push(geometry)
     this._lineHasRenderableChar = true
@@ -1775,16 +1791,17 @@ export class MTextProcessor {
   }
 
   /**
-   * In AutoCAD, the width of a regular space character (ASCII 32, the space key on the keyboard) in MText
-   * depends on the current font and text height, and is not a fixed value.
-   * Specifically:
-   * - Space width ≈ Text height × space width ratio defined by the font
-   * - For common TrueType fonts (like Arial), the space width is typically about 1/4 to 1/3 of the text height.
-   * For example, if the text height is 10 (units), the space width would be approximately 2.5 to 3.3 units.
-   * - For SHX fonts (AutoCAD's built-in vector fonts, such as txt.shx), the space width is often half the text height.
-   * So if the text height is 10, the space width is typically 5 units.
+   * Resolves horizontal advance for an ASCII space in the active font.
+   *
+   * AutoCAD uses each font's own space glyph metrics (SHX pen advance or TrueType
+   * horizontal advance). A fixed fraction of text height (e.g. 50% for SHX) is only
+   * a rough fallback when the font has no space definition.
    */
   private calculateBlankWidthForFont(font: string, fontSize: number) {
+    const spaceShape = this.fontManager.getCharShape(' ', font, fontSize)
+    if (spaceShape && spaceShape.width > 0) {
+      return spaceShape.width
+    }
     const fontType = this.fontManager.getFontType(font)
     return fontType === 'shx' ? fontSize * 0.5 : fontSize * 0.3
   }

--- a/packages/mtext-renderer/test/renderer/mtext.cjk-layout.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.cjk-layout.test.ts
@@ -1,0 +1,244 @@
+import * as THREE from 'three'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { FontData } from '../../src/font/font'
+import { FontFactory } from '../../src/font/fontFactory'
+import { FontManager } from '../../src/font/fontManager'
+import { MText } from '../../src/renderer/mtext'
+import {
+  CharBoxType,
+  createDefaultColorSettings,
+  MTextAttachmentPoint,
+  TextStyle
+} from '../../src/renderer/types'
+
+const PAGE_LABEL = '共1页第1页'
+/** DXF TEXT value for page total (five spaces between 共 and 页). */
+const PAGE_TOTAL_TEXT = ' 共     页 '
+/** DXF TEXT value for page index (five spaces between 第 and 页). */
+const PAGE_INDEX_TEXT = ' 第     页 '
+/** Insertion-point gap between the two TEXT entities in 机械工差.dxf. */
+const DXF_TEXT_INSERTION_GAP = 16.938
+const FONT_BASE = 'https://mlightcad.gitlab.io/cad-data/fonts/'
+
+async function registerShxFont(name: string, file: string, encoding?: string) {
+  const response = await fetch(FONT_BASE + file)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${file}: ${response.status}`)
+  }
+  const fontData: FontData = {
+    name,
+    type: 'shx',
+    data: await response.arrayBuffer(),
+    encoding,
+    alias: [name]
+  }
+  const font = FontFactory.instance.createFont(fontData)
+  font.names.add(name)
+  ;(FontManager.instance as unknown as { loadedFontMap: Map<string, unknown> })
+    .loadedFontMap.set(name, font)
+}
+
+type CharBoxEntry = {
+  type: CharBoxType
+  char: string
+  box: THREE.Box3
+}
+
+function collectCharBoxes(object: THREE.Object3D): CharBoxEntry[] {
+  const out: CharBoxEntry[] = []
+  object.traverse(node => {
+    const boxes = node.userData?.layout?.chars as CharBoxEntry[] | undefined
+    if (boxes) {
+      out.push(...boxes)
+    }
+  })
+  return out
+}
+
+function charBoxesInReadingOrder(boxes: CharBoxEntry[]) {
+  return [...boxes]
+    .filter(entry => entry.type === CharBoxType.CHAR && entry.char.trim() !== '')
+    .sort((a, b) => a.box.min.x - b.box.min.x)
+}
+
+function assertNoHorizontalOverlap(ordered: CharBoxEntry[], epsilon = 1e-4) {
+  for (let i = 0; i < ordered.length - 1; i++) {
+    const left = ordered[i]
+    const right = ordered[i + 1]
+    expect(
+      left.box.max.x,
+      `“${left.char}” overlaps “${right.char}” (${left.box.max.x} > ${right.box.min.x})`
+    ).toBeLessThanOrEqual(right.box.min.x + epsilon)
+  }
+}
+
+describe('MText CJK layout regression', () => {
+  const styleManager = {
+    unsupportedTextStyles: {},
+    getMeshBasicMaterial: vi
+      .fn()
+      .mockReturnValue(new THREE.MeshBasicMaterial()),
+    getLineBasicMaterial: vi
+      .fn()
+      .mockReturnValue(new THREE.LineBasicMaterial())
+  }
+
+  const style: TextStyle = {
+    name: 'standard',
+    standardFlag: 0,
+    fixedTextHeight: 0,
+    widthFactor: 1,
+    obliqueAngle: 0,
+    textGenerationFlag: 0,
+    lastHeight: 10,
+    font: 'txt',
+    bigFont: 'hztxt'
+  }
+
+  beforeAll(async () => {
+    FontManager.instance.release()
+    FontManager.instance.enableFontCache = false
+    await registerShxFont('txt', 'txt.shx')
+    await registerShxFont('hztxt', 'hztxt.shx', 'gbk')
+    await registerShxFont('isocp', 'isocp.shx')
+  })
+
+  afterEach(() => {
+    FontManager.instance.release()
+    FontManager.instance.enableFontCache = true
+  })
+
+  it('does not overlap “页” and “第” when rendering page label text', () => {
+    const fontManager = FontManager.instance
+
+    const mtext = new MText(
+      {
+        text: PAGE_LABEL,
+        height: 10,
+        width: 0,
+        position: { x: 0, y: 0, z: 0 },
+        attachmentPoint: MTextAttachmentPoint.TopLeft,
+        collectCharBoxes: true
+      },
+      style,
+      styleManager as any,
+      fontManager as any,
+      createDefaultColorSettings()
+    )
+
+    mtext.syncDraw()
+
+    const ordered = charBoxesInReadingOrder(collectCharBoxes(mtext))
+    expect(ordered.map(entry => entry.char).join('')).toBe(PAGE_LABEL)
+
+    const pageIndex = ordered.findIndex(entry => entry.char === '页')
+    const diIndex = ordered.findIndex(
+      (entry, index) => entry.char === '第' && index > pageIndex
+    )
+    expect(pageIndex).toBeGreaterThanOrEqual(0)
+    expect(diIndex).toBeGreaterThan(pageIndex)
+
+    const pageBox = ordered[pageIndex].box
+    const diBox = ordered[diIndex].box
+    expect(pageBox.max.x).toBeLessThanOrEqual(diBox.min.x + 1e-4)
+
+    assertNoHorizontalOverlap(ordered)
+  })
+})
+
+describe('SHX space width (PC_TEXTSTYLE / isocp)', () => {
+  const styleManager = {
+    unsupportedTextStyles: {},
+    getMeshBasicMaterial: vi
+      .fn()
+      .mockReturnValue(new THREE.MeshBasicMaterial()),
+    getLineBasicMaterial: vi
+      .fn()
+      .mockReturnValue(new THREE.LineBasicMaterial())
+  }
+
+  const pcTextStyle: TextStyle = {
+    name: 'PC_TEXTSTYLE',
+    standardFlag: 0,
+    fixedTextHeight: 0,
+    widthFactor: 1,
+    obliqueAngle: 0,
+    textGenerationFlag: 0,
+    lastHeight: 5,
+    font: 'isocp',
+    bigFont: 'hztxt'
+  }
+
+  beforeAll(async () => {
+    FontManager.instance.release()
+    FontManager.instance.enableFontCache = false
+    await registerShxFont('isocp', 'isocp.shx')
+    await registerShxFont('hztxt', 'hztxt.shx', 'gbk')
+  })
+
+  afterEach(() => {
+    FontManager.instance.release()
+    FontManager.instance.enableFontCache = true
+  })
+
+  it('uses the isocp space glyph advance instead of half the text height', () => {
+    const fontManager = FontManager.instance
+    const spaceShape = fontManager.getCharShape(' ', 'isocp', 5)
+    expect(spaceShape).toBeDefined()
+    expect(spaceShape!.width).toBeCloseTo(1.538, 2)
+    expect(spaceShape!.width).toBeLessThan(5 * 0.5)
+  })
+
+  it('keeps “ 共     页 ” narrow enough to avoid overlapping “ 第     页 ”', () => {
+    const fontManager = FontManager.instance
+    const widthFactor = 0.6669999957084656
+
+    const totalLabel = new MText(
+      {
+        text: PAGE_TOTAL_TEXT,
+        height: 5,
+        width: 0,
+        widthFactor,
+        position: { x: 0, y: 0, z: 0 },
+        attachmentPoint: MTextAttachmentPoint.TopLeft,
+        collectCharBoxes: true
+      },
+      pcTextStyle,
+      styleManager as any,
+      fontManager as any,
+      createDefaultColorSettings()
+    )
+    totalLabel.syncDraw()
+    const totalWidth = totalLabel.box.max.x - totalLabel.box.min.x
+
+    const indexLabel = new MText(
+      {
+        text: PAGE_INDEX_TEXT,
+        height: 5,
+        width: 0,
+        widthFactor,
+        position: { x: DXF_TEXT_INSERTION_GAP, y: 0, z: 0 },
+        attachmentPoint: MTextAttachmentPoint.TopLeft,
+        collectCharBoxes: true
+      },
+      pcTextStyle,
+      styleManager as any,
+      fontManager as any,
+      createDefaultColorSettings()
+    )
+    indexLabel.syncDraw()
+
+    totalLabel.updateMatrixWorld(true)
+    indexLabel.updateMatrixWorld(true)
+
+    expect(totalLabel.box.max.x).toBeLessThanOrEqual(
+      indexLabel.box.min.x + 1e-3
+    )
+
+    // Five spaces at the old 50%-em heuristic would be 5 * (h * 0.5) * wf ≈ 8.34;
+    // the full string must stay within the DXF insertion gap (~16.94).
+    expect(totalWidth).toBeLessThan(DXF_TEXT_INSERTION_GAP)
+    expect(totalWidth).toBeGreaterThan(5)
+  })
+})

--- a/packages/mtext-renderer/vitest.config.ts
+++ b/packages/mtext-renderer/vitest.config.ts
@@ -1,0 +1,20 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+const require = createRequire(import.meta.url)
+const shxParserRoot = path.dirname(
+  require.resolve('@mlightcad/shx-parser/package.json')
+)
+
+export default defineConfig({
+  test: {
+    testTimeout: 30_000
+  },
+  resolve: {
+    alias: {
+      // Vitest loads this package as ESM; point at the ESM build instead of index.cjs.js.
+      '@mlightcad/shx-parser': path.join(shxParserRoot, 'dist/index.es.js')
+    }
+  }
+})


### PR DESCRIPTION
## Summary

Fixes horizontal layout issues in MText when using SHX fonts—especially CJK (big font) glyphs and space characters—and aligns spacing behavior more closely with AutoCAD.

- **SHX big font (CJK):** Advance width now uses the scaled font cell width (`content.width / content.height × fontSize`) in addition to bbox and pen-down end X, preventing successive Han characters from overlapping (e.g. page labels like `共1页第1页`).
- **SHX space width:** Spaces and missing glyphs use the SHX space glyph pen advance via `getSpaceAdvance()` instead of a fixed `textHeight` step; `calculateBlankWidthForFont` prefers the active font’s space glyph metrics with heuristic fallback only when undefined.
- **MText layout:** Introduces `currentBlankAdvance` (blank width × word spacing × width factor) for consistent space, char-box, and line-break handling; oblique/italic skew adds extra horizontal advance so glyphs do not visually collide on the line.

## Changes

| Area | File(s) |
|------|---------|
| SHX space & shape generation | `shxFont.ts` |
| SHX advance width (Unicode vs BIGFONT) | `shxTextShape.ts` |
| MText blank advance, oblique advance | `mtextProcessor.ts` |
| Regression tests | `test/renderer/mtext.cjk-layout.test.ts` |
| Vitest + `@mlightcad/shx-parser` ESM alias | `vitest.config.ts` |

## Test plan

- [ ] Run package tests: `npx nx test mtext-renderer` (or `vitest` in `packages/mtext-renderer`)
- [ ] Confirm CJK regression: page label `共1页第1页` has no horizontal overlap between `页` and `第`
- [ ] Confirm `isocp` space advance (~1.538 at height 5) is used instead of 50% em heuristic
- [ ] Confirm ` 共     页 ` + ` 第     页 ` at DXF insertion gap (~16.94) do not overlap with `PC_TEXTSTYLE` (width factor ~0.667)
- [ ] Smoke-check MText with oblique/italic styles for correct line advance
- [ ] Verify example app / existing MText demos still render as expected

## Notes

Tests fetch SHX fonts from `https://mlightcad.gitlab.io/cad-data/fonts/` and require network access. Vitest config resolves `@mlightcad/shx-parser` to the ESM build for compatibility.