### PR TITLE
fix: preserve MText insertion precision at large coordinates and correct CJK wrap width

### DIFF
--- a/packages/example/src/shims/stream.ts
+++ b/packages/example/src/shims/stream.ts
@@ -1,0 +1,5 @@
+// iconv-lite optionally enables its streaming API when stream.Transform exists.
+// A no-op stub keeps encode/decode working in the browser without Node polyfills.
+const streamStub = {}
+export default streamStub
+export const Transform = undefined

--- a/packages/example/vite.config.ts
+++ b/packages/example/vite.config.ts
@@ -4,6 +4,12 @@ import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 export default defineConfig({
   base: './',
+  resolve: {
+    alias: {
+      // iconv-lite (used by SHX bigfont encoding) probes stream.Transform at init.
+      stream: resolve(__dirname, 'src/shims/stream.ts')
+    }
+  },
   build: {
     outDir: resolve(__dirname, 'dist'),
     sourcemap: true,

--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-renderer",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "AutoCAD MText renderer based on Three.js",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",

--- a/packages/mtext-renderer/src/renderer/colorUtils.ts
+++ b/packages/mtext-renderer/src/renderer/colorUtils.ts
@@ -1,3 +1,5 @@
+import { MTextColor } from '@mlightcad/mtext-parser'
+
 import { getColorByIndex } from '../common'
 import { ColorSettings } from './types'
 
@@ -21,4 +23,31 @@ export function resolveMTextColor(colorSettings: ColorSettings): number {
     return normalizeColorNumber(color.rgbValue)
   }
   return normalizeColorNumber(colorSettings.byLayerColor)
+}
+
+/**
+ * Rebuild ColorSettings for a worker-deserialized glyph material.
+ *
+ * Worker meshes already carry the final resolved RGB in their serialized
+ * material. When the entity base color is ByLayer, preserve that semantic only
+ * for glyphs that match the layer fallback color.
+ */
+export function buildWorkerMaterialColorSettings(
+  base: ColorSettings,
+  resolvedColor: number,
+  baseByLayer: boolean
+): ColorSettings {
+  const color = new MTextColor()
+  if (baseByLayer && resolvedColor === base.byLayerColor) {
+    color.aci = 256
+  } else {
+    color.rgbValue = resolvedColor
+  }
+
+  return {
+    byLayerColor: base.byLayerColor,
+    byBlockColor: base.byBlockColor,
+    layer: base.layer,
+    color
+  }
 }

--- a/packages/mtext-renderer/src/renderer/index.ts
+++ b/packages/mtext-renderer/src/renderer/index.ts
@@ -1,5 +1,6 @@
 export * from './colorUtils'
 export * from './constants'
 export * from './mtext'
+export * from './mtextDataUtils'
 export * from './styleManager'
 export * from './types'

--- a/packages/mtext-renderer/src/renderer/mtext.ts
+++ b/packages/mtext-renderer/src/renderer/mtext.ts
@@ -9,6 +9,7 @@ import * as THREE from 'three'
 
 import { FontManager } from '../font'
 import { buildCharBoxesFromObject } from './charBoxUtils'
+import { resolveMTextWrapWidth } from './mtextDataUtils'
 import { MTextFormatOptions, MTextProcessor } from './mtextProcessor'
 import { StyleManager } from './styleManager'
 import {
@@ -28,11 +29,6 @@ import {
 const tempPoint = /*@__PURE__*/ new THREE.Vector3()
 const tempPoint2 = /*@__PURE__*/ new THREE.Vector3()
 const tempPoint3 = /*@__PURE__*/ new THREE.Vector3()
-const tempVector = /*@__PURE__*/ new THREE.Vector3()
-const tempScale = /*@__PURE__*/ new THREE.Vector3()
-const tempQuaternion = /*@__PURE__*/ new THREE.Quaternion()
-const translateTempMatrix = /*@__PURE__*/ new THREE.Matrix4()
-const tempMatrix = /*@__PURE__*/ new THREE.Matrix4()
 const AxisX = /*@__PURE__*/ new THREE.Vector3(1, 0, 0)
 
 /**
@@ -323,13 +319,6 @@ export class MText extends THREE.Object3D {
       return undefined
     }
 
-    object.matrix.decompose(tempVector, tempQuaternion, tempScale)
-    if (mtextData.position) {
-      tempVector.x += mtextData.position.x
-      tempVector.y += mtextData.position.y
-      object.matrix.compose(tempVector, tempQuaternion, tempScale)
-    }
-
     // When the caller does not pre-declare the text width (e.g. AcDbText
     // and AcDbAttribute, which let the renderer's own font metrics drive
     // layout), `mtextData.width` is `Infinity`. Using that value verbatim
@@ -337,11 +326,15 @@ export class MText extends THREE.Object3D {
     // attachment. Measure the bbox of the just-built object so the anchor
     // is computed from the *real* rendered glyph extent — independent of
     // font, kerning, or character composition.
-    let width = mtextData.width
+    let width = resolveMTextWrapWidth(mtextData)
     object.updateWorldMatrix(true, true)
     const bbox = new THREE.Box3().setFromObject(object)
     if (!Number.isFinite(width)) {
-      const measured = bbox.max.x - bbox.min.x
+      const logicalAdvanceWidth = object.userData?.logicalAdvanceWidth
+      const measured =
+        typeof logicalAdvanceWidth === 'number' && logicalAdvanceWidth > 0
+          ? logicalAdvanceWidth
+          : bbox.max.x - bbox.min.x
       width = Number.isFinite(measured) && measured > 0 ? measured : 0
     }
     const anchorMetrics = this.measureAnchorMetrics(
@@ -397,6 +390,8 @@ export class MText extends THREE.Object3D {
       obj.layers.enableAll()
     })
 
+    // Keep insertion coordinates out of glyph vertices. Large drawing
+    // positions are applied as object transforms after local anchor offsets.
     let rotateAngle = mtextData.rotation || 0
     if (mtextData.directionVector) {
       const dv = mtextData.directionVector
@@ -406,16 +401,12 @@ export class MText extends THREE.Object3D {
       rotateAngle = v.z > 0 ? -angle : angle
     }
 
-    object.matrix.compose(tempVector, tempQuaternion, tempScale)
-    const translate = mtextData.position
-      ? tempVector.clone().sub(mtextData.position)
-      : tempVector
-    translateTempMatrix.makeTranslation(-translate.x, -translate.y, 0)
-    tempMatrix.makeRotationZ(rotateAngle)
-    object.matrix.multiply(translateTempMatrix)
-    object.matrix.multiply(tempMatrix)
-    object.matrix.multiply(translateTempMatrix.invert())
-    object.matrix.decompose(object.position, object.quaternion, object.scale)
+    const insertion = mtextData.position
+    object.position.set(insertion?.x ?? 0, insertion?.y ?? 0, insertion?.z ?? 0)
+    object.quaternion.setFromAxisAngle(new THREE.Vector3(0, 0, 1), rotateAngle)
+    object.scale.set(1, 1, 1)
+    object.updateMatrix()
+    object.updateMatrixWorld(true)
     return object
   }
 
@@ -434,7 +425,7 @@ export class MText extends THREE.Object3D {
       this.styleManager.unsupportedTextStyles[fontFileAndStyleName]++
     }
 
-    const maxWidth = mtextData.width || 0
+    const maxWidth = resolveMTextWrapWidth(mtextData) || 0
     // Internal paragraph alignment: only meaningful for multi-line MText
     // with a declared FINITE `width`. For unconstrained text (Infinity,
     // used by AcDbText/AcDbAttribute), forcing LEFT avoids generating

--- a/packages/mtext-renderer/src/renderer/mtextDataUtils.ts
+++ b/packages/mtext-renderer/src/renderer/mtextDataUtils.ts
@@ -1,0 +1,57 @@
+import { MTextData } from './types'
+
+/**
+ * Minimum width-to-height ratio for a declared MTEXT wrap box to be treated as
+ * a real column width rather than a mistaken width factor or other bad DXF value.
+ */
+export const MIN_REASONABLE_MTEXT_WIDTH_HEIGHT_RATIO = 1.5
+
+/**
+ * Conservative CJK full-width glyph advance as a fraction of cap height, used
+ * only when estimating a replacement wrap width from explicit line content.
+ */
+export const CJK_MTEXT_CHAR_WIDTH_HEIGHT_RATIO = 0.8
+
+/**
+ * Estimates a usable MTEXT wrap width from the longest explicit line in the raw
+ * MTEXT string while preserving explicit line breaks such as `\P`.
+ */
+export function estimateMTextWrapWidth(text: string, height: number): number {
+  const maxLineLength = Math.max(
+    1,
+    ...String(text ?? '')
+      .replace(/\\P/g, '\n')
+      .replace(/[{}]/g, '')
+      .split(/\r?\n/)
+      .map(line => line.length)
+  )
+  return maxLineLength * height * CJK_MTEXT_CHAR_WIDTH_HEIGHT_RATIO
+}
+
+/**
+ * Resolves the MTEXT wrap width used for layout and anchoring.
+ *
+ * Some CAD files contain MTEXT group-code 41 values that are smaller than a
+ * single glyph height, usually because the value came from a text width factor
+ * instead of an actual wrapping box width. Treating that tiny positive value as
+ * the word-wrap width forces CJK text to wrap one character per line. When the
+ * width is clearly impossible as a layout width, estimate a usable width from
+ * the longest explicit MTEXT line and preserve explicit line breaks such as `\P`.
+ */
+export function resolveMTextWrapWidth(
+  mtextData: Pick<MTextData, 'text' | 'height' | 'width'>
+): number {
+  const width = mtextData.width
+  const height = mtextData.height
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width <= 0 ||
+    height <= 0 ||
+    width >= height * MIN_REASONABLE_MTEXT_WIDTH_HEIGHT_RATIO
+  ) {
+    return width
+  }
+
+  return estimateMTextWrapWidth(mtextData.text, height)
+}

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -181,6 +181,7 @@ export class MTextProcessor {
   private _options: MTextFormatOptions
   private _totalHeight: number
   private _hOffset: number
+  private _maxLineAdvance: number
   private _vOffset: number
   private _lineCount: number
   private _currentLineObjects: THREE.Object3D[]
@@ -229,6 +230,7 @@ export class MTextProcessor {
     this._options = options
     this._totalHeight = 0
     this._hOffset = 0
+    this._maxLineAdvance = 0
     this._vOffset = 0
     this._lineCount = 1
     this._currentLineObjects = []
@@ -300,6 +302,16 @@ export class MTextProcessor {
    */
   get maxWidth() {
     return this._options.maxWidth
+  }
+
+  /**
+   * Maximum logical pen advance across processed visual lines.
+   *
+   * Unlike visible geometry bounds, this keeps the text insertion origin tied to
+   * the layout pen position even when glyphs have side bearings or overhangs.
+   */
+  get maxLineAdvance() {
+    return this._maxLineAdvance
   }
 
   /**
@@ -911,6 +923,7 @@ export class MTextProcessor {
     }
 
     this.processLastLine()
+    this.captureCurrentLineAdvance()
     this.recordCurrentLineLayout()
     group.userData.lineLayouts = this._lineLayouts.map((line, index) => ({
       ...line,
@@ -919,6 +932,7 @@ export class MTextProcessor {
           ? this._lineBreakIndices[index]
           : undefined
     }))
+    group.userData.logicalAdvanceWidth = this._maxLineAdvance
     return group
   }
 
@@ -1592,6 +1606,7 @@ export class MTextProcessor {
     if (collectBreakIndex) {
       this.recordVisualLineBreak()
     }
+    this.captureCurrentLineAdvance()
     this.recordCurrentLineLayout()
     this._hOffset = 0
     if (!this._lineHasRenderableChar) {
@@ -1615,6 +1630,12 @@ export class MTextProcessor {
     // Reset maxFontSize for the new line
     this._maxFontSize = 0
     this._lineHasRenderableChar = false
+  }
+
+  private captureCurrentLineAdvance() {
+    if (Number.isFinite(this._hOffset)) {
+      this._maxLineAdvance = Math.max(this._maxLineAdvance, this._hOffset)
+    }
   }
 
   private countFinalCharBoxes(
@@ -1722,7 +1743,9 @@ export class MTextProcessor {
     switch (this.currentHorizontalAlignment) {
       case MTextParagraphAlignment.LEFT:
       case MTextParagraphAlignment.JUSTIFIED: {
-        const dx = this._currentLeftMargin - resolvedBBox.min.x
+        const dx = Number.isFinite(this.maxLineWidth)
+          ? this._currentLeftMargin - resolvedBBox.min.x
+          : this._currentLeftMargin
 
         const translated = new Set<THREE.Object3D>()
         geometryEntries.forEach(entry => {

--- a/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
+++ b/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
@@ -1,8 +1,8 @@
-import { MTextColor } from '@mlightcad/mtext-parser'
 import * as THREE from 'three'
 
 import { FontManager } from '../font'
 import { buildCharBoxesFromObject } from '../renderer/charBoxUtils'
+import { buildWorkerMaterialColorSettings } from '../renderer/colorUtils'
 import { DefaultStyleManager } from '../renderer/defaultStyleManager'
 import { StyleManager } from '../renderer/styleManager'
 import {
@@ -526,7 +526,7 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
       // Create material using StyleManager for proper material reuse
       let material: THREE.Material
       if (childData.type === 'mesh') {
-        const materialColorSettings = this.buildMaterialColorSettings(
+        const materialColorSettings = buildWorkerMaterialColorSettings(
           colorSettings,
           childData.material.color,
           baseByLayer
@@ -545,7 +545,7 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
           material.side = childData.material.side as THREE.Side
         }
       } else {
-        const materialColorSettings = this.buildMaterialColorSettings(
+        const materialColorSettings = buildWorkerMaterialColorSettings(
           colorSettings,
           childData.material.color,
           baseByLayer
@@ -648,28 +648,6 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
     }
 
     return mtextObject
-  }
-
-  private buildMaterialColorSettings(
-    base: ColorSettings,
-    resolvedColor: number,
-    baseByLayer: boolean
-  ): ColorSettings {
-    const color = new MTextColor()
-    if (baseByLayer && resolvedColor === base.byLayerColor) {
-      color.aci = 256
-    } else if (base.color.isAci && base.color.aci !== null) {
-      color.aci = base.color.aci
-    } else {
-      color.rgbValue = resolvedColor
-    }
-
-    return {
-      byLayerColor: base.byLayerColor,
-      byBlockColor: base.byBlockColor,
-      layer: base.layer,
-      color
-    }
   }
 
   private deserializeCharBoxes(serialized: SerializedCharBox[]): CharBox[] {

--- a/packages/mtext-renderer/test/renderer/colorUtils.worker.test.ts
+++ b/packages/mtext-renderer/test/renderer/colorUtils.worker.test.ts
@@ -1,0 +1,49 @@
+import { MTextColor } from '@mlightcad/mtext-parser'
+import { describe, expect, it } from 'vitest'
+
+import { getColorByIndex } from '../../src/common'
+import {
+  buildWorkerMaterialColorSettings,
+  resolveMTextColor
+} from '../../src/renderer/colorUtils'
+import { ColorSettings } from '../../src/renderer/types'
+
+function createBaseColorSettings(
+  overrides: Partial<ColorSettings> = {}
+): ColorSettings {
+  return {
+    byLayerColor: 0xffffff,
+    byBlockColor: 0x00ff00,
+    layer: '0',
+    color: new MTextColor(256),
+    ...overrides
+  }
+}
+
+describe('buildWorkerMaterialColorSettings', () => {
+  it('preserves ByLayer when the resolved glyph color matches the layer fallback', () => {
+    const base = createBaseColorSettings()
+    const rebuilt = buildWorkerMaterialColorSettings(base, 0xffffff, true)
+
+    expect(rebuilt.color.aci).toBe(256)
+    expect(resolveMTextColor(rebuilt)).toBe(0xffffff)
+  })
+
+  it('keeps ACI glyph colors when the entity base color is ByLayer', () => {
+    const base = createBaseColorSettings()
+    const red = getColorByIndex(1)
+    const rebuilt = buildWorkerMaterialColorSettings(base, red, true)
+
+    expect(rebuilt.color.aci).toBeNull()
+    expect(rebuilt.color.rgbValue).toBe(red)
+    expect(resolveMTextColor(rebuilt)).toBe(red)
+  })
+
+  it('keeps explicit RGB glyph colors from the worker payload', () => {
+    const base = createBaseColorSettings()
+    const rebuilt = buildWorkerMaterialColorSettings(base, 0x336699, true)
+
+    expect(rebuilt.color.rgbValue).toBe(0x336699)
+    expect(resolveMTextColor(rebuilt)).toBe(0x336699)
+  })
+})

--- a/packages/mtext-renderer/test/renderer/mtext.anchor.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.anchor.test.ts
@@ -5,6 +5,7 @@ import { MText } from '../../src/renderer/mtext'
 import {
   createDefaultColorSettings,
   MTextAttachmentPoint,
+  MTextFlowDirection,
   TextStyle
 } from '../../src/renderer/types'
 
@@ -15,6 +16,16 @@ function createShapeGeometry(width: number, height: number) {
   shape.lineTo(width, height)
   shape.lineTo(0, height)
   shape.lineTo(0, 0)
+  return new THREE.ShapeGeometry(shape)
+}
+
+function createOffsetShapeGeometry(width: number, height: number, offsetX = 0) {
+  const shape = new THREE.Shape()
+  shape.moveTo(offsetX, 0)
+  shape.lineTo(offsetX + width, 0)
+  shape.lineTo(offsetX + width, height)
+  shape.lineTo(offsetX, height)
+  shape.lineTo(offsetX, 0)
   return new THREE.ShapeGeometry(shape)
 }
 
@@ -38,6 +49,90 @@ function createGeometryBox(object: THREE.Object3D) {
   })
 
   return box
+}
+
+function getGeometryPositionMaxAbs(object: THREE.Object3D) {
+  let maxAbs = 0
+
+  object.traverse(child => {
+    if (!('geometry' in child)) return
+
+    const position = (child.geometry as THREE.BufferGeometry).getAttribute(
+      'position'
+    )
+    if (!position) return
+
+    for (let i = 0; i < position.count; i++) {
+      maxAbs = Math.max(
+        maxAbs,
+        Math.abs(position.getX(i)),
+        Math.abs(position.getY(i)),
+        Math.abs(position.getZ(i))
+      )
+    }
+  })
+
+  return maxAbs
+}
+
+function createTextFixture(
+  overrides: Partial<{
+    text: string
+    height: number
+    width: number
+    widthFactor: number
+    position: { x: number; y: number; z: number }
+    rotation: number
+    drawingDirection: MTextFlowDirection
+    attachmentPoint: MTextAttachmentPoint
+  }> = {}
+) {
+  const textHeight = overrides.height ?? 24
+  const style: TextStyle = {
+    name: 'default',
+    standardFlag: 0,
+    fixedTextHeight: 0,
+    widthFactor: 1,
+    obliqueAngle: 0,
+    textGenerationFlag: 0,
+    lastHeight: textHeight,
+    font: 'fake',
+    bigFont: ''
+  }
+  const styleManager = {
+    unsupportedTextStyles: {},
+    getMeshBasicMaterial: vi
+      .fn()
+      .mockReturnValue(new THREE.MeshBasicMaterial()),
+    getLineBasicMaterial: vi.fn().mockReturnValue(new THREE.LineBasicMaterial())
+  }
+  const fontManager = {
+    getFontScaleFactor: () => 1,
+    getFontType: () => 'mesh',
+    findAndReplaceFont: (name: string) => name,
+    getCharShape: (_char: string, _fontName: string, size: number) => ({
+      width: 10,
+      toGeometry: () => createShapeGeometry(10, size)
+    }),
+    getNotFoundTextShape: () => undefined
+  }
+
+  return new MText(
+    {
+      text: overrides.text ?? 'A',
+      height: textHeight,
+      width: overrides.width ?? 100,
+      widthFactor: overrides.widthFactor,
+      position: overrides.position ?? { x: 0, y: 0, z: 0 },
+      rotation: overrides.rotation,
+      drawingDirection: overrides.drawingDirection,
+      attachmentPoint: overrides.attachmentPoint
+    },
+    style,
+    styleManager as any,
+    fontManager as any,
+    createDefaultColorSettings()
+  )
 }
 
 describe('MText attachment anchoring', () => {
@@ -227,5 +322,112 @@ describe('MText attachment anchoring', () => {
     expect(layout.chars[0].box.max.x).toBeCloseTo(geometryBox.max.x, 6)
     expect(layout.chars[0].box.min.y).toBeCloseTo(geometryBox.min.y, 6)
     expect(layout.chars[0].box.max.y).toBeCloseTo(geometryBox.max.y, 6)
+  })
+
+  it('keeps baseline-left insertion at the logical pen origin for side-bearing glyphs', () => {
+    const textHeight = 12
+    const sideBearing = 3
+    const position = { x: 38425192.41436505, y: 4069213.352858167, z: 0 }
+    const style: TextStyle = {
+      name: 'default',
+      standardFlag: 0,
+      fixedTextHeight: 0,
+      widthFactor: 1,
+      obliqueAngle: 0,
+      textGenerationFlag: 0,
+      lastHeight: textHeight,
+      font: 'fake',
+      bigFont: ''
+    }
+    const styleManager = {
+      unsupportedTextStyles: {},
+      getMeshBasicMaterial: vi
+        .fn()
+        .mockReturnValue(new THREE.MeshBasicMaterial()),
+      getLineBasicMaterial: vi
+        .fn()
+        .mockReturnValue(new THREE.LineBasicMaterial())
+    }
+    const fontManager = {
+      getFontScaleFactor: () => 1,
+      getFontType: () => 'mesh',
+      findAndReplaceFont: (name: string) => name,
+      getCharShape: (_char: string, _fontName: string, size: number) => ({
+        width: 10,
+        toGeometry: () => createOffsetShapeGeometry(10, size, sideBearing)
+      }),
+      getNotFoundTextShape: () => undefined
+    }
+
+    const mtext = new MText(
+      {
+        text: 'A',
+        height: textHeight,
+        width: Number.POSITIVE_INFINITY,
+        position,
+        drawingDirection: MTextFlowDirection.BOTTOM_TO_TOP,
+        attachmentPoint: MTextAttachmentPoint.BaselineLeft
+      },
+      style,
+      styleManager as any,
+      fontManager as any,
+      createDefaultColorSettings()
+    )
+
+    mtext.syncDraw()
+
+    const renderRoot = mtext.children[0]
+    const geometryBox = createGeometryBox(renderRoot)
+    expect(renderRoot.position.x).toBeCloseTo(position.x, 6)
+    expect(renderRoot.position.y).toBeCloseTo(position.y, 6)
+    expect(geometryBox.min.x).toBeCloseTo(position.x + sideBearing, 6)
+  })
+
+  it('applies insertion on the render root so glyph world positions include it', () => {
+    const position = { x: 38425192.41436505, y: 4069213.352858167, z: 0 }
+    const mtext = createTextFixture({
+      text: 'ABC',
+      height: 12,
+      width: Number.POSITIVE_INFINITY,
+      position,
+      attachmentPoint: MTextAttachmentPoint.BaselineLeft
+    })
+
+    mtext.syncDraw()
+
+    const renderRoot = mtext.children[0]
+    expect(renderRoot).toBeDefined()
+
+    const worldPoint = new THREE.Vector3()
+    renderRoot.updateWorldMatrix(true, true)
+    renderRoot.getWorldPosition(worldPoint)
+    expect(worldPoint.x).toBeCloseTo(position.x, 3)
+    expect(worldPoint.y).toBeCloseTo(position.y, 3)
+
+    const geometryBox = createGeometryBox(renderRoot)
+    expect(geometryBox.min.x).toBeGreaterThan(position.x - 100)
+    expect(geometryBox.max.x).toBeLessThan(position.x + 100)
+  })
+
+  it('keeps glyph geometry local when anchoring text at large drawing coordinates', () => {
+    const position = { x: 38425192.41436505, y: 4069213.352858167, z: 0 }
+    const mtext = createTextFixture({
+      text: '1501采区2号水仓',
+      height: 13.60447212599999,
+      width: Number.POSITIVE_INFINITY,
+      widthFactor: 0.9,
+      position,
+      rotation: 2.519494460842435,
+      drawingDirection: MTextFlowDirection.BOTTOM_TO_TOP,
+      attachmentPoint: MTextAttachmentPoint.BaselineLeft
+    })
+
+    mtext.syncDraw()
+
+    expect(getGeometryPositionMaxAbs(mtext)).toBeLessThan(100)
+    expect(mtext.box.min.x).toBeGreaterThan(position.x - 100)
+    expect(mtext.box.max.x).toBeLessThan(position.x + 100)
+    expect(mtext.box.min.y).toBeGreaterThan(position.y - 100)
+    expect(mtext.box.max.y).toBeLessThan(position.y + 100)
   })
 })

--- a/packages/mtext-renderer/test/renderer/mtext.cjk-layout.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.cjk-layout.test.ts
@@ -35,8 +35,9 @@ async function registerShxFont(name: string, file: string, encoding?: string) {
   }
   const font = FontFactory.instance.createFont(fontData)
   font.names.add(name)
-  ;(FontManager.instance as unknown as { loadedFontMap: Map<string, unknown> })
-    .loadedFontMap.set(name, font)
+  ;(
+    FontManager.instance as unknown as { loadedFontMap: Map<string, unknown> }
+  ).loadedFontMap.set(name, font)
 }
 
 type CharBoxEntry = {
@@ -58,7 +59,9 @@ function collectCharBoxes(object: THREE.Object3D): CharBoxEntry[] {
 
 function charBoxesInReadingOrder(boxes: CharBoxEntry[]) {
   return [...boxes]
-    .filter(entry => entry.type === CharBoxType.CHAR && entry.char.trim() !== '')
+    .filter(
+      entry => entry.type === CharBoxType.CHAR && entry.char.trim() !== ''
+    )
     .sort((a, b) => a.box.min.x - b.box.min.x)
 }
 
@@ -79,9 +82,7 @@ describe('MText CJK layout regression', () => {
     getMeshBasicMaterial: vi
       .fn()
       .mockReturnValue(new THREE.MeshBasicMaterial()),
-    getLineBasicMaterial: vi
-      .fn()
-      .mockReturnValue(new THREE.LineBasicMaterial())
+    getLineBasicMaterial: vi.fn().mockReturnValue(new THREE.LineBasicMaterial())
   }
 
   const style: TextStyle = {
@@ -153,9 +154,7 @@ describe('SHX space width (PC_TEXTSTYLE / isocp)', () => {
     getMeshBasicMaterial: vi
       .fn()
       .mockReturnValue(new THREE.MeshBasicMaterial()),
-    getLineBasicMaterial: vi
-      .fn()
-      .mockReturnValue(new THREE.LineBasicMaterial())
+    getLineBasicMaterial: vi.fn().mockReturnValue(new THREE.LineBasicMaterial())
   }
 
   const pcTextStyle: TextStyle = {

--- a/packages/mtext-renderer/test/renderer/mtext.wrapWidth.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.wrapWidth.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  estimateMTextWrapWidth,
+  resolveMTextWrapWidth
+} from '../../src/renderer/mtextDataUtils'
+
+describe('resolveMTextWrapWidth', () => {
+  it('expands an impossible positive mtext wrap width before rendering', () => {
+    const mtextData = {
+      text: '设计依据\\P建筑机电工程抗震设计规范',
+      height: 100,
+      width: 0.5
+    }
+
+    expect(resolveMTextWrapWidth(mtextData)).toBe(960)
+    expect(mtextData.width).toBe(0.5)
+  })
+
+  it('keeps a plausible mtext wrap width unchanged', () => {
+    const mtextData = {
+      text: '设计依据',
+      height: 100,
+      width: 300
+    }
+
+    expect(resolveMTextWrapWidth(mtextData)).toBe(300)
+  })
+
+  it('keeps zero width as no-wrap', () => {
+    const mtextData = {
+      text: '设计依据',
+      height: 100,
+      width: 0
+    }
+
+    expect(resolveMTextWrapWidth(mtextData)).toBe(0)
+  })
+
+  it('keeps unconstrained width unchanged', () => {
+    const mtextData = {
+      text: '设计依据',
+      height: 100,
+      width: Number.POSITIVE_INFINITY
+    }
+
+    expect(resolveMTextWrapWidth(mtextData)).toBe(Number.POSITIVE_INFINITY)
+  })
+})
+
+describe('estimateMTextWrapWidth', () => {
+  it('uses the longest explicit line after paragraph breaks', () => {
+    expect(
+      estimateMTextWrapWidth('设计依据\\P建筑机电工程抗震设计规范', 100)
+    ).toBe(960)
+    expect(estimateMTextWrapWidth('short\\Plonger', 10)).toBe(48)
+  })
+})


### PR DESCRIPTION
## Summary

This PR improves MText rendering accuracy for real-world CAD drawings, especially those with large insertion coordinates and CJK content.

- **Large-coordinate insertion precision** — Insertion coordinates are no longer baked into glyph vertex positions. Large drawing positions (e.g. UTM/EPSG coordinates) are applied as object transforms after local anchor offsets, keeping geometry in a local coordinate space and avoiding floating-point precision loss.
- **Logical pen-origin anchoring** — `MTextProcessor` now tracks `maxLineAdvance` and exposes `logicalAdvanceWidth` on the render root. Anchor and width calculations prefer this logical advance over visible geometry bounds, so baseline-left insertion stays at the pen origin even when glyphs have side bearings or overhangs.
- **CJK wrap-width correction** — Some DXF files supply MTEXT group-code 41 values that are smaller than a single glyph height (often a width factor mistaken for a wrap box). Treating those as layout width forced CJK text to wrap one character per line. `resolveMTextWrapWidth()` detects implausible widths and estimates a usable wrap width from the longest explicit line while preserving `\P` paragraph breaks.
- **Unconstrained text alignment** — For text without a finite wrap width, left/justified paragraph alignment no longer shifts geometry to align visible bounds, preserving the layout pen position.
- **Worker color settings refactor** — Extracted `buildWorkerMaterialColorSettings()` into `colorUtils.ts` for reuse and testability; worker deserialization now rebuilds ByLayer semantics from resolved glyph colors.
- **Example app browser fix** — Added a minimal `stream` shim so `iconv-lite` (used by SHX bigfont encoding) works in the Vite browser build without Node polyfills.

Bumps `@mlightcad/mtext-renderer` to **0.10.16**.

## Test plan

- [x] Unit tests for `resolveMTextWrapWidth` / `estimateMTextWrapWidth` (impossible width, plausible width, zero, unconstrained)
- [x] Unit tests for `buildWorkerMaterialColorSettings` (ByLayer, ACI, explicit RGB)
- [x] Anchor tests for baseline-left insertion with side-bearing glyphs at large coordinates (~38M, ~4M)
- [x] Regression test ensuring glyph geometry stays local (< 100 units) while world bounds reflect insertion at large coordinates
- [x] Existing CJK layout and anchor tests pass
- [ ] Manual verification with a drawing containing large-coordinate MTEXT/CJK labels
- [ ] Manual verification that worker-based rendering matches main-thread placement and colors