### PR TITLE
chroe: migrate CI to Node.js 24 actions and declare Node 22 engine requirement

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,16 +20,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version-file: package.json
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org
        
@@ -55,14 +55,14 @@ jobs:
 
       - name: Create GitHub release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
           generate_release_notes: true
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './packages//example/dist/'
 
@@ -72,8 +72,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "packageManager": "pnpm@10.33.4",
   "engines": {
+    "node": ">=22",
     "pnpm": ">=10"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Resolves GitHub Actions deprecation warnings about JavaScript actions running on Node.js 20, and centralizes the CI Node.js version in `package.json`.

- Upgrade all workflow actions to versions that run on Node.js 24:
  - `actions/checkout` v4 → v6
  - `actions/setup-node` v4 → v6
  - `pnpm/action-setup` v4 → v6
  - `softprops/action-gh-release` v2 → v3
  - `actions/upload-pages-artifact` v3 → v5
  - `actions/configure-pages` v5 → v6
  - `actions/deploy-pages` v4 → v5
- Add `"node": ">=22"` to root `package.json` `engines` (Node 20 reached EOL in April 2026)
- Replace hardcoded `node-version: 20` in CI with `node-version-file: package.json` so the runner version is driven by a single source of truth

## Motivation

GitHub Actions is deprecating Node.js 20 for action runtimes, with Node.js 24 becoming the default in mid-2026. The previous workflow pinned several actions that still ran on Node.js 20, triggering CI warnings.

Separately, the project runtime was pinned to Node 20 in the workflow without an `engines.node` field in `package.json`. Declaring `>=22` and reading it via `setup-node` keeps local development and CI aligned.

## Test plan

- [ ] CI workflow passes on this PR (lint, test, build)
- [ ] No Node.js 20 deprecation warnings appear in the workflow run
- [ ] GitHub Pages deploy still succeeds on `main` (if applicable)
- [ ] Tag-based npm publish and GitHub release still work (if applicable)