### PR TITLE
feat: separate mesh/SHX default fonts and preserve worker precision

### DIFF
--- a/packages/example/index.html
+++ b/packages/example/index.html
@@ -119,11 +119,25 @@
         <h2>MText Renderer Example</h2>
         <div class="row">
             <div class="field">
-                <label for="font-select">Default Font:</label>
-                <select id="font-select">
+                <label for="default-mesh-font-select">Default Mesh Font:</label>
+                <select id="default-mesh-font-select">
                     <option value="simkai">simkai</option>
                 </select>
             </div>
+            <div class="field">
+                <label for="default-shx-font-select">Default English SHX Font:</label>
+                <select id="default-shx-font-select">
+                    <option value="txt">txt</option>
+                </select>
+            </div>
+            <div class="field">
+                <label for="default-shx-big-font-select">Default SHX Big Font:</label>
+                <select id="default-shx-big-font-select">
+                    <option value="hztxt">hztxt</option>
+                </select>
+            </div>
+        </div>
+        <div class="row">
             <div class="field">
                 <label for="render-mode">Render Mode:</label>
                 <select id="render-mode">

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -28,7 +28,9 @@ class MTextRendererExample {
   private mtextInput: HTMLTextAreaElement
   private renderBtn: HTMLButtonElement
   private statusDiv: HTMLDivElement
-  private fontSelect: HTMLSelectElement
+  private defaultMeshFontSelect: HTMLSelectElement
+  private defaultShxFontSelect: HTMLSelectElement
+  private defaultShxBigFontSelect: HTMLSelectElement
   private showBoundingBoxCheckbox: HTMLInputElement
   private showCharBoxesCheckbox: HTMLInputElement
   private showLineBoxesCheckbox: HTMLInputElement
@@ -47,7 +49,7 @@ class MTextRendererExample {
       '{Circle diameter dimensioning symbol: %%c},\\P{Degree symbol: %%d}\\P{Plus/minus tolerance symbol: %%p}\\P{A single percent sign: %%%}\\P{Unicode character: %%130 %%131}\\P{Toggles strikethrough on and off: %%kon, %%koff}\\P{Toggles overscoring on and off.: %%oon, %%ooff}\\P{Toggles underscoring  on and off.: %%uon, %%uoff}',
     color:
       '{\\C0;By Block}\\P{\\C1;Red Text}\\P{\\C2;Yellow Text}\\P{\\C3;Green Text}\\P{\\C4;Cyan Text}\\P{\\C5;Blue Text}\\P{\\C6;Magenta Text}\\P{\\C7;White Text}\\P{\\C256;By Layer}\\P{\\c16761035;Pink (0x0FFC0CB)}\\PRestore ByLayer\\P\\C1;Old Context Color: Red, {\\C2; New Context Color: Yellow, } Restored Context Color: Red',
-    font: '{\\C1;\\W2;\\FSimSun;SimSun Text 宋体文字（面积、材料、8、①④⑧⑩⑫㉔㉚）}\\P{\\C2;\\W0.5;\\FArial;Arial Text}\\P{\\C3;30;\\Faehalf.shx;SHX Text}\\P{\\C4;\\Fgbcbig.shx;东亚字符集字体}\\P{\\C5;\\Q1;\\FSimHei;SimHei Text，黑体文字}\\P{\\C6;\\Q0.5;\\FSimKai;SimKai Text}',
+    font: '{\\C1;\\W2;\\FSimSun;SimSun Text 宋体文字（面积、材料、8、①④⑧⑩⑫㉔㉚）}\\P{\\C2;\\W0.5;\\FArial;Arial Text}\\P{\\C3;30;\\Faehalf.shx;SHX Text}\\P{\\C4;\\Fgbcbig.shx;东亚字符集字体}\\P{\\C5;\\Q1;\\FSimHei;SimHei Text，黑体文字}\\P{\\C6;\\Q0.5;\\FSimKai;SimKai Text}\\P{\\C7;\\F__missing_mesh__.ttf;Missing mesh → default mesh font}\\P{\\C8;\\F__missing__.shx;Missing inline SHX → default English SHX}\\P{\\C9;Style primary fallback: ABC}\\P{\\C10;Style SHX big-font fallback: 中文}',
     stacking:
       '{\\C1;Basic Fractions:}\\P{\\C2;The value is \\S1/2; and \\S3/4; of the total.}\\P{\\C3;\\H0.16;Stacked Fractions:}\\P{\\C4;\\S1 2/3 4; represents \\Sx^ y; in the equation \\S1#2;.}\\P{\\C5;Complex Fractions:}\\P{\\C6;The result \\S1/2/3; is between \\S1^ 2^ 3; and \\S1#2#3;.}\\P{\\C7;Subscript Examples:}\\P{\\C8;H\\S^ 2;O (Water)}\\P{\\C9;CO\\S^ 2; (Carbon Dioxide)}\\P{\\C10;x\\S^ 2; + y\\S^ 2;}\\P{\\C11;Superscript Examples:}\\P{\\C12;E = mc\\S2^ ; (Energy)}\\P{\\C13;x\\S2^ ; + y\\S2^ ; = r\\S2^ ; (Circle)}\\P{\\C14;Combined Examples:}\\P{\\C15;H\\S^ 2;O\\S2^ ; (Hydrogen Peroxide)}\\P{\\C16;Fe\\S^ 2;+\\S3^ ; (Iron Ion)}',
     alignment:
@@ -99,8 +101,14 @@ class MTextRendererExample {
     ) as HTMLTextAreaElement
     this.renderBtn = document.getElementById('render-btn') as HTMLButtonElement
     this.statusDiv = document.getElementById('status') as HTMLDivElement
-    this.fontSelect = document.getElementById(
-      'font-select'
+    this.defaultMeshFontSelect = document.getElementById(
+      'default-mesh-font-select'
+    ) as HTMLSelectElement
+    this.defaultShxFontSelect = document.getElementById(
+      'default-shx-font-select'
+    ) as HTMLSelectElement
+    this.defaultShxBigFontSelect = document.getElementById(
+      'default-shx-big-font-select'
     ) as HTMLSelectElement
     this.showBoundingBoxCheckbox = document.getElementById(
       'show-bounding-box'
@@ -174,13 +182,14 @@ class MTextRendererExample {
       await this.renderMText(content)
     })
 
-    // Font selection
-    this.fontSelect.addEventListener('change', async () => {
-      const content = this.mtextInput.value
-
-      // Re-render MText with new font
-      await this.renderMText(content)
-    })
+    // Default font selection
+    const reloadDefaultFonts = async () => {
+      await this.initializeFonts(false)
+      await this.renderMText(this.mtextInput.value)
+    }
+    this.defaultMeshFontSelect.addEventListener('change', reloadDefaultFonts)
+    this.defaultShxFontSelect.addEventListener('change', reloadDefaultFonts)
+    this.defaultShxBigFontSelect.addEventListener('change', reloadDefaultFonts)
 
     // Example buttons
     document.querySelectorAll('.example-btn').forEach(button => {
@@ -242,33 +251,78 @@ class MTextRendererExample {
     })
   }
 
+  private createTextStyle(options?: {
+    demoMissingStyleFonts?: boolean
+    fixedTextHeight?: number
+  }): TextStyle {
+    const demoMissingStyleFonts = options?.demoMissingStyleFonts ?? false
+    const fixedTextHeight = options?.fixedTextHeight ?? 24
+    return {
+      name: 'Standard',
+      standardFlag: 0,
+      fixedTextHeight,
+      widthFactor: 1,
+      obliqueAngle: 0,
+      textGenerationFlag: 0,
+      lastHeight: fixedTextHeight,
+      font: demoMissingStyleFonts
+        ? '__missing_primary__.shx'
+        : this.defaultShxFontSelect.value,
+      bigFont: demoMissingStyleFonts
+        ? '__missing_big__.shx'
+        : this.defaultShxBigFontSelect.value
+    }
+  }
+
+  private populateFontSelect(
+    select: HTMLSelectElement,
+    fonts: Array<{ name: string[]; type?: string }>,
+    fontType: 'mesh' | 'shx',
+    defaultName: string
+  ): void {
+    select.innerHTML = ''
+    fonts
+      .filter(font => font.type === fontType)
+      .forEach(font => {
+        const option = document.createElement('option')
+        option.value = font.name[0]
+        option.textContent = font.name[0]
+        if (font.name[0] === defaultName) {
+          option.selected = true
+        }
+        select.appendChild(option)
+      })
+  }
+
   private async initializeFonts(isResetAvaiableFonts = true): Promise<void> {
     try {
       if (isResetAvaiableFonts) {
-        // Load available fonts for the dropdown
         const result = await this.unifiedRenderer.getAvailableFonts()
         const fonts = result.fonts
 
-        // Clear existing options
-        this.fontSelect.innerHTML = ''
-
-        // Add all available fonts to dropdown
-        fonts.forEach(font => {
-          const option = document.createElement('option')
-          option.value = font.name[0]
-          option.textContent = font.name[0] // Use the first name from the array
-          // Set selected if this is the default font
-          if (font.name[0] === 'simkai') {
-            option.selected = true
-          }
-          this.fontSelect.appendChild(option)
-        })
+        this.populateFontSelect(
+          this.defaultMeshFontSelect,
+          fonts,
+          'mesh',
+          'simkai'
+        )
+        this.populateFontSelect(this.defaultShxFontSelect, fonts, 'shx', 'txt')
+        this.populateFontSelect(
+          this.defaultShxBigFontSelect,
+          fonts,
+          'shx',
+          'hztxt'
+        )
       }
 
-      // Load default fonts
-      const selectedFont = this.fontSelect.value
-      await this.unifiedRenderer.loadFonts([selectedFont])
-      this.statusDiv.textContent = 'Fonts loaded successfully'
+      const meshFont = this.defaultMeshFontSelect.value
+      const shxFont = this.defaultShxFontSelect.value
+      const shxBigFont = this.defaultShxBigFontSelect.value
+      await this.unifiedRenderer.setDefaultFonts(meshFont, shxFont, shxBigFont)
+      await this.unifiedRenderer.loadFonts(
+        [...new Set([meshFont, shxFont, shxBigFont])]
+      )
+      this.statusDiv.textContent = `Default fonts loaded (mesh: ${meshFont}, english: ${shxFont}, shx big: ${shxBigFont})`
       this.statusDiv.style.color = '#0f0'
     } catch (error) {
       console.error('Error loading fonts:', error)
@@ -536,17 +590,7 @@ class MTextRendererExample {
           position: new THREE.Vector3(cx, cy, 0),
           attachmentPoint
         },
-        textStyle: {
-          name: 'Standard',
-          standardFlag: 0,
-          fixedTextHeight: 10,
-          widthFactor: 1,
-          obliqueAngle: 0,
-          textGenerationFlag: 0,
-          lastHeight: 10,
-          font: this.fontSelect.value,
-          bigFont: ''
-        }
+        textStyle: this.createTextStyle({ fixedTextHeight: 10 })
       }
     })
   }
@@ -581,17 +625,7 @@ class MTextRendererExample {
           width: 240,
           position: new THREE.Vector3(x, y, 0)
         },
-        textStyle: {
-          name: 'Standard',
-          standardFlag: 0,
-          fixedTextHeight: 24,
-          widthFactor: 1,
-          obliqueAngle: 0,
-          textGenerationFlag: 0,
-          lastHeight: 24,
-          font: this.fontSelect.value,
-          bigFont: ''
-        }
+        textStyle: this.createTextStyle()
       }
     })
   }
@@ -893,17 +927,9 @@ class MTextRendererExample {
           position: new THREE.Vector3(70, 530, 0)
         }
 
-        const textStyle: TextStyle = {
-          name: 'Standard',
-          standardFlag: 0,
-          fixedTextHeight: 24,
-          widthFactor: 1,
-          obliqueAngle: 0,
-          textGenerationFlag: 0,
-          lastHeight: 24,
-          font: this.fontSelect.value,
-          bigFont: ''
-        }
+        const textStyle = this.createTextStyle({
+          demoMissingStyleFonts: content === this.exampleTexts.font
+        })
 
         // Render MText using unified renderer
         this.currentMText = await this.unifiedRenderer.asyncRenderMText(

--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-renderer",
-  "version": "0.10.16",
+  "version": "0.11.0",
   "description": "AutoCAD MText renderer based on Three.js",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",

--- a/packages/mtext-renderer/src/font/font.ts
+++ b/packages/mtext-renderer/src/font/font.ts
@@ -6,6 +6,14 @@
 export type FontType = 'shx' | 'mesh'
 
 /**
+ * Role of a default fallback font in AutoCAD-style text styles.
+ * - 'mesh': TrueType/mesh font fallback (DXF group 3, big font empty)
+ * - 'shx': Primary SHX font fallback (DXF group 3, ASCII/Latin)
+ * - 'shxBigFont': SHX big-font fallback (DXF group 4, CJK/DBCS)
+ */
+export type DefaultFontRole = 'mesh' | 'shx' | 'shxBigFont'
+
+/**
  * Represents font data stored in the cache database.
  * This interface defines the structure of font data that is stored and retrieved from the cache.
  */

--- a/packages/mtext-renderer/src/font/fontManager.ts
+++ b/packages/mtext-renderer/src/font/fontManager.ts
@@ -9,7 +9,7 @@ import {
 import { BaseFont } from './baseFont'
 import { BaseTextShape } from './baseTextShape'
 import { DefaultFontLoader } from './defaultFontLoader'
-import { FontData, FontType } from './font'
+import { FontData, FontType, DefaultFontRole } from './font'
 import { FontFactory } from './fontFactory'
 import { FontInfo, FontLoader, FontLoadStatus } from './fontLoader'
 
@@ -57,8 +57,35 @@ export class FontManager {
   public missedFonts: Record<string, number> = {}
   /** Flag to enable/disable font caching */
   public enableFontCache = true
-  /** Default font to use when a requested font is not found */
-  public defaultFont = 'simkai'
+  /** Default mesh font to use when a requested mesh font is not found */
+  public defaultMeshFont = 'simkai'
+  /** Default primary (English) SHX font when a requested SHX font is not found (DXF group 3) */
+  public defaultShxFont = 'txt'
+  /** Default SHX big font when a requested big font is not found (DXF group 4) */
+  public defaultShxBigFont = 'hztxt'
+
+  /**
+   * @deprecated Use {@link defaultShxBigFont} instead.
+   */
+  get defaultBigFont() {
+    return this.defaultShxBigFont
+  }
+  set defaultBigFont(value: string) {
+    this.defaultShxBigFont = value
+  }
+
+  /**
+   * Default font to use when a requested font is not found.
+   * Setting this value updates all three default font properties.
+   */
+  get defaultFont() {
+    return this.defaultMeshFont
+  }
+  set defaultFont(value: string) {
+    this.defaultMeshFont = value
+    this.defaultShxFont = value
+    this.defaultShxBigFont = value
+  }
 
   /** Event managers for font-related events */
   public readonly events = {
@@ -124,19 +151,71 @@ export class FontManager {
   }
 
   /**
-   * Return true if the default font was loaded.
-   * @returns True if the default font was loaded. False otherwise.
+   * Return true if all configured default fonts were loaded.
+   * @returns True if all default fonts were loaded. False otherwise.
    */
   isDefaultFontLoaded() {
-    return this.loadedFontMap.get(this.defaultFont.toLowerCase()) != null
+    return this.getDefaultFontsToLoad().every(
+      fontName => this.loadedFontMap.get(fontName.toLowerCase()) != null
+    )
   }
 
   /**
-   * Loads the default font
+   * Returns the distinct default font names that should be loaded.
+   */
+  getDefaultFontsToLoad(): string[] {
+    return [
+      ...new Set([
+        this.defaultMeshFont,
+        this.defaultShxFont,
+        this.defaultShxBigFont
+      ])
+    ]
+  }
+
+  /**
+   * Resolves the default font for the given font type or text-style role.
+   */
+  getDefaultFontForRole(role?: DefaultFontRole, fontType?: FontType): string {
+    if (role === 'shxBigFont') {
+      return this.defaultShxBigFont
+    }
+    if (role === 'shx' || fontType === 'shx') {
+      return this.defaultShxFont
+    }
+    return this.defaultMeshFont
+  }
+
+  /**
+   * Resolves the default font for the given font type.
+   * @deprecated Use {@link getDefaultFontForRole} instead.
+   */
+  getDefaultFontForType(fontType?: FontType): string {
+    return this.getDefaultFontForRole(undefined, fontType)
+  }
+
+  /**
+   * Infers font type from a font name or a loaded font entry.
+   */
+  inferFontTypeFromName(fontName: string): FontType | undefined {
+    const lower = fontName.toLowerCase()
+    if (lower.endsWith('.shx')) {
+      return 'shx'
+    }
+    if (/\.(ttf|otf|woff)$/.test(lower)) {
+      return 'mesh'
+    }
+
+    const withoutExtension = lower.replace(/\.(ttf|otf|woff|shx)$/, '')
+    return this.loadedFontMap.get(withoutExtension)?.type
+  }
+
+  /**
+   * Loads the default mesh, primary SHX, and big SHX fonts
    * @returns Promise that resolves to the font load statuses
    */
   async loadDefaultFont() {
-    return await this.loadFontsByNames(this.defaultFont)
+    return await this.loadFontsByNames(this.getDefaultFontsToLoad())
   }
 
   /**
@@ -185,7 +264,11 @@ export class FontManager {
    * @param fontName - The font name to find
    * @returns The original font name if found, or the replacement font name if not found
    */
-  findAndReplaceFont(fontName: string) {
+  findAndReplaceFont(
+    fontName: string,
+    fontTypeHint?: FontType,
+    role?: DefaultFontRole
+  ) {
     let font = this.loadedFontMap.get(fontName.toLowerCase())
     if (font == null) {
       const mappedFontName = this.fontMapping[fontName]
@@ -194,7 +277,12 @@ export class FontManager {
         return mappedFontName
       }
     }
-    return font ? fontName : this.defaultFont
+    if (font) {
+      return fontName
+    }
+
+    const fontType = fontTypeHint ?? this.inferFontTypeFromName(fontName)
+    return this.getDefaultFontForRole(role, fontType)
   }
 
   /**

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -9,7 +9,7 @@ import * as THREE from 'three'
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js'
 
 import { getColorByIndex } from '../common'
-import { FontManager } from '../font'
+import { DefaultFontRole, FontManager } from '../font'
 import { resolveMTextColor } from './colorUtils'
 import {
   LINE_SPACING_SCALE_FACTOR,
@@ -250,7 +250,9 @@ export class MTextProcessor {
     // Set initial color
     this._currentContext.setColorFromHex(this.resolveBaseColor())
     // Set initial font face
-    this._currentContext.fontFace.family = this.textStyle.font.toLowerCase()
+    this._currentContext.fontFace.family = this.getResolvedStyleFontName(
+      this.textStyle.font
+    )
     // Set initial width factor
     this._currentContext.widthFactor = {
       value: options.widthFactor,
@@ -1216,7 +1218,7 @@ export class MTextProcessor {
           'position',
           new THREE.BufferAttribute(lineVertices, 3)
         )
-        lineGeometry.setIndex(null)
+        lineGeometry.setIndex([0, 1])
         lineGeometry.userData = { isDecoration: true }
         lineGeometries.push(lineGeometry)
       }
@@ -1481,7 +1483,7 @@ export class MTextProcessor {
           3
         )
       )
-      underlineGeom.setIndex(null)
+      underlineGeom.setIndex([0, 1])
       underlineGeom.userData = { isDecoration: true }
       lineGeometries.push(underlineGeom)
     }
@@ -1503,7 +1505,7 @@ export class MTextProcessor {
           3
         )
       )
-      overlineGeom.setIndex(null)
+      overlineGeom.setIndex([0, 1])
       overlineGeom.userData = { isDecoration: true }
       lineGeometries.push(overlineGeom)
     }
@@ -1525,7 +1527,7 @@ export class MTextProcessor {
           3
         )
       )
-      strikeGeom.setIndex(null)
+      strikeGeom.setIndex([0, 1])
       strikeGeom.userData = { isDecoration: true }
       lineGeometries.push(strikeGeom)
     }
@@ -1539,13 +1541,35 @@ export class MTextProcessor {
     this.calcuateLineParams()
   }
 
-  private changeFont(fontName: string) {
+  private getResolvedStyleFontName(
+    fontName: string,
+    role?: DefaultFontRole
+  ): string {
     let processedFontName = fontName
     if (this._options.removeFontExtension) {
       processedFontName = fontName.replace(/\.(ttf|otf|woff|shx)$/, '')
     }
-    this._currentContext.fontFace.family =
-      this.fontManager.findAndReplaceFont(processedFontName)
+    const fontType = this.fontManager.inferFontTypeFromName(fontName)
+    const resolvedRole =
+      role ??
+      (fontType === 'mesh'
+        ? 'mesh'
+        : fontType === 'shx'
+          ? 'shx'
+          : undefined)
+    return this.fontManager.findAndReplaceFont(
+      processedFontName,
+      fontType,
+      resolvedRole
+    )
+  }
+
+  private getResolvedBigFontName(fontName: string): string {
+    return this.getResolvedStyleFontName(fontName, 'shxBigFont')
+  }
+
+  private changeFont(fontName: string) {
+    this._currentContext.fontFace.family = this.getResolvedStyleFontName(fontName)
     this.calcuateLineParams()
     this._currentContext.blankWidth = this.calculateBlankWidthForFont(
       this._currentContext.fontFace.family,
@@ -1583,7 +1607,7 @@ export class MTextProcessor {
     if (this.textStyle.bigFont && !shape) {
       shape = this.fontManager.getCharShape(
         char,
-        this.textStyle.bigFont,
+        this.getResolvedBigFontName(this.textStyle.bigFont),
         this.currentFontSize
       )
     }
@@ -1873,12 +1897,15 @@ export class MTextProcessor {
     const allLineGeoms = [
       ...lineGeometries,
       ...geometries.filter(g => !(g instanceof THREE.ShapeGeometry))
-    ]
+    ].map(geometry => this.ensureLineGeometryIndexed(geometry))
     if (allLineGeoms.length > 0) {
       const mergedLineGeom =
         allLineGeoms.length > 1
           ? mergeGeometries(allLineGeoms)
           : allLineGeoms[0]
+      if (!mergedLineGeom) {
+        throw new Error('Failed to merge line geometries for MText rendering')
+      }
       const lineMesh = new THREE.LineSegments(mergedLineGeom, lineMaterial)
       lineMesh.userData.bboxIntersectionCheck = true
       lineMesh.userData.charBoxType = charBoxType
@@ -1895,6 +1922,26 @@ export class MTextProcessor {
     } else {
       return meshGroup
     }
+  }
+
+  private ensureLineGeometryIndexed(
+    geometry: THREE.BufferGeometry
+  ): THREE.BufferGeometry {
+    if (geometry.getIndex()) {
+      return geometry
+    }
+
+    const position = geometry.getAttribute('position')
+    if (!position || position.count < 2) {
+      return geometry
+    }
+
+    const indices: number[] = []
+    for (let i = 0; i < position.count; i++) {
+      indices.push(i)
+    }
+    geometry.setIndex(indices)
+    return geometry
   }
 
   private changeFontSizeScaleFactor(value: number) {

--- a/packages/mtext-renderer/src/worker/baseRenderer.ts
+++ b/packages/mtext-renderer/src/worker/baseRenderer.ts
@@ -101,6 +101,15 @@ export interface MTextBaseRenderer {
   setFontUrl(value: string): Promise<void>
 
   /**
+   * Configure default fallback fonts for mesh, primary SHX, and big SHX types.
+   */
+  setDefaultFonts(
+    meshFont: string,
+    shxFont: string,
+    shxBigFont: string
+  ): Promise<void>
+
+  /**
    * Release any resources owned by the renderer (e.g., terminate Web Workers).
    *
    * Safe to call multiple times.

--- a/packages/mtext-renderer/src/worker/mainThreadRenderer.ts
+++ b/packages/mtext-renderer/src/worker/mainThreadRenderer.ts
@@ -44,6 +44,15 @@ export class MainThreadRenderer implements MTextBaseRenderer {
   }
 
   /**
+   * Configure default fallback fonts for mesh, primary SHX, and big SHX types.
+   */
+  async setDefaultFonts(meshFont: string, shxFont: string, shxBigFont: string) {
+    this.fontManager.defaultMeshFont = meshFont
+    this.fontManager.defaultShxFont = shxFont
+    this.fontManager.defaultShxBigFont = shxBigFont
+  }
+
+  /**
    * Render MText directly in the main thread asynchronously. It will ensure that default font
    * is loaded. And fonts needed in mtext are loaded on demand.
    */
@@ -108,8 +117,8 @@ export class MainThreadRenderer implements MTextBaseRenderer {
 
   private async ensureInitialized() {
     if (!this.isInitialized) {
-      // Guarantee the default font is loaded
-      await this.loadFonts([FontManager.instance.defaultFont])
+      // Guarantee the default fonts are loaded
+      await this.loadFonts(FontManager.instance.getDefaultFontsToLoad())
       this.isInitialized = true
     }
   }

--- a/packages/mtext-renderer/src/worker/mtextWorker.ts
+++ b/packages/mtext-renderer/src/worker/mtextWorker.ts
@@ -14,7 +14,12 @@ import {
 
 // Worker message types
 interface WorkerMessage {
-  type: 'render' | 'loadFonts' | 'setFontUrl' | 'getAvailableFonts'
+  type:
+    | 'render'
+    | 'loadFonts'
+    | 'setFontUrl'
+    | 'setDefaultFonts'
+    | 'getAvailableFonts'
   id: string
   data?: {
     mtextContent?: unknown
@@ -22,11 +27,19 @@ interface WorkerMessage {
     colorSettings?: unknown
     fonts?: string[]
     url?: string
+    meshFont?: string
+    shxFont?: string
   }
 }
 
 interface WorkerResponse {
-  type: 'render' | 'loadFonts' | 'setFontUrl' | 'getAvailableFonts' | 'error'
+  type:
+    | 'render'
+    | 'loadFonts'
+    | 'setFontUrl'
+    | 'setDefaultFonts'
+    | 'getAvailableFonts'
+    | 'error'
   id: string
   success: boolean
   data?: unknown
@@ -103,6 +116,25 @@ self.addEventListener('message', async (event: MessageEvent<WorkerMessage>) => {
         fontManager.baseUrl = url
         self.postMessage({
           type: 'setFontUrl',
+          id,
+          success: true,
+          data: {}
+        } as WorkerResponse)
+        break
+      }
+
+      case 'setDefaultFonts': {
+        if (!data) throw new Error('Missing data for setDefaultFonts message')
+        const { meshFont, shxFont, shxBigFont } = data as {
+          meshFont: string
+          shxFont: string
+          shxBigFont: string
+        }
+        fontManager.defaultMeshFont = meshFont
+        fontManager.defaultShxFont = shxFont
+        fontManager.defaultShxBigFont = shxBigFont
+        self.postMessage({
+          type: 'setDefaultFonts',
           id,
           success: true,
           data: {}
@@ -191,21 +223,23 @@ function serializeMText(mtext: MText): {
   data: unknown
   transferableObjects: ArrayBuffer[]
 } {
-  // Get the world matrix to capture all transformations
-  const worldMatrix = mtext.matrixWorld.clone()
+  // `MText` is a wrapper Object3D; insertion/rotation live on the rendered child group
+  // created in `loadMText`. Keep large drawing coordinates on that root transform, not
+  // in Float32 geometry buffers.
+  const renderRoot = mtext.children[0] as THREE.Object3D | undefined
+  const rootForTransform = renderRoot ?? mtext
+
+  const worldMatrix = rootForTransform.matrixWorld.clone()
   const position = new THREE.Vector3()
   const quaternion = new THREE.Quaternion()
   const scale = new THREE.Vector3()
 
-  // Decompose the world matrix to get the final position, rotation, and scale
   worldMatrix.decompose(position, quaternion, scale)
 
-  // Transform the bounding box to world coordinates
+  // `mtext.box` is already accumulated in world space during `syncDraw`.
   const transformedBox = mtext.box.clone()
-  transformedBox.applyMatrix4(worldMatrix)
 
-  // Serialize children and collect transferable objects
-  const { children, transferableObjects } = serializeChildren(mtext)
+  const { children, transferableObjects } = serializeChildren(rootForTransform)
 
   // Create a comprehensive JSON-serializable representation
   const serialized = {
@@ -246,26 +280,36 @@ function serializeMText(mtext: MText): {
   return { data: serialized, transferableObjects }
 }
 
+const rootWorldInverse = /*@__PURE__*/ new THREE.Matrix4()
+const childRelativeMatrix = /*@__PURE__*/ new THREE.Matrix4()
+
 // Serialize all child objects as JSON with transferable objects
-function serializeChildren(mtext: MText): {
+function serializeChildren(root: THREE.Object3D): {
   children: unknown[]
   transferableObjects: ArrayBuffer[]
 } {
   const children: unknown[] = []
   const allTransferableObjects: ArrayBuffer[] = []
 
-  mtext.traverse(child => {
+  root.updateWorldMatrix(true, true)
+  rootWorldInverse.copy(root.matrixWorld).invert()
+
+  root.traverse(child => {
     if (child instanceof THREE.Mesh || child instanceof THREE.Line) {
       const geometry = child.geometry
       const material = child.material
 
       if (geometry instanceof THREE.BufferGeometry) {
-        // Get world matrix for transformations
-        const worldMatrix = child.matrixWorld.clone()
+        // Keep glyph geometry local and express each child transform relative to
+        // the MText root so large insertion coordinates stay on the root group.
         const position = new THREE.Vector3()
         const quaternion = new THREE.Quaternion()
         const scale = new THREE.Vector3()
-        worldMatrix.decompose(position, quaternion, scale)
+        childRelativeMatrix.multiplyMatrices(
+          rootWorldInverse,
+          child.matrixWorld
+        )
+        childRelativeMatrix.decompose(position, quaternion, scale)
 
         // Serialize geometry attributes using transferable objects
         const attributes: Record<string, unknown> = {}

--- a/packages/mtext-renderer/src/worker/unifiedRenderer.ts
+++ b/packages/mtext-renderer/src/worker/unifiedRenderer.ts
@@ -79,6 +79,14 @@ export class UnifiedRenderer {
   }
 
   /**
+   * Configure default fallback fonts for mesh, primary SHX, and SHX big types.
+   */
+  setDefaultFonts(meshFont: string, shxFont: string, shxBigFont: string) {
+    this.mainThreadRenderer.setDefaultFonts(meshFont, shxFont, shxBigFont)
+    return this.webWorkerRenderer.setDefaultFonts(meshFont, shxFont, shxBigFont)
+  }
+
+  /**
    * Get the default rendering mode
    */
   getDefaultMode(): RenderMode {

--- a/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
+++ b/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
@@ -83,12 +83,22 @@ type SetFontUrlMessage = WorkerMessageBase<
   }
 >
 
+type SetDefaultFontsMessage = WorkerMessageBase<
+  'setDefaultFonts',
+  {
+    meshFont: string
+    shxFont: string
+    shxBigFont: string
+  }
+>
+
 type GetAvailableFontsMessage = WorkerMessageBase<'getAvailableFonts'>
 
 type WorkerMessageTyped =
   | RenderMessage
   | LoadFontsMessage
   | SetFontUrlMessage
+  | SetDefaultFontsMessage
   | GetAvailableFontsMessage
 
 //
@@ -105,6 +115,8 @@ type LoadFontsResponse = WorkerResponseBase<
 
 type SetFontUrlResponse = WorkerResponseBase<'setFontUrl'>
 
+type SetDefaultFontsResponse = WorkerResponseBase<'setDefaultFonts'>
+
 type GetAvailableFontsResponse = WorkerResponseBase<
   'getAvailableFonts',
   {
@@ -116,6 +128,7 @@ type WorkerResponseTyped =
   | RenderResponse
   | LoadFontsResponse
   | SetFontUrlResponse
+  | SetDefaultFontsResponse
   | GetAvailableFontsResponse
 
 // Serialized MText data from worker (JSON-based)
@@ -239,8 +252,8 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
 
   private async ensureInitialized() {
     if (!this.isInitialized) {
-      // Guarantee the default font is loaded
-      await this.loadFonts([FontManager.instance.defaultFont])
+      // Guarantee the default fonts are loaded
+      await this.loadFonts(FontManager.instance.getDefaultFontsToLoad())
       this.isInitialized = true
     }
   }
@@ -408,6 +421,22 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
   }
 
   /**
+   * Configure default fallback fonts for mesh, primary SHX, and big SHX types in all workers.
+   */
+  async setDefaultFonts(meshFont: string, shxFont: string, shxBigFont: string) {
+    FontManager.instance.defaultMeshFont = meshFont
+    FontManager.instance.defaultShxFont = shxFont
+    FontManager.instance.defaultShxBigFont = shxBigFont
+    await this.sendMessageToAllWorkers<
+      SetDefaultFontsMessage,
+      SetDefaultFontsResponse
+    >({
+      type: 'setDefaultFonts',
+      data: { meshFont, shxFont, shxBigFont }
+    })
+  }
+
+  /**
    * Render MText in one worker and return serialized data asynchronously.
    */
   async asyncRenderMText(
@@ -480,6 +509,24 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
   ): MTextObject {
     const baseByLayer = colorSettings.color.aci === 256
     const group = new THREE.Group()
+
+    // Large drawing coordinates live on the root transform; glyph geometry stays local.
+    group.position.set(
+      serializedData.position.x,
+      serializedData.position.y,
+      serializedData.position.z
+    )
+    group.quaternion.set(
+      serializedData.rotation.x,
+      serializedData.rotation.y,
+      serializedData.rotation.z,
+      serializedData.rotation.w
+    )
+    group.scale.set(
+      serializedData.scale.x,
+      serializedData.scale.y,
+      serializedData.scale.z
+    )
 
     // Reconstruct all child objects
     serializedData.children.forEach(childData => {
@@ -586,7 +633,7 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
         geometry.computeBoundingSphere()
       }
 
-      // Set position, rotation, and scale directly (already in world coordinates)
+      // Child transforms are local to the MText root group.
       object.position.set(
         childData.position.x,
         childData.position.y,

--- a/packages/mtext-renderer/test/font/fontManager.test.ts
+++ b/packages/mtext-renderer/test/font/fontManager.test.ts
@@ -62,6 +62,9 @@ describe('FontManager', () => {
     manager.fileNames = []
     manager.enableFontCache = true
     manager.defaultFont = 'simkai'
+    manager.defaultMeshFont = 'simkai'
+    manager.defaultShxFont = 'txt'
+    manager.defaultShxBigFont = 'hztxt'
   })
 
   afterEach(() => {
@@ -114,7 +117,7 @@ describe('FontManager', () => {
 
     const result = await manager.loadDefaultFont()
 
-    expect(loader.load).toHaveBeenCalledWith(['simkai'])
+    expect(loader.load).toHaveBeenCalledWith(['simkai', 'txt', 'hztxt'])
     expect(result).toEqual([
       {
         fontName: 'simkai',
@@ -133,6 +136,13 @@ describe('FontManager', () => {
       'replacement'
     )
     expect(FontManager.instance.findAndReplaceFont('Unknown')).toBe('simkai')
+    expect(FontManager.instance.findAndReplaceFont('missing.shx')).toBe('txt')
+    expect(FontManager.instance.findAndReplaceFont('missing', 'shx')).toBe(
+      'txt'
+    )
+    expect(
+      FontManager.instance.findAndReplaceFont('missing_big', 'shx', 'shxBigFont')
+    ).toBe('hztxt')
   })
 
   it('finds fonts by name, strips common font extensions, and records misses', () => {

--- a/packages/mtext-renderer/test/renderer/mtext.anchor.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.anchor.test.ts
@@ -110,6 +110,7 @@ function createTextFixture(
     getFontScaleFactor: () => 1,
     getFontType: () => 'mesh',
     findAndReplaceFont: (name: string) => name,
+    inferFontTypeFromName: () => 'mesh' as const,
     getCharShape: (_char: string, _fontName: string, size: number) => ({
       width: 10,
       toGeometry: () => createShapeGeometry(10, size)
@@ -163,6 +164,7 @@ describe('MText attachment anchoring', () => {
       getFontScaleFactor: () => fontScaleFactor,
       getFontType: () => 'mesh',
       findAndReplaceFont: (name: string) => name,
+    inferFontTypeFromName: () => 'mesh' as const,
       getCharShape: (_char: string, _fontName: string, size: number) => ({
         width: 10,
         toGeometry: () => createShapeGeometry(10, size / fontScaleFactor)
@@ -236,6 +238,7 @@ describe('MText attachment anchoring', () => {
         getFontScaleFactor: () => 1,
         getFontType: () => 'mesh',
         findAndReplaceFont: (name: string) => name,
+    inferFontTypeFromName: () => 'mesh' as const,
         getCharShape: (_char: string, _fontName: string, size: number) => ({
           width: 10,
           toGeometry: () => createShapeGeometry(10, size)
@@ -292,6 +295,7 @@ describe('MText attachment anchoring', () => {
       getFontScaleFactor: () => 1,
       getFontType: () => 'mesh',
       findAndReplaceFont: (name: string) => name,
+    inferFontTypeFromName: () => 'mesh' as const,
       getCharShape: (_char: string, _fontName: string, size: number) => ({
         width: 10,
         toGeometry: () => createShapeGeometry(10, size)
@@ -352,6 +356,7 @@ describe('MText attachment anchoring', () => {
       getFontScaleFactor: () => 1,
       getFontType: () => 'mesh',
       findAndReplaceFont: (name: string) => name,
+    inferFontTypeFromName: () => 'mesh' as const,
       getCharShape: (_char: string, _fontName: string, size: number) => ({
         width: 10,
         toGeometry: () => createOffsetShapeGeometry(10, size, sideBearing)

--- a/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
@@ -149,6 +149,7 @@ function createProcessor(
     getFontScaleFactor: () => fontScaleFactor,
     getFontType: () => fontType,
     findAndReplaceFont: (name: string) => name,
+    inferFontTypeFromName: () => fontType,
     getCharShape: (char: string) => {
       if (!char || char === ' ') return undefined
       return {

--- a/packages/mtext-renderer/test/renderer/webWorkerRenderer.precision.test.ts
+++ b/packages/mtext-renderer/test/renderer/webWorkerRenderer.precision.test.ts
@@ -1,0 +1,114 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+
+import { createDefaultColorSettings } from '../../src/renderer/types'
+import { WebWorkerRenderer } from '../../src/worker/webWorkerRenderer'
+
+function getGeometryPositionMaxAbs(object: THREE.Object3D) {
+  let maxAbs = 0
+
+  object.traverse(child => {
+    if (!('geometry' in child)) return
+
+    const position = (child.geometry as THREE.BufferGeometry).getAttribute(
+      'position'
+    )
+    if (!position) return
+
+    for (let i = 0; i < position.count; i++) {
+      maxAbs = Math.max(
+        maxAbs,
+        Math.abs(position.getX(i)),
+        Math.abs(position.getY(i)),
+        Math.abs(position.getZ(i))
+      )
+    }
+  })
+
+  return maxAbs
+}
+
+function createQuadGeometry(width: number, height: number) {
+  const geometry = new THREE.BufferGeometry()
+  const positions = new Float32Array([
+    0,
+    0,
+    0,
+    width,
+    0,
+    0,
+    width,
+    height,
+    0,
+    0,
+    height,
+    0
+  ])
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+  geometry.setIndex([0, 1, 1, 2, 2, 3, 3, 0])
+  return geometry
+}
+
+describe('WebWorkerRenderer reconstructMText precision', () => {
+  it('keeps glyph geometry local while insertion lives on the root transform', () => {
+    const position = { x: 38425192.41436505, y: 4069213.352858167, z: 0 }
+    const geometry = createQuadGeometry(10, 12)
+    const positions = geometry.getAttribute('position').array as Float32Array
+
+    const renderer = new WebWorkerRenderer({ poolSize: 0 })
+    const object = renderer.reconstructMText(
+      {
+        type: 'MText',
+        position,
+        rotation: { x: 0, y: 0, z: 0, w: 1 },
+        scale: { x: 1, y: 1, z: 1 },
+        box: {
+          min: { x: position.x, y: position.y, z: 0 },
+          max: { x: position.x + 10, y: position.y + 12, z: 0 }
+        },
+        children: [
+          {
+            type: 'mesh',
+            position: { x: 0, y: 0, z: 0 },
+            rotation: { x: 0, y: 0, z: 0, w: 1 },
+            scale: { x: 1, y: 1, z: 1 },
+            geometry: {
+              attributes: {
+                position: {
+                  arrayBuffer: positions.buffer,
+                  byteOffset: positions.byteOffset,
+                  length: positions.length,
+                  itemSize: 3,
+                  normalized: false
+                }
+              },
+              index: null
+            },
+            material: {
+              type: 'MeshBasicMaterial',
+              color: 0xffffff,
+              transparent: false,
+              opacity: 1
+            }
+          }
+        ]
+      },
+      createDefaultColorSettings()
+    )
+
+    expect(object.position.x).toBeCloseTo(position.x, 3)
+    expect(object.position.y).toBeCloseTo(position.y, 3)
+    expect(getGeometryPositionMaxAbs(object)).toBeLessThan(100)
+
+    const worldPoint = new THREE.Vector3()
+    object.updateWorldMatrix(true, true)
+    object.traverse(child => {
+      if (!(child instanceof THREE.Mesh)) return
+      child.getWorldPosition(worldPoint)
+      expect(worldPoint.x).toBeCloseTo(position.x, 3)
+      expect(worldPoint.y).toBeCloseTo(position.y, 3)
+    })
+
+    renderer.destroy()
+  })
+})


### PR DESCRIPTION
## Summary

- Introduce role-based default fallback fonts in FontManager: mesh (defaultMeshFont), primary SHX (defaultShxFont), and SHX big font (defaultShxBigFont), with indAndReplaceFont resolving by font type/role instead of a single defaultFont.
- Add setDefaultFonts(mesh, shx, shxBig) on UnifiedRenderer / main-thread / Web Worker renderers; initialization loads all three defaults.
- Fix Web Worker MText serialization/reconstruction so large drawing insertion coordinates stay on the root group transform while glyph geometry remains local (avoids float precision loss in vertex buffers).
- Fix decoration line geometries to use explicit indices; ensure unindexed line geometries are indexed before merge.
- Update the example app with separate default font dropdowns and demo cases for missing inline/style fonts.
- Bump @mlightcad/mtext-renderer to **0.11.0**.

## Test plan

- [ ] Run 
x test mtext-renderer (or package test script) and confirm ontManager, mtext.processor, mtext.anchor, and webWorkerRenderer.precision tests pass.
- [ ] Run the example app; verify mesh / English SHX / big SHX default selectors reload fonts and re-render.
- [ ] In the example **font** demo, confirm missing mesh/SHX inline fonts and missing text-style primary/big fonts fall back to the configured defaults.
- [ ] Render MText at large world coordinates in Web Worker mode and confirm position/anchor match main-thread rendering (no jitter or offset).

Made with [Cursor](https://cursor.com)