### PR TITLE
feat: ordered default font fallback chain and AutoCAD glyph semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The central manager for font operations. It's a singleton class that handles fon
 - `missedFonts`: Record of fonts that were requested but not found
 - `enableFontCache`: Flag to enable/disable font caching. If it is true, parsed fonts 
 will be stored in local IndexedDB to improve performance. Default value is true.
-- `defaultFont`: Default font to use when a requested font is not found
+- `defaultFonts`: Set of default font names; used when a requested font is not found or lacks a glyph (earlier entries are tried first)
 - `events`: Event managers for font-related events
   - `fontNotFound`: Triggered when a font cannot be found
   - `fontLoaded`: Triggered when a font is successfully loaded
@@ -192,7 +192,7 @@ classDiagram
         +unsupportedChars: Record
         +missedFonts: Record
         +enableFontCache: boolean
-        +defaultFont: string
+        +defaultFonts: Set~string~
         +events: EventManagers
         +loadFonts(urls)
         +getCharShape(char, fontName, size)

--- a/packages/mtext-renderer/src/font/defaultFontsPresets.ts
+++ b/packages/mtext-renderer/src/font/defaultFontsPresets.ts
@@ -1,0 +1,38 @@
+/**
+ * Preset names for common AutoCAD-era default font fallback chains.
+ *
+ * Third-party DWG viewers often mirror fonts that were widely bundled or
+ * referenced during the AutoCAD R12/R14 era, then simplified in later releases.
+ */
+export type DefaultFontsPreset =
+  /** Single mesh fallback; matches the library default. */
+  | 'minimal'
+  /** Classic R12/R14 stack: SHX basics, GB big font, then mesh CJK and GDT. */
+  | 'r12r14'
+  /** Later-era stack: hztxt big font with simsun and GDT symbols. */
+  | 'modern'
+  /** Western SHX fonts plus simsun and GDT; no CJK-specific SHX big fonts. */
+  | 'international'
+  /** Broad CJK coverage: both GB big-font SHX files plus common mesh fallbacks. */
+  | 'cjk'
+
+/**
+ * Predefined default font fallback chains.
+ * Font names are logical names without file extensions; earlier entries are tried first.
+ */
+export const DEFAULT_FONTS_PRESETS: Record<
+  DefaultFontsPreset,
+  readonly string[]
+> = {
+  minimal: ['simkai'],
+  r12r14: ['txt', 'simplex', 'romans', 'gbcbig', 'simsun', 'gdt'],
+  modern: ['hztxt', 'simsun', 'gdt'],
+  international: ['txt', 'simplex', 'romans', 'simsun', 'gdt'],
+  cjk: ['gbcbig', 'hztxt', 'simsun', 'simkai', 'gdt']
+}
+
+export function isDefaultFontsPreset(
+  value: string
+): value is DefaultFontsPreset {
+  return Object.prototype.hasOwnProperty.call(DEFAULT_FONTS_PRESETS, value)
+}

--- a/packages/mtext-renderer/src/font/fontManager.ts
+++ b/packages/mtext-renderer/src/font/fontManager.ts
@@ -9,6 +9,11 @@ import {
 import { BaseFont } from './baseFont'
 import { BaseTextShape } from './baseTextShape'
 import { DefaultFontLoader } from './defaultFontLoader'
+import {
+  DEFAULT_FONTS_PRESETS,
+  DefaultFontsPreset,
+  isDefaultFontsPreset
+} from './defaultFontsPresets'
 import { FontData, FontType } from './font'
 import { FontFactory } from './fontFactory'
 import { FontInfo, FontLoader, FontLoadStatus } from './fontLoader'
@@ -57,8 +62,11 @@ export class FontManager {
   public missedFonts: Record<string, number> = {}
   /** Flag to enable/disable font caching */
   public enableFontCache = true
-  /** Default font to use when a requested font is not found */
-  public defaultFont = 'simkai'
+  /**
+   * Default fonts to use when a requested font is not found or lacks a glyph.
+   * Insertion order is preserved; earlier entries are tried first.
+   */
+  public defaultFonts = new Set<string>(['simkai'])
 
   /** Event managers for font-related events */
   public readonly events = {
@@ -106,6 +114,40 @@ export class FontManager {
   }
 
   /**
+   * Sets the default font fallback chain.
+   *
+   * Pass a {@link DefaultFontsPreset} name to apply a predefined AutoCAD-era
+   * fallback stack, or pass one or more font names to define a custom chain.
+   * Earlier entries are tried first when a glyph is missing.
+   *
+   * @param fonts - A preset name, a single font name, or an ordered list of font names
+   * @example
+   * ```ts
+   * FontManager.instance.setDefaultFonts('r12r14')
+   * FontManager.instance.setDefaultFonts(['hztxt', 'simsun', 'gdt'])
+   * FontManager.instance.setDefaultFonts('simkai')
+   * ```
+   */
+  setDefaultFonts(fonts: DefaultFontsPreset): void
+  setDefaultFonts(fonts: string | readonly string[]): void
+  setDefaultFonts(fonts: DefaultFontsPreset | string | readonly string[]) {
+    if (typeof fonts === 'string' && isDefaultFontsPreset(fonts)) {
+      this.defaultFonts = new Set(DEFAULT_FONTS_PRESETS[fonts])
+      return
+    }
+    const list = typeof fonts === 'string' ? [fonts] : [...fonts]
+    this.defaultFonts = new Set(list)
+  }
+
+  /**
+   * Returns the font names for a predefined default-font preset.
+   * @param preset - The preset to look up
+   */
+  getDefaultFontsPreset(preset: DefaultFontsPreset): readonly string[] {
+    return DEFAULT_FONTS_PRESETS[preset]
+  }
+
+  /**
    * Sets the font loader
    * @param fontLoader - The font loader to set
    */
@@ -124,19 +166,24 @@ export class FontManager {
   }
 
   /**
-   * Return true if the default font was loaded.
-   * @returns True if the default font was loaded. False otherwise.
+   * Return true if all default fonts were loaded.
+   * @returns True if every font in `defaultFonts` is loaded. False otherwise.
    */
   isDefaultFontLoaded() {
-    return this.loadedFontMap.get(this.defaultFont.toLowerCase()) != null
+    for (const fontName of this.defaultFonts) {
+      if (this.loadedFontMap.get(fontName.toLowerCase()) == null) {
+        return false
+      }
+    }
+    return this.defaultFonts.size > 0
   }
 
   /**
-   * Loads the default font
+   * Loads all default fonts
    * @returns Promise that resolves to the font load statuses
    */
   async loadDefaultFont() {
-    return await this.loadFontsByNames(this.defaultFont)
+    return await this.loadFontsByNames([...this.defaultFonts])
   }
 
   /**
@@ -194,7 +241,15 @@ export class FontManager {
         return mappedFontName
       }
     }
-    return font ? fontName : this.defaultFont
+    if (font) {
+      return fontName
+    }
+    for (const defaultFontName of this.defaultFonts) {
+      if (this.loadedFontMap.has(defaultFontName.toLowerCase())) {
+        return defaultFontName
+      }
+    }
+    return [...this.defaultFonts][0] ?? ''
   }
 
   /**
@@ -250,7 +305,8 @@ export class FontManager {
   }
 
   /**
-   * Gets the text shape for a specific character with the specified font and size
+   * Gets the text shape for a specific character in the named font only.
+   * Does not fall back to bigFont, default fonts, or other loaded fonts.
    * @param char - The character to get the shape for
    * @param fontName - The name of the font to use
    * @param size - The size of the character
@@ -261,11 +317,33 @@ export class FontManager {
     fontName: string,
     size: number
   ): BaseTextShape | undefined {
-    let currentFont = this.getFontByName(fontName)
-    if (!currentFont) {
-      currentFont = this.getFontByChar(char)
-    }
+    const currentFont = this.getFontByName(fontName)
     return currentFont?.getCharShape(char, size)
+  }
+
+  /**
+   * Gets the text shape from the first loaded default font that contains the character.
+   * Used after primary and optional bigFont lookups per AutoCAD text-style semantics.
+   */
+  public getCharShapeFromDefaults(
+    char: string,
+    size: number
+  ): BaseTextShape | undefined {
+    const fallbackFont = this.getFontFromDefaults(char)
+    return fallbackFont?.getCharShape(char, size)
+  }
+
+  /**
+   * Gets the first loaded default font that contains the specified character.
+   */
+  private getFontFromDefaults(char: string): BaseFont | undefined {
+    for (const fontName of this.defaultFonts) {
+      const font = this.loadedFontMap.get(fontName.toLowerCase())
+      if (font?.hasChar(char)) {
+        return font
+      }
+    }
+    return undefined
   }
 
   /**

--- a/packages/mtext-renderer/src/font/index.ts
+++ b/packages/mtext-renderer/src/font/index.ts
@@ -1,6 +1,7 @@
 export * from './baseFont'
 export * from './baseTextShape'
 export * from './defaultFontLoader'
+export * from './defaultFontsPresets'
 export * from './font'
 export * from './fontFactory'
 export * from './fontLoader'

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -1656,16 +1656,19 @@ export class MTextProcessor {
       this.currentFont,
       this.currentFontSize
     )
-    if (this.textStyle.bigFont && !shape) {
+    const bigFont = this.textStyle.bigFont?.trim()
+    if (bigFont && !shape) {
       shape = this.fontManager.getCharShape(
         char,
-        this.textStyle.bigFont,
+        bigFont,
         this.currentFontSize
       )
     }
     if (!shape) {
-      // When the text cannot be found in the font file, all font files are searched until the text is found.
-      shape = this.fontManager.getCharShape(char, '', this.currentFontSize)
+      shape = this.fontManager.getCharShapeFromDefaults(
+        char,
+        this.currentFontSize
+      )
     }
     if (!shape) {
       shape = this.fontManager.getNotFoundTextShape(this.currentFontSize)

--- a/packages/mtext-renderer/src/worker/mainThreadRenderer.ts
+++ b/packages/mtext-renderer/src/worker/mainThreadRenderer.ts
@@ -109,7 +109,7 @@ export class MainThreadRenderer implements MTextBaseRenderer {
   private async ensureInitialized() {
     if (!this.isInitialized) {
       // Guarantee the default font is loaded
-      await this.loadFonts([FontManager.instance.defaultFont])
+      await this.loadFonts([...FontManager.instance.defaultFonts])
       this.isInitialized = true
     }
   }

--- a/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
+++ b/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
@@ -240,7 +240,7 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
   private async ensureInitialized() {
     if (!this.isInitialized) {
       // Guarantee the default font is loaded
-      await this.loadFonts([FontManager.instance.defaultFont])
+      await this.loadFonts([...FontManager.instance.defaultFonts])
       this.isInitialized = true
     }
   }

--- a/packages/mtext-renderer/test/font/fontManager.test.ts
+++ b/packages/mtext-renderer/test/font/fontManager.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../src/font/fontFactory', () => ({
 }))
 
 import { FontManager } from '../../src/font/fontManager'
+import { DEFAULT_FONTS_PRESETS } from '../../src/font/defaultFontsPresets'
 import { FontCacheManager } from '../../src/cache'
 import { FontFactory } from '../../src/font/fontFactory'
 import { FontInfo, FontLoader, FontLoadStatus } from '../../src/font/fontLoader'
@@ -61,7 +62,7 @@ describe('FontManager', () => {
     manager.unsupportedChars = {}
     manager.fileNames = []
     manager.enableFontCache = true
-    manager.defaultFont = 'simkai'
+    manager.defaultFonts = new Set(['simkai'])
   })
 
   afterEach(() => {
@@ -150,18 +151,51 @@ describe('FontManager', () => {
     FontManager.instance.events.fontNotFound.removeEventListener(listener)
   })
 
-  it('finds fonts by character and falls back by character when a named font is missing', () => {
+  it('does not fall back when the requested font lacks a glyph', () => {
+    const manager = FontManager.instance as any
+    const primary = createFakeFont({
+      hasChar: vi.fn().mockReturnValue(false),
+      getCharShape: vi.fn()
+    })
+    const fallback = createFakeFont({
+      hasChar: vi.fn((char: string) => char === '中'),
+      getCharShape: vi.fn().mockReturnValue({ width: 1 })
+    })
+    manager.defaultFonts = new Set(['fallback'])
+    manager.loadedFontMap.set('primary', primary)
+    manager.loadedFontMap.set('fallback', fallback)
+
+    expect(
+      FontManager.instance.getCharShape('中', 'primary', 12)
+    ).toBeUndefined()
+    expect(primary.getCharShape).toHaveBeenCalledWith('中', 12)
+    expect(fallback.getCharShape).not.toHaveBeenCalled()
+  })
+
+  it('falls back through defaultFonts via getCharShapeFromDefaults', () => {
     const shape = { width: 1 }
+    const manager = FontManager.instance as any
+    const fallback = createFakeFont({
+      hasChar: vi.fn((char: string) => char === '中'),
+      getCharShape: vi.fn().mockReturnValue(shape)
+    })
+    manager.defaultFonts = new Set(['fallback'])
+    manager.loadedFontMap.set('fallback', fallback)
+
+    expect(FontManager.instance.getCharShapeFromDefaults('中', 12)).toBe(shape)
+    expect(fallback.getCharShape).toHaveBeenCalledWith('中', 12)
+  })
+
+  it('finds fonts by character without using getCharShape on a missing font name', () => {
     const manager = FontManager.instance as any
     const font = createFakeFont({
       hasChar: vi.fn((char: string) => char === 'A'),
-      getCharShape: vi.fn().mockReturnValue(shape)
+      getCharShape: vi.fn().mockReturnValue({ width: 1 })
     })
     manager.loadedFontMap.set('fallback', font)
 
     expect(FontManager.instance.getFontByChar('A')).toBe(font)
-    expect(FontManager.instance.getCharShape('A', 'missing', 12)).toBe(shape)
-    expect(font.getCharShape).toHaveBeenCalledWith('A', 12)
+    expect(FontManager.instance.getCharShape('A', 'missing', 12)).toBeUndefined()
   })
 
   it('returns font metadata helpers from loaded fonts', () => {
@@ -237,6 +271,46 @@ describe('FontManager', () => {
         status: 'Success'
       }
     ])
+  })
+
+  it('sets default fonts from a preset', () => {
+    const manager = FontManager.instance
+
+    manager.setDefaultFonts('r12r14')
+    expect([...manager.defaultFonts]).toEqual([
+      ...DEFAULT_FONTS_PRESETS.r12r14
+    ])
+
+    manager.setDefaultFonts('modern')
+    expect([...manager.defaultFonts]).toEqual([...DEFAULT_FONTS_PRESETS.modern])
+  })
+
+  it('sets custom default fonts from a list or single name', () => {
+    const manager = FontManager.instance
+
+    manager.setDefaultFonts(['hztxt', 'simsun', 'gdt'])
+    expect([...manager.defaultFonts]).toEqual(['hztxt', 'simsun', 'gdt'])
+
+    manager.setDefaultFonts('simkai')
+    expect([...manager.defaultFonts]).toEqual(['simkai'])
+  })
+
+  it('returns preset font names via getDefaultFontsPreset', () => {
+    expect(FontManager.instance.getDefaultFontsPreset('cjk')).toEqual(
+      DEFAULT_FONTS_PRESETS.cjk
+    )
+  })
+
+  it('loads default fonts configured by preset', async () => {
+    const loader = createFontLoader('https://cdn.example.com/fonts/')
+    vi.mocked(loader.load).mockResolvedValue([])
+    const manager = FontManager.instance
+    manager.setFontLoader(loader)
+    manager.setDefaultFonts('modern')
+
+    await manager.loadDefaultFont()
+
+    expect(loader.load).toHaveBeenCalledWith(['hztxt', 'simsun', 'gdt'])
   })
 
   it('loads fonts from cache without requesting the font URL', async () => {

--- a/packages/mtext-renderer/test/renderer/mtext.glyph-fallback.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.glyph-fallback.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it, vi } from 'vitest'
+import * as THREE from 'three'
+import { MTextColor } from '@mlightcad/mtext-parser'
+
+vi.mock('@mlightcad/mtext-parser', () => {
+  class FakeColor {
+    isAci = false
+    isRgb = true
+    rgbValue: number | null = 0xffffff
+    private _aci: number | null = null
+    private _rgb: [number, number, number] = [255, 255, 255]
+
+    get aci() {
+      return this._aci
+    }
+
+    set aci(value: number | null) {
+      this._aci = value
+      this.isAci = value !== null
+      if (value !== null) {
+        this.isRgb = false
+      }
+    }
+
+    get rgb() {
+      return this._rgb
+    }
+
+    set rgb(value: [number, number, number]) {
+      this._rgb = value
+      this.isRgb = true
+      this.isAci = false
+      this.rgbValue =
+        ((value[0] & 0xff) << 16) | ((value[1] & 0xff) << 8) | (value[2] & 0xff)
+      this._aci = null
+    }
+
+    copy() {
+      const out = new FakeColor()
+      out.isAci = this.isAci
+      out.isRgb = this.isRgb
+      out.rgbValue = this.rgbValue
+      out._aci = this._aci
+      out._rgb = [...this._rgb] as [number, number, number]
+      return out
+    }
+  }
+
+  class MTextContext {
+    continueStroke = false
+    color = new FakeColor()
+    align = 0
+    fontFace = { family: '', style: 'Regular', weight: 400 }
+    capHeight = { value: 1, isRelative: true }
+    widthFactor = { value: 1, isRelative: true }
+    charTrackingFactor = { value: 1, isRelative: true }
+    oblique = 0
+    paragraph = { align: 1 }
+  }
+
+  return {
+    MTextColor: FakeColor,
+    MTextContext,
+    MTextParagraphAlignment: {
+      DEFAULT: 0,
+      LEFT: 1,
+      CENTER: 2,
+      RIGHT: 3,
+      DISTRIBUTED: 5
+    }
+  }
+})
+
+vi.mock('../../src/font', () => ({
+  FontManager: class FontManager {}
+}))
+
+import {
+  MTextFormatOptions,
+  MTextProcessor
+} from '../../src/renderer/mtextProcessor'
+import { MTextFlowDirection, TextStyle } from '../../src/renderer/types'
+
+type GlyphShape = { width: number }
+
+function createShape(width: number): GlyphShape {
+  return { width }
+}
+
+function createGlyphFallbackProcessor(
+  style: Pick<TextStyle, 'font' | 'bigFont'>,
+  fontManager: Record<string, unknown>
+) {
+  const textStyle: TextStyle = {
+    name: 'standard',
+    standardFlag: 0,
+    fixedTextHeight: 0,
+    widthFactor: 1,
+    obliqueAngle: 0,
+    textGenerationFlag: 0,
+    lastHeight: 10,
+    font: style.font,
+    bigFont: style.bigFont ?? ''
+  }
+
+  const options: MTextFormatOptions = {
+    fontSize: 10,
+    widthFactor: 1,
+    lineSpaceFactor: 0.3,
+    horizontalAlignment: 1,
+    maxWidth: 0,
+    flowDirection: MTextFlowDirection.LEFT_TO_RIGHT,
+    byBlockColor: 0x123456,
+    byLayerColor: 0xabcdef,
+    removeFontExtension: true
+  }
+
+  const processor = new MTextProcessor(
+    textStyle,
+    {
+      byBlockColor: options.byBlockColor,
+      byLayerColor: options.byLayerColor,
+      layer: '0',
+      color: new MTextColor(256)
+    } as any,
+    {
+      getMeshBasicMaterial: vi
+        .fn()
+        .mockReturnValue(new THREE.MeshBasicMaterial({ color: 0xffffff })),
+      getLineBasicMaterial: vi
+        .fn()
+        .mockReturnValue(new THREE.LineBasicMaterial({ color: 0xffffff }))
+    } as any,
+    fontManager as any,
+    options
+  )
+
+  return processor
+}
+
+function resolveCharShape(
+  char: string,
+  fontName: string,
+  glyphs: Record<string, Record<string, GlyphShape | undefined>>
+): GlyphShape | undefined {
+  const fontGlyphs = glyphs[fontName]
+  return fontGlyphs?.[char]
+}
+
+describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
+  const primaryFont = 'txt'
+  const bigFontName = 'hztxt'
+  const defaultFont = 'simkai'
+  const cjkChar = '中'
+
+  it('uses bigFont when primary font lacks the glyph and does not use default fonts', () => {
+    const primaryShape = createShape(1)
+    const bigShape = createShape(2)
+    const defaultShape = createShape(3)
+
+    const glyphs: Record<string, Record<string, GlyphShape | undefined>> = {
+      [primaryFont]: {},
+      [bigFontName]: { [cjkChar]: bigShape },
+      [defaultFont]: { [cjkChar]: defaultShape }
+    }
+
+    const getCharShape = vi.fn((char: string, fontName: string) =>
+      resolveCharShape(char, fontName, glyphs)
+    )
+    const getCharShapeFromDefaults = vi.fn((char: string) =>
+      resolveCharShape(char, defaultFont, glyphs)
+    )
+
+    const processor = createGlyphFallbackProcessor(
+      { font: primaryFont, bigFont: bigFontName },
+      {
+        getFontScaleFactor: () => 1,
+        getFontType: () => 'shx' as const,
+        findAndReplaceFont: (name: string) => name,
+        getCharShape,
+        getCharShapeFromDefaults,
+        getNotFoundTextShape: () => undefined
+      }
+    )
+
+    getCharShape.mockClear()
+    getCharShapeFromDefaults.mockClear()
+
+    const shape = (processor as any).getCharShape(cjkChar)
+
+    expect(shape).toBe(bigShape)
+    expect(getCharShape).toHaveBeenCalledWith(cjkChar, primaryFont, 10)
+    expect(getCharShape).toHaveBeenCalledWith(cjkChar, bigFontName, 10)
+    expect(getCharShapeFromDefaults).not.toHaveBeenCalled()
+  })
+
+  it('uses default fonts when bigFont is empty and primary font lacks the glyph', () => {
+    const defaultShape = createShape(3)
+
+    const glyphs: Record<string, Record<string, GlyphShape | undefined>> = {
+      [primaryFont]: {},
+      [defaultFont]: { [cjkChar]: defaultShape }
+    }
+
+    const getCharShape = vi.fn((char: string, fontName: string) =>
+      resolveCharShape(char, fontName, glyphs)
+    )
+    const getCharShapeFromDefaults = vi.fn((char: string, size: number) => {
+      const shape = resolveCharShape(char, defaultFont, glyphs)
+      return shape ? { ...shape, width: shape.width * (size / 10) } : undefined
+    })
+
+    const processor = createGlyphFallbackProcessor(
+      { font: primaryFont, bigFont: '' },
+      {
+        getFontScaleFactor: () => 1,
+        getFontType: () => 'shx' as const,
+        findAndReplaceFont: (name: string) => name,
+        getCharShape,
+        getCharShapeFromDefaults,
+        getNotFoundTextShape: () => undefined
+      }
+    )
+
+    getCharShape.mockClear()
+    getCharShapeFromDefaults.mockClear()
+
+    const shape = (processor as any).getCharShape(cjkChar)
+
+    expect(shape).toEqual(defaultShape)
+    expect(getCharShape).toHaveBeenCalledTimes(1)
+    expect(getCharShape).toHaveBeenCalledWith(cjkChar, primaryFont, 10)
+    expect(getCharShapeFromDefaults).toHaveBeenCalledWith(cjkChar, 10)
+  })
+
+  it('falls back to default fonts when primary and bigFont both lack the glyph', () => {
+    const defaultShape = createShape(3)
+
+    const glyphs: Record<string, Record<string, GlyphShape | undefined>> = {
+      [primaryFont]: {},
+      [bigFontName]: {},
+      [defaultFont]: { [cjkChar]: defaultShape }
+    }
+
+    const getCharShape = vi.fn((char: string, fontName: string) =>
+      resolveCharShape(char, fontName, glyphs)
+    )
+    const getCharShapeFromDefaults = vi.fn((char: string) =>
+      resolveCharShape(char, defaultFont, glyphs)
+    )
+
+    const processor = createGlyphFallbackProcessor(
+      { font: primaryFont, bigFont: bigFontName },
+      {
+        getFontScaleFactor: () => 1,
+        getFontType: () => 'shx' as const,
+        findAndReplaceFont: (name: string) => name,
+        getCharShape,
+        getCharShapeFromDefaults,
+        getNotFoundTextShape: () => undefined
+      }
+    )
+
+    getCharShape.mockClear()
+    getCharShapeFromDefaults.mockClear()
+
+    const shape = (processor as any).getCharShape(cjkChar)
+
+    expect(shape).toBe(defaultShape)
+    expect(getCharShape).toHaveBeenCalledWith(cjkChar, primaryFont, 10)
+    expect(getCharShape).toHaveBeenCalledWith(cjkChar, bigFontName, 10)
+    expect(getCharShapeFromDefaults).toHaveBeenCalledWith(cjkChar, 10)
+  })
+
+  it('stops at primary font when the glyph is present there', () => {
+    const primaryShape = createShape(1)
+    const bigShape = createShape(2)
+
+    const glyphs: Record<string, Record<string, GlyphShape | undefined>> = {
+      [primaryFont]: { [cjkChar]: primaryShape },
+      [bigFontName]: { [cjkChar]: bigShape }
+    }
+
+    const getCharShape = vi.fn((char: string, fontName: string) =>
+      resolveCharShape(char, fontName, glyphs)
+    )
+    const getCharShapeFromDefaults = vi.fn()
+
+    const processor = createGlyphFallbackProcessor(
+      { font: primaryFont, bigFont: bigFontName },
+      {
+        getFontScaleFactor: () => 1,
+        getFontType: () => 'shx' as const,
+        findAndReplaceFont: (name: string) => name,
+        getCharShape,
+        getCharShapeFromDefaults,
+        getNotFoundTextShape: () => undefined
+      }
+    )
+
+    getCharShape.mockClear()
+    getCharShapeFromDefaults.mockClear()
+
+    const shape = (processor as any).getCharShape(cjkChar)
+
+    expect(shape).toBe(primaryShape)
+    expect(getCharShape).toHaveBeenCalledTimes(1)
+    expect(getCharShape).toHaveBeenCalledWith(cjkChar, primaryFont, 10)
+    expect(getCharShapeFromDefaults).not.toHaveBeenCalled()
+  })
+
+  it('treats whitespace-only bigFont as empty and skips the bigFont step', () => {
+    const defaultShape = createShape(3)
+
+    const glyphs: Record<string, Record<string, GlyphShape | undefined>> = {
+      [primaryFont]: {},
+      [defaultFont]: { [cjkChar]: defaultShape }
+    }
+
+    const getCharShape = vi.fn((char: string, fontName: string) =>
+      resolveCharShape(char, fontName, glyphs)
+    )
+    const getCharShapeFromDefaults = vi.fn((char: string) =>
+      resolveCharShape(char, defaultFont, glyphs)
+    )
+
+    const processor = createGlyphFallbackProcessor(
+      { font: primaryFont, bigFont: '   ' },
+      {
+        getFontScaleFactor: () => 1,
+        getFontType: () => 'shx' as const,
+        findAndReplaceFont: (name: string) => name,
+        getCharShape,
+        getCharShapeFromDefaults,
+        getNotFoundTextShape: () => undefined
+      }
+    )
+
+    getCharShape.mockClear()
+    getCharShapeFromDefaults.mockClear()
+
+    const shape = (processor as any).getCharShape(cjkChar)
+
+    expect(shape).toBe(defaultShape)
+    expect(getCharShape).toHaveBeenCalledTimes(1)
+    expect(getCharShapeFromDefaults).toHaveBeenCalledWith(cjkChar, 10)
+  })
+
+  it('uses not-found shape when no font provides the glyph', () => {
+    const notFoundShape = createShape(99)
+
+    const getCharShape = vi.fn(() => undefined)
+    const getCharShapeFromDefaults = vi.fn(() => undefined)
+    const getNotFoundTextShape = vi.fn(() => notFoundShape)
+
+    const processor = createGlyphFallbackProcessor(
+      { font: primaryFont, bigFont: bigFontName },
+      {
+        getFontScaleFactor: () => 1,
+        getFontType: () => 'shx' as const,
+        findAndReplaceFont: (name: string) => name,
+        getCharShape,
+        getCharShapeFromDefaults,
+        getNotFoundTextShape
+      }
+    )
+
+    getCharShape.mockClear()
+    getCharShapeFromDefaults.mockClear()
+    getNotFoundTextShape.mockClear()
+
+    const shape = (processor as any).getCharShape(cjkChar)
+
+    expect(shape).toBe(notFoundShape)
+    expect(getCharShape).toHaveBeenCalledWith(cjkChar, primaryFont, 10)
+    expect(getCharShape).toHaveBeenCalledWith(cjkChar, bigFontName, 10)
+    expect(getCharShapeFromDefaults).toHaveBeenCalledWith(cjkChar, 10)
+    expect(getNotFoundTextShape).toHaveBeenCalledWith(10)
+  })
+})

--- a/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
@@ -164,6 +164,7 @@ function createProcessor(
         }
       }
     },
+    getCharShapeFromDefaults: () => undefined,
     getNotFoundTextShape: () => undefined
   }
 
@@ -478,6 +479,7 @@ describe('MTextProcessor format state', () => {
           }
         }
       },
+      getCharShapeFromDefaults: () => undefined,
       getNotFoundTextShape: () => undefined
     }
 


### PR DESCRIPTION
## Summary

- Replace single `defaultFont` with an ordered `defaultFonts` set and AutoCAD-era presets (`r12r14`, `modern`, `cjk`, etc.) via `setDefaultFonts()`.
- Align MText glyph lookup with AutoCAD: primary font → bigFont → default fonts; `getCharShape` no longer scans all loaded fonts.
- Preload the full default font chain in main-thread and web-worker renderers; document API in README.

## Test plan

- [x] `npm test -- --run` in `packages/mtext-renderer` (86 tests)
- [ ] Verify DWG with missing glyphs uses bigFont before defaults
- [ ] Try `FontManager.instance.setDefaultFonts('r12r14')` in example app