### PR TITLE
feat: default font presets with SHX symbol font fallback

### DIFF
--- a/packages/example/index.html
+++ b/packages/example/index.html
@@ -119,9 +119,19 @@
         <h2>MText Renderer Example</h2>
         <div class="row">
             <div class="field">
-                <label for="font-select">Default Font:</label>
+                <label for="font-select">Text Style Font:</label>
                 <select id="font-select">
                     <option value="simkai">simkai</option>
+                </select>
+            </div>
+            <div class="field">
+                <label for="default-fonts-preset">Default Fonts Preset:</label>
+                <select id="default-fonts-preset">
+                    <option value="minimal">minimal (simkai)</option>
+                    <option value="r12r14">r12r14 (txt → gdt)</option>
+                    <option value="modern">modern (hztxt → gdt)</option>
+                    <option value="international">international (txt → gdt)</option>
+                    <option value="cjk">cjk (gbcbig → gdt)</option>
                 </select>
             </div>
             <div class="field">
@@ -166,6 +176,7 @@
             <button class="example-btn" data-example="controlCode">Control Code</button>
             <button class="example-btn" data-example="color">Color</button>
             <button class="example-btn" data-example="font">Font</button>
+            <button class="example-btn" data-example="defaultFonts">Default Fonts</button>
             <button class="example-btn" data-example="alignment">Alignment</button>
             <button class="example-btn" data-example="paragraph">Paragraph</button>
             <button class="example-btn" data-example="stacking">Stacking</button>

--- a/packages/example/index.html
+++ b/packages/example/index.html
@@ -127,7 +127,7 @@
             <div class="field">
                 <label for="default-fonts-preset">Default Fonts Preset:</label>
                 <select id="default-fonts-preset">
-                    <option value="minimal">minimal (simkai)</option>
+                    <option value="minimal" selected>minimal (txt → amgdt → gdt → simkai)</option>
                     <option value="r12r14">r12r14 (txt → gdt)</option>
                     <option value="modern">modern (hztxt → gdt)</option>
                     <option value="international">international (txt → gdt)</option>

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -46,10 +46,10 @@ class MTextRendererExample {
     complex:
       '{\\C1;\\W2;Title}\\P{\\C2;This is a paragraph with different styles.}\\P{\\C3;\\W1.5;Subtitle}\\P{\\C4;• First item\\P• Second item\\P• Third item}\\P{\\T2;Absolute character spacing: 2, }{\\T0.2x;Relative character spacing: 0.2}\\P{\\W0.8;Footer text}',
     controlCode:
-      '{Circle diameter dimensioning symbol: %%c},\\P{Degree symbol: %%d}\\P{Plus/minus tolerance symbol: %%p}\\P{A single percent sign: %%%}\\P{Unicode character: %%130 %%131}\\P{Toggles strikethrough on and off: %%kon, %%koff}\\P{Toggles overscoring on and off.: %%oon, %%ooff}\\P{Toggles underscoring  on and off.: %%uon, %%uoff}',
+      '{Circle diameter dimensioning symbol: %%c},\\P{Degree symbol: %%d}\\P{Plus/minus tolerance symbol: %%p}\\P{A single percent sign: %%%}\\P{Unicode character: %%130 %%131}\\P{Strikethrough toggle (%%k): %%kstruck%%k normal}\\P{Strikethrough explicit: %%konstruck%%koff normal}\\P{Overscore toggle (%%o): %%oover%%o normal}\\P{Overscore explicit: %%oonover%%ooff normal}\\P{Underscore toggle (%%u): %%uunder%%u normal}\\P{Underscore explicit: %%uonunder%%uoff normal}',
     color:
       '{\\C0;By Block}\\P{\\C1;Red Text}\\P{\\C2;Yellow Text}\\P{\\C3;Green Text}\\P{\\C4;Cyan Text}\\P{\\C5;Blue Text}\\P{\\C6;Magenta Text}\\P{\\C7;White Text}\\P{\\C256;By Layer}\\P{\\c16761035;Pink (0x0FFC0CB)}\\PRestore ByLayer\\P\\C1;Old Context Color: Red, {\\C2; New Context Color: Yellow, } Restored Context Color: Red',
-    font: '{\\C1;\\W2;\\FSimSun;SimSun 宋体}\\P{\\FArial;SimFang 仿宋（面积、材料、8、①④⑧⑩⑫㉔㉚）}\\P{\\C2;\\W0.5;\\FArial;Arial Text}\\P{\\C3;30;\\Faehalf.shx;SHX Text}\\P{\\C4;\\Fgbcbig.shx;东亚字符集字体}\\P{\\C5;\\Q1;\\FSimHei;SimHei Text，黑体}\\P{\\C6;\\Q0.5;\\FSimKai;SimKai 楷体}',
+    font: '{\\C1;\\W2;\\FSimSun;SimSun 宋体}\\P{\\F仿宋_gb2312;SimFang 仿宋（面积、材料、8、①④⑧⑩⑫㉔㉚）}\\P{\\C2;\\W0.5;\\FArial;Arial Text}\\P{\\C3;30;\\Faehalf.shx;SHX Text}\\P{\\C4;\\Fgbcbig.shx;东亚字符集字体}\\P{\\C5;\\Q1;\\FSimHei;SimHei Text，黑体}\\P{\\C6;\\Q0.5;\\FSimKai;SimKai 楷体}',
     defaultFonts:
       '{\\C1;Primary \\Ftxt;txt (SHX) — Latin: Hello %%c50}\\P{\\C2;CJK falls back via preset chain: 材料 装车 直径 你好}\\P{\\C3;Symbol %%c %%d %%p — may use gdt in chain}\\P{\\C4;Switch preset above and re-render to compare fallback order}',
     stacking:
@@ -260,12 +260,13 @@ class MTextRendererExample {
   private async applyDefaultFontsPreset(): Promise<void> {
     const preset = this.getSelectedDefaultFontsPreset()
     await this.unifiedRenderer.setDefaultFonts(preset)
-    const chain = this.unifiedRenderer.getDefaultFontsPreset(preset)
+    const textChain = this.unifiedRenderer.getDefaultFontsPreset(preset)
+    const symbolChain = this.unifiedRenderer.getSymbolFontsPreset(preset)
     const fontsToLoad = [
-      ...new Set([...chain, this.fontSelect.value, 'txt'])
+      ...new Set([...textChain, ...symbolChain, this.fontSelect.value])
     ]
     await this.unifiedRenderer.loadFonts(fontsToLoad)
-    this.statusDiv.textContent = `Preset "${preset}": ${chain.join(' → ')}`
+    this.statusDiv.textContent = `Preset "${preset}": text ${textChain.join(' → ')} | symbol ${symbolChain.join(' → ')}`
     this.statusDiv.style.color = '#0f0'
   }
 

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -1,6 +1,7 @@
 import {
   CharBox,
   CharBoxType,
+  DefaultFontsPreset,
   LineLayout,
   MTextAttachmentPoint,
   MTextColor,
@@ -29,6 +30,7 @@ class MTextRendererExample {
   private renderBtn: HTMLButtonElement
   private statusDiv: HTMLDivElement
   private fontSelect: HTMLSelectElement
+  private defaultFontsPresetSelect: HTMLSelectElement
   private showBoundingBoxCheckbox: HTMLInputElement
   private showCharBoxesCheckbox: HTMLInputElement
   private showLineBoxesCheckbox: HTMLInputElement
@@ -48,6 +50,8 @@ class MTextRendererExample {
     color:
       '{\\C0;By Block}\\P{\\C1;Red Text}\\P{\\C2;Yellow Text}\\P{\\C3;Green Text}\\P{\\C4;Cyan Text}\\P{\\C5;Blue Text}\\P{\\C6;Magenta Text}\\P{\\C7;White Text}\\P{\\C256;By Layer}\\P{\\c16761035;Pink (0x0FFC0CB)}\\PRestore ByLayer\\P\\C1;Old Context Color: Red, {\\C2; New Context Color: Yellow, } Restored Context Color: Red',
     font: '{\\C1;\\W2;\\FSimSun;SimSun 宋体}\\P{\\FArial;SimFang 仿宋（面积、材料、8、①④⑧⑩⑫㉔㉚）}\\P{\\C2;\\W0.5;\\FArial;Arial Text}\\P{\\C3;30;\\Faehalf.shx;SHX Text}\\P{\\C4;\\Fgbcbig.shx;东亚字符集字体}\\P{\\C5;\\Q1;\\FSimHei;SimHei Text，黑体}\\P{\\C6;\\Q0.5;\\FSimKai;SimKai 楷体}',
+    defaultFonts:
+      '{\\C1;Primary \\Ftxt;txt (SHX) — Latin: Hello %%c50}\\P{\\C2;CJK falls back via preset chain: 材料 装车 直径 你好}\\P{\\C3;Symbol %%c %%d %%p — may use gdt in chain}\\P{\\C4;Switch preset above and re-render to compare fallback order}',
     stacking:
       '%%c30{\\C3;\\H0.7x;\\S+0.021^  0;}\\P{\\C1;Basic Fractions:}\\P{\\C2;The value is \\S1/2; and \\S3/4; of the total.}\\P{\\C3;\\H0.16;Stacked Fractions:}\\P{\\C4;\\S1 2/3 4; represents \\Sx^ y; in the equation \\S1#2;.}\\P{\\C5;Complex Fractions:}\\P{\\C6;The result \\S1/2/3; is between \\S1^ 2^ 3; and \\S1#2#3;.}\\P{\\C7;Subscript Examples:}\\P{\\C8;H\\S^ 2;O (Water)}\\P{\\C9;CO\\S^ 2; (Carbon Dioxide)}\\P{\\C10;x\\S^ 2; + y\\S^ 2;}\\P{\\C11;Superscript Examples:}\\P{\\C12;E = mc\\S2^ ; (Energy)}\\P{\\C13;x\\S2^ ; + y\\S2^ ; = r\\S2^ ; (Circle)}\\P{\\C14;Combined Examples:}\\P{\\C15;H\\S^ 2;O\\S2^ ; (Hydrogen Peroxide)}\\P{\\C16;Fe\\S^ 2;+\\S3^ ; (Iron Ion)}',
     alignment:
@@ -101,6 +105,9 @@ class MTextRendererExample {
     this.statusDiv = document.getElementById('status') as HTMLDivElement
     this.fontSelect = document.getElementById(
       'font-select'
+    ) as HTMLSelectElement
+    this.defaultFontsPresetSelect = document.getElementById(
+      'default-fonts-preset'
     ) as HTMLSelectElement
     this.showBoundingBoxCheckbox = document.getElementById(
       'show-bounding-box'
@@ -174,12 +181,16 @@ class MTextRendererExample {
       await this.renderMText(content)
     })
 
-    // Font selection
+    // Text style font selection
     this.fontSelect.addEventListener('change', async () => {
-      const content = this.mtextInput.value
+      await this.applyDefaultFontsPreset()
+      await this.renderMText(this.mtextInput.value)
+    })
 
-      // Re-render MText with new font
-      await this.renderMText(content)
+    // Default fonts preset (fallback chain)
+    this.defaultFontsPresetSelect.addEventListener('change', async () => {
+      await this.applyDefaultFontsPreset()
+      await this.renderMText(this.mtextInput.value)
     })
 
     // Example buttons
@@ -242,6 +253,22 @@ class MTextRendererExample {
     })
   }
 
+  private getSelectedDefaultFontsPreset(): DefaultFontsPreset {
+    return this.defaultFontsPresetSelect.value as DefaultFontsPreset
+  }
+
+  private async applyDefaultFontsPreset(): Promise<void> {
+    const preset = this.getSelectedDefaultFontsPreset()
+    await this.unifiedRenderer.setDefaultFonts(preset)
+    const chain = this.unifiedRenderer.getDefaultFontsPreset(preset)
+    const fontsToLoad = [
+      ...new Set([...chain, this.fontSelect.value, 'txt'])
+    ]
+    await this.unifiedRenderer.loadFonts(fontsToLoad)
+    this.statusDiv.textContent = `Preset "${preset}": ${chain.join(' → ')}`
+    this.statusDiv.style.color = '#0f0'
+  }
+
   private async initializeFonts(isResetAvaiableFonts = true): Promise<void> {
     try {
       if (isResetAvaiableFonts) {
@@ -257,7 +284,6 @@ class MTextRendererExample {
           const option = document.createElement('option')
           option.value = font.name[0]
           option.textContent = font.name[0] // Use the first name from the array
-          // Set selected if this is the default font
           if (font.name[0] === 'simkai') {
             option.selected = true
           }
@@ -265,11 +291,7 @@ class MTextRendererExample {
         })
       }
 
-      // Load default fonts
-      const selectedFont = this.fontSelect.value
-      await this.unifiedRenderer.loadFonts([selectedFont])
-      this.statusDiv.textContent = 'Fonts loaded successfully'
-      this.statusDiv.style.color = '#0f0'
+      await this.applyDefaultFontsPreset()
     } catch (error) {
       console.error('Error loading fonts:', error)
       this.statusDiv.textContent = 'Error loading fonts'

--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -46,10 +46,10 @@
     "@mlightcad/shx-parser": "^1.3.2",
     "iconv-lite": "^0.7.0",
     "idb": "^8.0.3",
-    "opentype.js": "^1.3.4"
+    "opentype.js": "^2.0.0"
   },
   "devDependencies": {
-    "@types/opentype.js": "^1.3.8",
+    "@types/opentype.js": "^1.3.10",
     "@types/three": "^0.172.0",
     "vitest": "^3.2.4"
   },

--- a/packages/mtext-renderer/src/font/defaultFontLoader.ts
+++ b/packages/mtext-renderer/src/font/defaultFontLoader.ts
@@ -1,3 +1,4 @@
+import { getFileNameWithoutExtension } from '../common'
 import { FontInfo, FontLoader, FontLoadStatus } from './fontLoader'
 import { FontManager } from './fontManager'
 
@@ -86,7 +87,7 @@ export class DefaultFontLoader implements FontLoader {
    * @param fontNames - Array of font names to load
    * @returns Promise that resolves to an array of FontLoadStatus objects
    */
-  async load(fontNames: string[]) {
+  async load(fontNames: readonly string[]): Promise<FontLoadStatus[]> {
     if (fontNames == null || fontNames.length === 0) {
       return []
     }
@@ -94,10 +95,12 @@ export class DefaultFontLoader implements FontLoader {
 
     const alreadyLoadedStatuses: FontLoadStatus[] = []
     const fontsToLoad: FontInfo[] = []
+    const requestedFontInfos = new Map<string, FontInfo>()
     fontNames.forEach(font => {
       const lowerCaseFontName = font.toLowerCase()
       const fontInfo = this._avaiableFontMap.get(lowerCaseFontName)
       if (fontInfo) {
+        requestedFontInfos.set(lowerCaseFontName, fontInfo)
         if (FontManager.instance.isFontLoaded(lowerCaseFontName)) {
           alreadyLoadedStatuses.push({
             fontName: lowerCaseFontName,
@@ -111,20 +114,47 @@ export class DefaultFontLoader implements FontLoader {
     const newlyLoadedStatuses =
       await FontManager.instance.loadFonts(fontsToLoad)
 
-    // Merge and return statuses for all requested fonts, preserving order
+    // Merge and return statuses for all requested fonts, preserving order.
+    // FontManager reports status by file name; alias requests need remapping.
     const statusMap: Record<string, FontLoadStatus> = {}
     ;[...alreadyLoadedStatuses, ...newlyLoadedStatuses].forEach(s => {
       statusMap[s.fontName] = s
     })
     return fontNames.map(font => {
       const lowerCaseFontName = font.toLowerCase()
-      return (
-        statusMap[lowerCaseFontName] || {
-          fontName: lowerCaseFontName,
-          url: '',
-          status: 'NotFound'
+      const directStatus = statusMap[lowerCaseFontName]
+      if (directStatus) {
+        return directStatus
+      }
+
+      const fontInfo = requestedFontInfos.get(lowerCaseFontName)
+      if (fontInfo) {
+        if (FontManager.instance.isFontLoaded(lowerCaseFontName)) {
+          return {
+            fontName: lowerCaseFontName,
+            url: fontInfo.url,
+            status: 'Success'
+          }
         }
-      )
+
+        const fileBaseName = getFileNameWithoutExtension(
+          fontInfo.file
+        ).toLowerCase()
+        const loadedByFile = statusMap[fileBaseName]
+        if (loadedByFile) {
+          return {
+            fontName: lowerCaseFontName,
+            url: fontInfo.url,
+            status: loadedByFile.status
+          }
+        }
+      }
+
+      return {
+        fontName: lowerCaseFontName,
+        url: '',
+        status: 'NotFound'
+      }
     })
   }
 
@@ -135,7 +165,7 @@ export class DefaultFontLoader implements FontLoader {
     const fontMap = this._avaiableFontMap
     this._avaiableFonts.forEach(font => {
       font.name.forEach(name => {
-        fontMap.set(name.toLocaleLowerCase(), font)
+        fontMap.set(name.toLowerCase(), font)
       })
     })
   }

--- a/packages/mtext-renderer/src/font/defaultFontsPresets.ts
+++ b/packages/mtext-renderer/src/font/defaultFontsPresets.ts
@@ -5,30 +5,46 @@
  * referenced during the AutoCAD R12/R14 era, then simplified in later releases.
  */
 export type DefaultFontsPreset =
-  /** Single mesh fallback; matches the library default. */
+  /** SHX symbol fonts plus mesh CJK fallback (library default). */
   | 'minimal'
-  /** Classic R12/R14 stack: SHX basics, GB big font, then mesh CJK and GDT. */
+  /** Classic R12/R14 stack: SHX basics, GB big font, then mesh CJK and AMGDT. */
   | 'r12r14'
-  /** Later-era stack: hztxt big font with simsun and GDT symbols. */
+  /** Later-era stack: hztxt big font with simsun and AMGDT symbols. */
   | 'modern'
-  /** Western SHX fonts plus simsun and GDT; no CJK-specific SHX big fonts. */
+  /** Western SHX fonts plus simsun and AMGDT; no CJK-specific SHX big fonts. */
   | 'international'
   /** Broad CJK coverage: both GB big-font SHX files plus common mesh fallbacks. */
   | 'cjk'
 
 /**
- * Predefined default font fallback chains.
- * Font names are logical names without file extensions; earlier entries are tried first.
+ * Predefined text-font fallback chains (primary / big-font substitutes and CJK
+ * mesh fallbacks). Symbol fonts such as `amgdt` are configured separately via
+ * {@link SYMBOL_FONTS_PRESETS}.
  */
 export const DEFAULT_FONTS_PRESETS: Record<
   DefaultFontsPreset,
   readonly string[]
 > = {
-  minimal: ['simkai'],
-  r12r14: ['txt', 'simplex', 'romans', 'gbcbig', 'simsun', 'gdt'],
-  modern: ['hztxt', 'simsun', 'gdt'],
-  international: ['txt', 'simplex', 'romans', 'simsun', 'gdt'],
-  cjk: ['gbcbig', 'hztxt', 'simsun', 'simkai', 'gdt']
+  minimal: ['txt', 'simkai'],
+  r12r14: ['txt', 'simplex', 'romans', 'gbcbig', 'simsun'],
+  modern: ['hztxt', 'simsun'],
+  international: ['txt', 'simplex', 'romans', 'simsun'],
+  cjk: ['gbcbig', 'hztxt', 'simsun', 'simkai']
+}
+
+/**
+ * GDT / SHX symbol-font chains used for AutoCAD control codes (`%%c`, `%%d`,
+ * `%%p`, `%%130`, etc.). Earlier entries are tried first.
+ */
+export const SYMBOL_FONTS_PRESETS: Record<
+  DefaultFontsPreset,
+  readonly string[]
+> = {
+  minimal: ['amgdt'],
+  r12r14: ['amgdt'],
+  modern: ['amgdt'],
+  international: ['amgdt'],
+  cjk: ['amgdt']
 }
 
 export function isDefaultFontsPreset(

--- a/packages/mtext-renderer/src/font/fontLoader.ts
+++ b/packages/mtext-renderer/src/font/fontLoader.ts
@@ -46,7 +46,7 @@ export interface FontLoader {
    * @param fontNames - Array of font names to load
    * @returns Promise that resolves to an array of FontLoadStatus objects indicating the load status of each font
    */
-  load(fontNames: string[]): Promise<FontLoadStatus[]>
+  load(fontNames: readonly string[]): Promise<FontLoadStatus[]>
 
   /**
    * Retrieves information about all available fonts in the system

--- a/packages/mtext-renderer/src/font/fontManager.ts
+++ b/packages/mtext-renderer/src/font/fontManager.ts
@@ -12,7 +12,8 @@ import { DefaultFontLoader } from './defaultFontLoader'
 import {
   DEFAULT_FONTS_PRESETS,
   DefaultFontsPreset,
-  isDefaultFontsPreset
+  isDefaultFontsPreset,
+  SYMBOL_FONTS_PRESETS
 } from './defaultFontsPresets'
 import { FontData, FontType } from './font'
 import { FontFactory } from './fontFactory'
@@ -67,6 +68,12 @@ export class FontManager {
    * Insertion order is preserved; earlier entries are tried first.
    */
   public defaultFonts = new Set<string>(['simkai'])
+  /**
+   * GDT / SHX symbol fonts for AutoCAD control-code glyphs (`%%c`, `%%d`, `%%p`,
+   * `%%nnn`, etc.). Separate from {@link defaultFonts} so text fallbacks are not
+   * polluted by symbol-font code-point matches.
+   */
+  public symbolFonts = new Set<string>(['amgdt'])
 
   /** Event managers for font-related events */
   public readonly events = {
@@ -133,10 +140,30 @@ export class FontManager {
   setDefaultFonts(fonts: DefaultFontsPreset | string | readonly string[]) {
     if (typeof fonts === 'string' && isDefaultFontsPreset(fonts)) {
       this.defaultFonts = new Set(DEFAULT_FONTS_PRESETS[fonts])
+      this.symbolFonts = new Set(SYMBOL_FONTS_PRESETS[fonts])
       return
     }
     const list = typeof fonts === 'string' ? [fonts] : [...fonts]
     this.defaultFonts = new Set(list)
+  }
+
+  /**
+   * Sets the symbol-font fallback chain for AutoCAD control-code glyphs.
+   *
+   * Pass a {@link DefaultFontsPreset} name to apply a predefined symbol stack,
+   * or pass one or more font names to define a custom chain.
+   *
+   * @param fonts - A preset name, a single font name, or an ordered list of font names
+   */
+  setSymbolFonts(fonts: DefaultFontsPreset): void
+  setSymbolFonts(fonts: string | readonly string[]): void
+  setSymbolFonts(fonts: DefaultFontsPreset | string | readonly string[]) {
+    if (typeof fonts === 'string' && isDefaultFontsPreset(fonts)) {
+      this.symbolFonts = new Set(SYMBOL_FONTS_PRESETS[fonts])
+      return
+    }
+    const list = typeof fonts === 'string' ? [fonts] : [...fonts]
+    this.symbolFonts = new Set(list)
   }
 
   /**
@@ -145,6 +172,21 @@ export class FontManager {
    */
   getDefaultFontsPreset(preset: DefaultFontsPreset): readonly string[] {
     return DEFAULT_FONTS_PRESETS[preset]
+  }
+
+  /**
+   * Returns the symbol-font names for a predefined preset.
+   * @param preset - The preset to look up
+   */
+  getSymbolFontsPreset(preset: DefaultFontsPreset): readonly string[] {
+    return SYMBOL_FONTS_PRESETS[preset]
+  }
+
+  /**
+   * Font names that should be loaded for the active default and symbol chains.
+   */
+  getFontsToLoad(): readonly string[] {
+    return [...new Set([...this.defaultFonts, ...this.symbolFonts])]
   }
 
   /**
@@ -170,20 +212,20 @@ export class FontManager {
    * @returns True if every font in `defaultFonts` is loaded. False otherwise.
    */
   isDefaultFontLoaded() {
-    for (const fontName of this.defaultFonts) {
+    for (const fontName of this.getFontsToLoad()) {
       if (this.loadedFontMap.get(fontName.toLowerCase()) == null) {
         return false
       }
     }
-    return this.defaultFonts.size > 0
+    return this.defaultFonts.size > 0 || this.symbolFonts.size > 0
   }
 
   /**
-   * Loads all default fonts
+   * Loads all default and symbol fonts
    * @returns Promise that resolves to the font load statuses
    */
   async loadDefaultFont() {
-    return await this.loadFontsByNames([...this.defaultFonts])
+    return await this.loadFontsByNames(this.getFontsToLoad())
   }
 
   /**
@@ -191,9 +233,11 @@ export class FontManager {
    * @param names - Font names to load.
    * @returns Promise that resolves to an array of font load statuses
    */
-  async loadFontsByNames(names: string | string[]): Promise<FontLoadStatus[]> {
-    names = Array.isArray(names) ? names : [names]
-    return await this.fontLoader.load(names)
+  async loadFontsByNames(
+    names: string | readonly string[]
+  ): Promise<FontLoadStatus[]> {
+    const list = typeof names === 'string' ? [names] : [...names]
+    return await this.fontLoader.load(list)
   }
 
   /**
@@ -329,18 +373,29 @@ export class FontManager {
     char: string,
     size: number
   ): BaseTextShape | undefined {
-    const fallbackFont = this.getFontFromDefaults(char)
-    return fallbackFont?.getCharShape(char, size)
+    for (const fontName of this.defaultFonts) {
+      const font = this.loadedFontMap.get(fontName.toLowerCase())
+      const shape = font?.getCharShape(char, size)
+      if (shape) {
+        return shape
+      }
+    }
+    return undefined
   }
 
   /**
-   * Gets the first loaded default font that contains the specified character.
+   * Gets the text shape from configured GDT / symbol fonts (e.g. `amgdt.shx`).
+   * Used for AutoCAD percent codes and other symbol-font code points.
    */
-  private getFontFromDefaults(char: string): BaseFont | undefined {
-    for (const fontName of this.defaultFonts) {
+  public getCharShapeFromSymbolFonts(
+    char: string,
+    size: number
+  ): BaseTextShape | undefined {
+    for (const fontName of this.symbolFonts) {
       const font = this.loadedFontMap.get(fontName.toLowerCase())
-      if (font?.hasChar(char)) {
-        return font
+      const shape = font?.getCharShape(char, size)
+      if (shape) {
+        return shape
       }
     }
     return undefined
@@ -424,14 +479,14 @@ export class FontManager {
     const data = await FontCacheManager.instance.get(fontName)
     if (data) {
       const font = FontFactory.instance.createFont(data)
-      this.loadedFontMap.set(fontName, font)
+      this.registerFontInMap(fontName, font)
     } else {
       const buffer = (await this.loader.loadAsync(fontInfo.url)) as ArrayBuffer
       fontData.data = buffer
       const font = FontFactory.instance.createFont(fontData)
       if (font) {
         fontInfo.name.forEach(name => font.names.add(name))
-        this.loadedFontMap.set(fontName, font)
+        this.registerFontInMap(fontName, font)
         if (this.enableFontCache) {
           await FontCacheManager.instance.set(fontName, fontData)
         }
@@ -470,8 +525,18 @@ export class FontManager {
         continue
       }
       const font = FontFactory.instance.createFont(fontFileData)
-      this.loadedFontMap.set(name, font)
+      this.registerFontInMap(name, font)
     }
+  }
+
+  /**
+   * Registers a loaded font under its primary name and all aliases.
+   */
+  private registerFontInMap(primaryName: string, font: BaseFont) {
+    this.loadedFontMap.set(primaryName.toLowerCase(), font)
+    font.names.forEach(name => {
+      this.loadedFontMap.set(name.toLowerCase(), font)
+    })
   }
 
   /**
@@ -501,8 +566,16 @@ export class FontManager {
     if (fontToRelease == null) {
       this.loadedFontMap.clear()
       return true
-    } else {
-      return this.loadedFontMap.delete(fontToRelease)
     }
+    const font = this.loadedFontMap.get(fontToRelease.toLowerCase())
+    if (!font) {
+      return false
+    }
+    for (const [key, value] of this.loadedFontMap) {
+      if (value === font) {
+        this.loadedFontMap.delete(key)
+      }
+    }
+    return true
   }
 }

--- a/packages/mtext-renderer/src/font/meshFont.ts
+++ b/packages/mtext-renderer/src/font/meshFont.ts
@@ -176,12 +176,26 @@ export class MeshFont extends BaseFont {
   }
 
   /**
+   * Whether opentype maps the character to a real glyph (not .notdef at index 0).
+   *
+   * opentype.js ≤1.3.4: {@link OpenTypeFont.hasChar} used `charToGlyphIndex(c) !== null`,
+   * but CmapEncoding returns 0 for missing code points — see
+   * https://github.com/opentypejs/opentype.js/issues/330 (fixed in 2.0.0).
+   * We keep `index > 0` here so hasChar stays aligned with {@link _loadGlyphIfNeeded}.
+   */
+  private opentypeHasGlyph(char: string): boolean {
+    if (!this.opentypeFont) return false
+    const index = this.opentypeFont.charToGlyphIndex(char)
+    return index != null && index > 0
+  }
+
+  /**
    * Return true if this font contains glyph of the specified character. Otherwise, return false.
    * @param char - The character to check
    * @returns True if this font contains glyph of the specified character. Otherwise, return false.
    */
   hasChar(char: string): boolean {
-    return this.opentypeFont.hasChar(char)
+    return this.opentypeHasGlyph(char)
   }
 
   /**
@@ -207,17 +221,7 @@ export class MeshFont extends BaseFont {
       return
     }
 
-    // Notes:
-    // Please don't use method `hasChar`. Its implementation is as follows.
-    // ```
-    // return this.encoding.charToGlyphIndex(n) !== null;
-    // ```
-    // Method `charToGlyphIndex` returns undefined if not found. However, it
-    // uses '!==null' to check whether it is found or not.
-    //
-    // I checked opentype.js source code and found it was fixed. However, it
-    // isn't included in latest released (1.3.4) yet.
-    if (this.opentypeFont.charToGlyphIndex(char) > 0) {
+    if (this.opentypeHasGlyph(char)) {
       const glyph = this.opentypeFont.charToGlyph(char)
       if (!glyph || !glyph.path) return
 

--- a/packages/mtext-renderer/src/renderer/mtext.ts
+++ b/packages/mtext-renderer/src/renderer/mtext.ts
@@ -11,6 +11,7 @@ import { FontManager } from '../font'
 import { buildCharBoxesFromObject } from './charBoxUtils'
 import { resolveMTextWrapWidth } from './mtextDataUtils'
 import { MTextFormatOptions, MTextProcessor } from './mtextProcessor'
+import { expandPercentControlCodes } from './percentControlCodes'
 import { StyleManager } from './styleManager'
 import {
   CharBox,
@@ -535,7 +536,7 @@ export class MText extends THREE.Object3D {
       this.fontManager,
       textLineFormatOptions
     )
-    const parser = new MTextParser(mtextData.text, context, {
+    const parser = new MTextParser(expandPercentControlCodes(mtextData.text), context, {
       resetParagraphParameters: true,
       yieldPropertyCommands: true
     })

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -15,6 +15,7 @@ import {
   LINE_SPACING_SCALE_FACTOR,
   STACK_VERTICAL_SHIFT_FACTOR
 } from './constants'
+import { getShxControlCodeCandidates } from './shxSymbolControlCodes'
 import { StyleManager } from './styleManager'
 import {
   CharBox,
@@ -1651,6 +1652,25 @@ export class MTextProcessor {
    * @returns Return the text shape of the specified character
    */
   private getCharShape(char: string) {
+    // Named AutoCAD percent codes (%%c/%%d/%%p) are expanded to Unicode by
+    // mtext-parser before rendering, but AutoCAD itself resolves those symbols
+    // from GDT/symbol SHX fonts (e.g. amgdt.shx) via legacy control-code code
+    // points—not from the primary text font's Unicode glyphs. Try the ordered
+    // SHX control-code candidates in the default symbol-font chain first so
+    // rendering matches AutoCAD and avoids incorrect glyphs from the text font.
+    for (const controlChar of getShxControlCodeCandidates(char)) {
+      const symbolShape = this.fontManager.getCharShapeFromSymbolFonts(
+        controlChar,
+        this.currentFontSize
+      )
+      if (symbolShape) {
+        if (this.currentFontSize > this._maxFontSize) {
+          this._maxFontSize = this.currentFontSize
+        }
+        return symbolShape
+      }
+    }
+
     let shape = this.fontManager.getCharShape(
       char,
       this.currentFont,
@@ -1666,6 +1686,12 @@ export class MTextProcessor {
     }
     if (!shape) {
       shape = this.fontManager.getCharShapeFromDefaults(
+        char,
+        this.currentFontSize
+      )
+    }
+    if (!shape) {
+      shape = this.fontManager.getCharShapeFromSymbolFonts(
         char,
         this.currentFontSize
       )

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -1909,6 +1909,22 @@ export class MTextProcessor {
   }
 
   /**
+   * Merges line-based geometries for LineSegments. SHX glyphs use indexed
+   * BufferGeometry while fraction/divider decorations omit an index; normalize
+   * to non-indexed form so mergeGeometries accepts the batch.
+   */
+  private mergeLineGeometries(
+    geometries: THREE.BufferGeometry[]
+  ): THREE.BufferGeometry {
+    const normalized = geometries.map(geometry =>
+      geometry.index != null ? geometry.toNonIndexed() : geometry
+    )
+    return normalized.length > 1
+      ? (mergeGeometries(normalized) ?? normalized[0])
+      : normalized[0]
+  }
+
+  /**
    * Convert the text shape geometries to three.js object
    * @param geometries Input text shape geometries
    * @returns Return three.js object created from the specified text shape geometries
@@ -1954,10 +1970,7 @@ export class MTextProcessor {
       ...geometries.filter(g => !(g instanceof THREE.ShapeGeometry))
     ]
     if (allLineGeoms.length > 0) {
-      const mergedLineGeom =
-        allLineGeoms.length > 1
-          ? mergeGeometries(allLineGeoms)
-          : allLineGeoms[0]
+      const mergedLineGeom = this.mergeLineGeometries(allLineGeoms)
       const lineMesh = new THREE.LineSegments(mergedLineGeom, lineMaterial)
       lineMesh.userData.bboxIntersectionCheck = true
       lineMesh.userData.charBoxType = charBoxType

--- a/packages/mtext-renderer/src/renderer/percentControlCodes.ts
+++ b/packages/mtext-renderer/src/renderer/percentControlCodes.ts
@@ -1,0 +1,53 @@
+/**
+ * AutoCAD percent-sign control codes that toggle or set text decorations.
+ *
+ * Standard TEXT codes (AutoCAD 2026 help):
+ * - `%%k` toggles strikethrough
+ * - `%%o` toggles overscore
+ * - `%%u` toggles underscore
+ *
+ * Some drawings also use explicit on/off spellings such as `%%kon` / `%%koff`.
+ * The upstream mtext parser only understands `\K`/`\k`, `\O`/`\o`, and `\L`/`\l`,
+ * so we expand percent codes to those inline commands before parsing.
+ */
+const EXPLICIT_PERCENT_CODES: ReadonlyArray<readonly [RegExp, string]> = [
+  [/%%koff/gi, '\\k'],
+  [/%%kon/gi, '\\K'],
+  [/%%ooff/gi, '\\o'],
+  [/%%oon/gi, '\\O'],
+  [/%%uoff/gi, '\\l'],
+  [/%%uon/gi, '\\L']
+]
+
+const TOGGLE_PERCENT_CODE = /%%([kou])/gi
+
+/**
+ * Expands AutoCAD `%%` stroke control codes into `\K`/`\k`, `\O`/`\o`, and `\L`/`\l`
+ * inline formatting commands understood by {@link @mlightcad/mtext-parser}.
+ */
+export function expandPercentControlCodes(text: string): string {
+  let result = text
+  for (const [pattern, replacement] of EXPLICIT_PERCENT_CODES) {
+    result = result.replace(pattern, replacement)
+  }
+
+  let strikeThrough = false
+  let overline = false
+  let underline = false
+
+  return result.replace(TOGGLE_PERCENT_CODE, (_, letter: string) => {
+    switch (letter.toLowerCase()) {
+      case 'k':
+        strikeThrough = !strikeThrough
+        return strikeThrough ? '\\K' : '\\k'
+      case 'o':
+        overline = !overline
+        return overline ? '\\O' : '\\o'
+      case 'u':
+        underline = !underline
+        return underline ? '\\L' : '\\l'
+      default:
+        return `%%${letter}`
+    }
+  })
+}

--- a/packages/mtext-renderer/src/renderer/shxSymbolControlCodes.ts
+++ b/packages/mtext-renderer/src/renderer/shxSymbolControlCodes.ts
@@ -1,0 +1,88 @@
+/**
+ * AutoCAD percent-sign symbol codes (`%%c`, `%%d`, `%%p`) and their SHX
+ * symbol-font code points.
+ *
+ * Named percent codes are expanded by {@link @mlightcad/mtext-parser} into Unicode
+ * before rendering. AutoCAD itself does not rely on those Unicode code points in
+ * the primary text font; it resolves the symbols through GDT / symbol SHX fonts
+ * such as `amgdt.shx` using legacy control-code code points.
+ *
+ * References:
+ * - AutoCAD "Text Symbols and Special Characters"
+ * - AutoCAD "Control Codes and Special Characters" (`%%nnn`)
+ * - Legacy SHX convention: 127 = degree, 128 = plus/minus, 129 = diameter
+ * - Modern `amgdt.shx`: degree at 126/176, ± at 177, diameter at U+2205 (∅);
+ *   code 130 = angle (∠). Legacy bytes 127–128 must not be used when CJK mesh
+ *   fonts in the fallback chain expose unrelated glyphs at those code points.
+ */
+export type AutoCadPercentSymbolCode = 'c' | 'd' | 'p'
+
+/**
+ * Ordered SHX byte-code candidates for each named AutoCAD percent symbol.
+ * Earlier entries are preferred when present in the symbol-font fallback chain
+ * Earlier entries are preferred when present in {@link FontManager.symbolFonts}.
+ */
+export const AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES: Readonly<
+  Record<AutoCadPercentSymbolCode, readonly number[]>
+> = {
+  /** %%c — circle diameter dimensioning symbol (legacy SHX position) */
+  c: [129],
+  /** %%d — degree symbol (126/176 in amgdt.shx; avoid legacy 127) */
+  d: [126, 176],
+  /** %%p — plus/minus tolerance symbol (177 in amgdt.shx; avoid legacy 128) */
+  p: [177]
+}
+
+/**
+ * Unicode characters to try in GDT / symbol SHX fonts when legacy control codes
+ * are absent (e.g. `amgdt.shx` stores diameter at U+2205, not at byte 129/130).
+ */
+const PERCENT_SYMBOL_FONT_UNICODE_ALTERNATES: Readonly<
+  Record<AutoCadPercentSymbolCode, readonly string[]>
+> = {
+  c: ['\u2205'], // ∅ — AutoCAD .NET diameter; present in amgdt.shx
+  d: [],
+  p: []
+}
+
+/**
+ * Unicode characters produced from percent codes (or documented AutoCAD aliases)
+ * mapped back to their percent-symbol key.
+ */
+const UNICODE_TO_PERCENT_SYMBOL: Readonly<
+  Record<string, AutoCadPercentSymbolCode>
+> = {
+  '\u00D8': 'c', // Ø — used by mtext-parser for %%c
+  '\u2205': 'c', // ∅ — documented in AutoCAD .NET API for diameter
+  '\u00B0': 'd', // ° — %%d
+  '\u00B1': 'p' // ± — %%p
+}
+
+/**
+ * Returns whether a character originated from an AutoCAD named percent symbol.
+ */
+export function isAutoCadPercentSymbolChar(char: string): boolean {
+  return UNICODE_TO_PERCENT_SYMBOL[char] != null
+}
+
+/**
+ * Returns ordered SHX control-code characters to try in symbol-font fallbacks
+ * for an AutoCAD percent-symbol Unicode expansion.
+ */
+export function getShxControlCodeCandidates(char: string): readonly string[] {
+  const symbol = UNICODE_TO_PERCENT_SYMBOL[char]
+  if (symbol == null) {
+    return []
+  }
+  const controlCodes = AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES[symbol].map(code =>
+    String.fromCharCode(code)
+  )
+  return [...controlCodes, ...PERCENT_SYMBOL_FONT_UNICODE_ALTERNATES[symbol]]
+}
+
+/**
+ * @deprecated Use {@link getShxControlCodeCandidates} instead.
+ */
+export function getShxControlCodeChar(char: string): string | undefined {
+  return getShxControlCodeCandidates(char)[0]
+}

--- a/packages/mtext-renderer/src/worker/baseRenderer.ts
+++ b/packages/mtext-renderer/src/worker/baseRenderer.ts
@@ -83,7 +83,7 @@ export interface MTextBaseRenderer {
    * @param fonts Font names to load (without extension for built-ins).
    * @returns A Promise with the list of fonts that were processed.
    */
-  loadFonts(fonts: string[]): Promise<{ loaded: string[] }>
+  loadFonts(fonts: readonly string[]): Promise<{ loaded: string[] }>
 
   /**
    * Retrieve the list of fonts that can be used by the renderer.

--- a/packages/mtext-renderer/src/worker/mainThreadRenderer.ts
+++ b/packages/mtext-renderer/src/worker/mainThreadRenderer.ts
@@ -89,9 +89,9 @@ export class MainThreadRenderer implements MTextBaseRenderer {
   /**
    * Load fonts in the main thread
    */
-  async loadFonts(fonts: string[]): Promise<{ loaded: string[] }> {
+  async loadFonts(fonts: readonly string[]): Promise<{ loaded: string[] }> {
     await this.fontManager.loadFontsByNames(fonts)
-    return { loaded: fonts }
+    return { loaded: [...fonts] }
   }
 
   /**
@@ -109,7 +109,7 @@ export class MainThreadRenderer implements MTextBaseRenderer {
   private async ensureInitialized() {
     if (!this.isInitialized) {
       // Guarantee the default font is loaded
-      await this.loadFonts([...FontManager.instance.defaultFonts])
+      await this.loadFonts(FontManager.instance.getFontsToLoad())
       this.isInitialized = true
     }
   }

--- a/packages/mtext-renderer/src/worker/mtextWorker.ts
+++ b/packages/mtext-renderer/src/worker/mtextWorker.ts
@@ -14,7 +14,12 @@ import {
 
 // Worker message types
 interface WorkerMessage {
-  type: 'render' | 'loadFonts' | 'setFontUrl' | 'getAvailableFonts'
+  type:
+    | 'render'
+    | 'loadFonts'
+    | 'setDefaultFonts'
+    | 'setFontUrl'
+    | 'getAvailableFonts'
   id: string
   data?: {
     mtextContent?: unknown
@@ -26,7 +31,13 @@ interface WorkerMessage {
 }
 
 interface WorkerResponse {
-  type: 'render' | 'loadFonts' | 'setFontUrl' | 'getAvailableFonts' | 'error'
+  type:
+    | 'render'
+    | 'loadFonts'
+    | 'setDefaultFonts'
+    | 'setFontUrl'
+    | 'getAvailableFonts'
+    | 'error'
   id: string
   success: boolean
   data?: unknown
@@ -93,6 +104,19 @@ self.addEventListener('message', async (event: MessageEvent<WorkerMessage>) => {
           id,
           success: true,
           data: { loaded: fonts }
+        } as WorkerResponse)
+        break
+      }
+
+      case 'setDefaultFonts': {
+        if (!data) throw new Error('Missing data for setDefaultFonts message')
+        const { fonts } = data as { fonts: string[] }
+        fontManager.setDefaultFonts(fonts)
+        self.postMessage({
+          type: 'setDefaultFonts',
+          id,
+          success: true,
+          data: { fonts: [...fontManager.defaultFonts] }
         } as WorkerResponse)
         break
       }

--- a/packages/mtext-renderer/src/worker/mtextWorker.ts
+++ b/packages/mtext-renderer/src/worker/mtextWorker.ts
@@ -110,13 +110,20 @@ self.addEventListener('message', async (event: MessageEvent<WorkerMessage>) => {
 
       case 'setDefaultFonts': {
         if (!data) throw new Error('Missing data for setDefaultFonts message')
-        const { fonts } = data as { fonts: string[] }
+        const { fonts, symbolFonts } = data as {
+          fonts: string[]
+          symbolFonts: string[]
+        }
         fontManager.setDefaultFonts(fonts)
+        fontManager.setSymbolFonts(symbolFonts)
         self.postMessage({
           type: 'setDefaultFonts',
           id,
           success: true,
-          data: { fonts: [...fontManager.defaultFonts] }
+          data: {
+            fonts: [...fontManager.defaultFonts],
+            symbolFonts: [...fontManager.symbolFonts]
+          }
         } as WorkerResponse)
         break
       }

--- a/packages/mtext-renderer/src/worker/unifiedRenderer.ts
+++ b/packages/mtext-renderer/src/worker/unifiedRenderer.ts
@@ -134,8 +134,10 @@ export class UnifiedRenderer {
     fonts: DefaultFontsPreset | string | readonly string[]
   ): Promise<void> {
     FontManager.instance.setDefaultFonts(fonts)
-    const chain = [...FontManager.instance.defaultFonts]
-    await this.webWorkerRenderer.setDefaultFonts(chain)
+    await this.webWorkerRenderer.setDefaultFonts(
+      [...FontManager.instance.defaultFonts],
+      [...FontManager.instance.symbolFonts]
+    )
   }
 
   /**
@@ -146,9 +148,16 @@ export class UnifiedRenderer {
   }
 
   /**
+   * Returns symbol-font names for a predefined preset.
+   */
+  getSymbolFontsPreset(preset: DefaultFontsPreset): readonly string[] {
+    return FontManager.instance.getSymbolFontsPreset(preset)
+  }
+
+  /**
    * Load fonts using the current mode
    */
-  async loadFonts(fonts: string[]): Promise<{ loaded: string[] }> {
+  async loadFonts(fonts: readonly string[]): Promise<{ loaded: string[] }> {
     return this.renderer.loadFonts(fonts)
   }
 

--- a/packages/mtext-renderer/src/worker/unifiedRenderer.ts
+++ b/packages/mtext-renderer/src/worker/unifiedRenderer.ts
@@ -1,3 +1,4 @@
+import { DefaultFontsPreset, FontManager } from '../font'
 import { StyleManager } from '../renderer'
 import {
   ColorSettings,
@@ -124,6 +125,24 @@ export class UnifiedRenderer {
       textStyle,
       colorSettings
     )
+  }
+
+  /**
+   * Sets the default font fallback chain on the active renderer and workers.
+   */
+  async setDefaultFonts(
+    fonts: DefaultFontsPreset | string | readonly string[]
+  ): Promise<void> {
+    FontManager.instance.setDefaultFonts(fonts)
+    const chain = [...FontManager.instance.defaultFonts]
+    await this.webWorkerRenderer.setDefaultFonts(chain)
+  }
+
+  /**
+   * Returns font names for a predefined default-font preset.
+   */
+  getDefaultFontsPreset(preset: DefaultFontsPreset): readonly string[] {
+    return FontManager.instance.getDefaultFontsPreset(preset)
   }
 
   /**

--- a/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
+++ b/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
@@ -85,9 +85,17 @@ type SetFontUrlMessage = WorkerMessageBase<
 
 type GetAvailableFontsMessage = WorkerMessageBase<'getAvailableFonts'>
 
+type SetDefaultFontsMessage = WorkerMessageBase<
+  'setDefaultFonts',
+  {
+    fonts: string[]
+  }
+>
+
 type WorkerMessageTyped =
   | RenderMessage
   | LoadFontsMessage
+  | SetDefaultFontsMessage
   | SetFontUrlMessage
   | GetAvailableFontsMessage
 
@@ -112,9 +120,17 @@ type GetAvailableFontsResponse = WorkerResponseBase<
   }
 >
 
+type SetDefaultFontsResponse = WorkerResponseBase<
+  'setDefaultFonts',
+  {
+    fonts: string[]
+  }
+>
+
 type WorkerResponseTyped =
   | RenderResponse
   | LoadFontsResponse
+  | SetDefaultFontsResponse
   | SetFontUrlResponse
   | GetAvailableFontsResponse
 
@@ -404,6 +420,20 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
     await this.sendMessageToAllWorkers<SetFontUrlMessage, SetFontUrlResponse>({
       type: 'setFontUrl',
       data: { url: value }
+    })
+  }
+
+  /**
+   * Syncs the default font fallback chain to all workers.
+   */
+  async setDefaultFonts(fonts: readonly string[]) {
+    FontManager.instance.setDefaultFonts(fonts)
+    await this.sendMessageToAllWorkers<
+      SetDefaultFontsMessage,
+      SetDefaultFontsResponse
+    >({
+      type: 'setDefaultFonts',
+      data: { fonts: [...fonts] }
     })
   }
 

--- a/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
+++ b/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
@@ -89,6 +89,7 @@ type SetDefaultFontsMessage = WorkerMessageBase<
   'setDefaultFonts',
   {
     fonts: string[]
+    symbolFonts: string[]
   }
 >
 
@@ -124,6 +125,7 @@ type SetDefaultFontsResponse = WorkerResponseBase<
   'setDefaultFonts',
   {
     fonts: string[]
+    symbolFonts: string[]
   }
 >
 
@@ -256,7 +258,7 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
   private async ensureInitialized() {
     if (!this.isInitialized) {
       // Guarantee the default font is loaded
-      await this.loadFonts([...FontManager.instance.defaultFonts])
+      await this.loadFonts(FontManager.instance.getFontsToLoad())
       this.isInitialized = true
     }
   }
@@ -426,14 +428,21 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
   /**
    * Syncs the default font fallback chain to all workers.
    */
-  async setDefaultFonts(fonts: readonly string[]) {
+  async setDefaultFonts(
+    fonts: readonly string[],
+    symbolFonts: readonly string[]
+  ) {
     FontManager.instance.setDefaultFonts(fonts)
+    FontManager.instance.setSymbolFonts(symbolFonts)
     await this.sendMessageToAllWorkers<
       SetDefaultFontsMessage,
       SetDefaultFontsResponse
     >({
       type: 'setDefaultFonts',
-      data: { fonts: [...fonts] }
+      data: {
+        fonts: [...fonts],
+        symbolFonts: [...symbolFonts]
+      }
     })
   }
 
@@ -472,7 +481,7 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
     )
   }
 
-  async loadFonts(fonts: string[]): Promise<{ loaded: string[] }> {
+  async loadFonts(fonts: readonly string[]): Promise<{ loaded: string[] }> {
     await this.ensureTasksFinished()
 
     const results = await this.sendMessageToAllWorkers<
@@ -480,7 +489,7 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
       LoadFontsResponse
     >({
       type: 'loadFonts',
-      data: { fonts }
+      data: { fonts: [...fonts] }
     })
 
     const aggregated = new Set<string>()

--- a/packages/mtext-renderer/test/font/defaultFontLoader.test.ts
+++ b/packages/mtext-renderer/test/font/defaultFontLoader.test.ts
@@ -166,6 +166,53 @@ describe('DefaultFontLoader', () => {
     ])
   })
 
+  it('reports success for alias requests when load status uses the file name', async () => {
+    vi.mocked(FontManager.instance.isFontLoaded).mockReturnValue(false)
+    vi.mocked(FontManager.instance.loadFonts).mockResolvedValue([
+      {
+        fontName: 'simfang',
+        url: 'https://cdn.example.com/fonts/simfang.woff',
+        status: 'Success'
+      }
+    ])
+    const loader = new DefaultFontLoader()
+    loader.baseUrl = 'https://cdn.example.com/fonts/'
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        jsonResponse([
+          {
+            name: [
+              'simfang',
+              'FangSong_GB2312',
+              '仿宋',
+              '仿宋_GB2312',
+              '华文仿宋'
+            ],
+            file: 'simfang.woff',
+            type: 'mesh',
+            url: ''
+          }
+        ])
+      )
+    )
+
+    const statuses = await loader.load(['仿宋_gb2312'])
+
+    expect(FontManager.instance.loadFonts).toHaveBeenCalledWith([
+      expect.objectContaining({
+        file: 'simfang.woff'
+      })
+    ])
+    expect(statuses).toEqual([
+      {
+        fontName: '仿宋_gb2312',
+        url: 'https://cdn.example.com/fonts/simfang.woff',
+        status: 'Success'
+      }
+    ])
+  })
+
   it('returns success immediately for already loaded requested fonts', async () => {
     vi.mocked(FontManager.instance.isFontLoaded).mockReturnValue(true)
     const loader = new DefaultFontLoader()

--- a/packages/mtext-renderer/test/font/fontManager.test.ts
+++ b/packages/mtext-renderer/test/font/fontManager.test.ts
@@ -19,7 +19,10 @@ vi.mock('../../src/font/fontFactory', () => ({
 }))
 
 import { FontManager } from '../../src/font/fontManager'
-import { DEFAULT_FONTS_PRESETS } from '../../src/font/defaultFontsPresets'
+import {
+  DEFAULT_FONTS_PRESETS,
+  SYMBOL_FONTS_PRESETS
+} from '../../src/font/defaultFontsPresets'
 import { FontCacheManager } from '../../src/cache'
 import { FontFactory } from '../../src/font/fontFactory'
 import { FontInfo, FontLoader, FontLoadStatus } from '../../src/font/fontLoader'
@@ -63,6 +66,7 @@ describe('FontManager', () => {
     manager.fileNames = []
     manager.enableFontCache = true
     manager.defaultFonts = new Set(['simkai'])
+    manager.symbolFonts = new Set(['amgdt'])
   })
 
   afterEach(() => {
@@ -115,7 +119,7 @@ describe('FontManager', () => {
 
     const result = await manager.loadDefaultFont()
 
-    expect(loader.load).toHaveBeenCalledWith(['simkai'])
+    expect(loader.load).toHaveBeenCalledWith(['simkai', 'amgdt'])
     expect(result).toEqual([
       {
         fontName: 'simkai',
@@ -184,6 +188,53 @@ describe('FontManager', () => {
 
     expect(FontManager.instance.getCharShapeFromDefaults('中', 12)).toBe(shape)
     expect(fallback.getCharShape).toHaveBeenCalledWith('中', 12)
+  })
+
+  it('skips default fonts that hasChar but cannot build a shape', () => {
+    const shape = { width: 1 }
+    const manager = FontManager.instance as any
+    const falsePositive = createFakeFont({
+      hasChar: vi.fn().mockReturnValue(true),
+      getCharShape: vi.fn().mockReturnValue(undefined)
+    })
+    const fallback = createFakeFont({
+      hasChar: vi.fn().mockReturnValue(false),
+      getCharShape: vi.fn().mockReturnValue(shape)
+    })
+    manager.defaultFonts = new Set(['falsepositive', 'fallback'])
+    manager.loadedFontMap.set('falsepositive', falsePositive)
+    manager.loadedFontMap.set('fallback', fallback)
+
+    expect(FontManager.instance.getCharShapeFromDefaults('中', 12)).toBe(shape)
+    expect(falsePositive.getCharShape).toHaveBeenCalledWith('中', 12)
+    expect(fallback.getCharShape).toHaveBeenCalledWith('中', 12)
+  })
+
+  it('prefers symbolFonts for AutoCAD control-code glyphs', () => {
+    const meshShape = { width: 99 }
+    const symbolShape = { width: 2.85 }
+    const manager = FontManager.instance as any
+    const mesh = createFakeFont({
+      hasChar: vi.fn((char: string) => char === '°'),
+      getCharShape: vi.fn().mockReturnValue(meshShape)
+    })
+    const symbol = createFakeFont({
+      hasChar: vi.fn((char: string) => char === '°'),
+      getCharShape: vi.fn().mockReturnValue(symbolShape)
+    })
+    manager.defaultFonts = new Set(['simsun'])
+    manager.symbolFonts = new Set(['amgdt'])
+    manager.loadedFontMap.set('simsun', mesh)
+    manager.loadedFontMap.set('amgdt', symbol)
+
+    expect(FontManager.instance.getCharShapeFromDefaults('°', 10)).toBe(
+      meshShape
+    )
+    expect(FontManager.instance.getCharShapeFromSymbolFonts('°', 10)).toBe(
+      symbolShape
+    )
+    expect(mesh.getCharShape).toHaveBeenCalled()
+    expect(symbol.getCharShape).toHaveBeenCalled()
   })
 
   it('finds fonts by character without using getCharShape on a missing font name', () => {
@@ -273,35 +324,47 @@ describe('FontManager', () => {
     ])
   })
 
-  it('sets default fonts from a preset', () => {
+  it('sets default and symbol fonts from a preset', () => {
     const manager = FontManager.instance
 
     manager.setDefaultFonts('r12r14')
     expect([...manager.defaultFonts]).toEqual([
       ...DEFAULT_FONTS_PRESETS.r12r14
     ])
+    expect([...manager.symbolFonts]).toEqual([
+      ...SYMBOL_FONTS_PRESETS.r12r14
+    ])
 
     manager.setDefaultFonts('modern')
     expect([...manager.defaultFonts]).toEqual([...DEFAULT_FONTS_PRESETS.modern])
+    expect([...manager.symbolFonts]).toEqual([...SYMBOL_FONTS_PRESETS.modern])
   })
 
-  it('sets custom default fonts from a list or single name', () => {
+  it('sets custom default fonts without changing symbol fonts', () => {
     const manager = FontManager.instance
 
-    manager.setDefaultFonts(['hztxt', 'simsun', 'gdt'])
-    expect([...manager.defaultFonts]).toEqual(['hztxt', 'simsun', 'gdt'])
+    manager.setDefaultFonts('modern')
+    manager.setDefaultFonts(['hztxt', 'simsun'])
+    expect([...manager.defaultFonts]).toEqual(['hztxt', 'simsun'])
+    expect([...manager.symbolFonts]).toEqual([...SYMBOL_FONTS_PRESETS.modern])
 
     manager.setDefaultFonts('simkai')
     expect([...manager.defaultFonts]).toEqual(['simkai'])
+
+    manager.setSymbolFonts(['amgdt', 'gdt'])
+    expect([...manager.symbolFonts]).toEqual(['amgdt', 'gdt'])
   })
 
-  it('returns preset font names via getDefaultFontsPreset', () => {
+  it('returns preset font names via getDefaultFontsPreset and getSymbolFontsPreset', () => {
     expect(FontManager.instance.getDefaultFontsPreset('cjk')).toEqual(
       DEFAULT_FONTS_PRESETS.cjk
     )
+    expect(FontManager.instance.getSymbolFontsPreset('cjk')).toEqual(
+      SYMBOL_FONTS_PRESETS.cjk
+    )
   })
 
-  it('loads default fonts configured by preset', async () => {
+  it('loads default and symbol fonts configured by preset', async () => {
     const loader = createFontLoader('https://cdn.example.com/fonts/')
     vi.mocked(loader.load).mockResolvedValue([])
     const manager = FontManager.instance
@@ -310,12 +373,70 @@ describe('FontManager', () => {
 
     await manager.loadDefaultFont()
 
-    expect(loader.load).toHaveBeenCalledWith(['hztxt', 'simsun', 'gdt'])
+    expect(loader.load).toHaveBeenCalledWith(['hztxt', 'simsun', 'amgdt'])
+  })
+
+  it('resolves fonts by alias names after loading', async () => {
+    const manager = FontManager.instance as any
+    const buffer = new ArrayBuffer(8)
+    const shape = { width: 1 }
+    const font = createFakeFont({
+      names: new Set([
+        'simfang',
+        'FangSong_GB2312',
+        '仿宋',
+        '仿宋_GB2312',
+        '华文仿宋'
+      ]),
+      type: 'mesh',
+      hasChar: vi.fn().mockReturnValue(true),
+      getCharShape: vi.fn().mockReturnValue(shape),
+      getScaleFactor: vi.fn().mockReturnValue(0.8)
+    })
+    manager.loader = {
+      loadAsync: vi.fn().mockResolvedValue(buffer)
+    }
+    vi.mocked(FontFactory.instance.createFont).mockReturnValue(font as any)
+
+    await FontManager.instance.loadFonts({
+      name: ['simfang', 'FangSong_GB2312', '仿宋', '仿宋_GB2312', '华文仿宋'],
+      file: 'simfang.woff',
+      type: 'mesh',
+      url: 'https://cdn.example.com/fonts/simfang.woff'
+    })
+
+    expect(FontManager.instance.isFontLoaded('simfang')).toBe(true)
+    expect(FontManager.instance.isFontLoaded('仿宋_GB2312')).toBe(true)
+    expect(FontManager.instance.isFontLoaded('仿宋_gb2312')).toBe(true)
+    expect(FontManager.instance.getFontByName('仿宋_GB2312')).toBe(font)
+    expect(FontManager.instance.getFontByName('仿宋_gb2312')).toBe(font)
+    expect(FontManager.instance.getFontScaleFactor('仿宋_GB2312')).toBe(0.8)
+    expect(FontManager.instance.getFontType('华文仿宋')).toBe('mesh')
+    expect(FontManager.instance.findAndReplaceFont('仿宋_gb2312')).toBe(
+      '仿宋_gb2312'
+    )
+    expect(FontManager.instance.getCharShape('仿', '仿宋_GB2312', 12)).toBe(
+      shape
+    )
+  })
+
+  it('releases a font and all of its alias entries', () => {
+    const manager = FontManager.instance as any
+    const font = createFakeFont({
+      names: new Set(['simfang', '仿宋_GB2312'])
+    })
+    manager.loadedFontMap.set('simfang', font)
+    manager.loadedFontMap.set('仿宋_gb2312', font)
+
+    expect(FontManager.instance.release('仿宋_GB2312')).toBe(true)
+    expect(FontManager.instance.isFontLoaded('simfang')).toBe(false)
+    expect(FontManager.instance.isFontLoaded('仿宋_GB2312')).toBe(false)
+    expect(manager.loadedFontMap.size).toBe(0)
   })
 
   it('loads fonts from cache without requesting the font URL', async () => {
     const manager = FontManager.instance as any
-    const font = createFakeFont()
+    const font = createFakeFont({ names: new Set(['Romans']) })
     const cachedFontData = {
       name: 'romans',
       alias: ['Romans'],
@@ -339,6 +460,8 @@ describe('FontManager', () => {
     expect(manager.loader.loadAsync).not.toHaveBeenCalled()
     expect(FontFactory.instance.createFont).toHaveBeenCalledWith(cachedFontData)
     expect(FontManager.instance.isFontLoaded('romans')).toBe(true)
+    expect(FontManager.instance.isFontLoaded('Romans')).toBe(true)
+    expect(FontManager.instance.getFontByName('Romans')).toBe(font)
     expect(statuses[0].status).toBe('Success')
   })
 })

--- a/packages/mtext-renderer/test/font/shx-control-code-glyphs.test.ts
+++ b/packages/mtext-renderer/test/font/shx-control-code-glyphs.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+
+import { FontData } from '../../src/font/font'
+import { FontFactory } from '../../src/font/fontFactory'
+import { FontManager } from '../../src/font/fontManager'
+import { MeshFont } from '../../src/font/meshFont'
+import { ShxFont } from '../../src/font/shxFont'
+
+const FONT_BASE = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data/fonts/'
+
+async function loadFont(
+  name: string,
+  file: string,
+  type: 'shx' | 'mesh' = 'shx'
+): Promise<ShxFont | MeshFont> {
+  const response = await fetch(FONT_BASE + file)
+  if (!response.ok) throw new Error(`Failed to fetch ${file}`)
+  const fontData: FontData = {
+    name,
+    type,
+    data: await response.arrayBuffer(),
+    alias: [name]
+  }
+  return FontFactory.instance.createFont(fontData) as ShxFont | MeshFont
+}
+
+function registerFont(name: string, font: ShxFont | MeshFont) {
+  const key = name.toLowerCase()
+  font.names.add(key)
+  ;(
+    FontManager.instance as unknown as { loadedFontMap: Map<string, unknown> }
+  ).loadedFontMap.set(key, font)
+}
+
+describe('AutoCAD percent symbols with isocp primary font (integration)', () => {
+  it(
+    'resolves %%c, %%d, and %%p through amgdt control codes instead of isocp Unicode glyphs',
+    async () => {
+      FontManager.instance.release()
+      FontManager.instance.enableFontCache = false
+      FontManager.instance.setDefaultFonts('modern')
+
+      registerFont('isocp', await loadFont('isocp', 'isocp.shx'))
+      registerFont('amgdt', await loadFont('amgdt', 'amgdt.shx'))
+
+      const cases = [
+        {
+          label: '%%c',
+          unicodeChar: 'Ø',
+          symbolChar: '\u2205',
+          isocpWidth: 10,
+          symbolWidth: 6.785714285714286
+        },
+        {
+          label: '%%d',
+          unicodeChar: '°',
+          controlCode: 176,
+          isocpWidth: 4.615384615384616,
+          symbolWidth: 2.857142857142857
+        },
+        {
+          label: '%%p',
+          unicodeChar: '±',
+          controlCode: 177,
+          isocpWidth: 5.384615384615385,
+          symbolWidth: 9.285714285714286
+        }
+      ] as const
+
+      for (const testCase of cases) {
+        const isocpShape = FontManager.instance.getCharShape(
+          testCase.unicodeChar,
+          'isocp',
+          10
+        )
+        const symbolLookupChar =
+          'symbolChar' in testCase
+            ? testCase.symbolChar
+            : String.fromCharCode(testCase.controlCode)
+        const symbolShape = FontManager.instance.getCharShapeFromSymbolFonts(
+          symbolLookupChar,
+          10
+        )
+
+        expect(isocpShape, testCase.label).toBeDefined()
+        expect(symbolShape, testCase.label).toBeDefined()
+        expect(isocpShape!.width, testCase.label).toBe(testCase.isocpWidth)
+        expect(symbolShape!.width, testCase.label).toBeCloseTo(
+          testCase.symbolWidth,
+          5
+        )
+        expect(isocpShape!.width, testCase.label).not.toBe(symbolShape!.width)
+      }
+    },
+    60_000
+  )
+})
+
+describe('%%130 %%131 glyph fallback (integration)', () => {
+  const ch130 = String.fromCharCode(130)
+  const ch131 = String.fromCharCode(131)
+
+  it(
+    'resolves %%130/%%131 from amgdt.shx; gdt.ttf has no real glyph at those code points',
+    async () => {
+      const txt = await loadFont('txt', 'txt.shx')
+      const amgdt = await loadFont('amgdt', 'amgdt.shx')
+      const gdt = await loadFont('gdt', 'gdt.ttf', 'mesh')
+
+      expect(txt.hasChar(ch130)).toBe(false)
+      // MeshFont: index 0 (.notdef) must not count as a glyph (opentype.js #330).
+      expect(gdt.hasChar(ch130)).toBe(false)
+      expect(gdt.getCharShape(ch130, 10)).toBeUndefined()
+      expect(amgdt.getCharShape(ch130, 10)).toBeDefined()
+      expect(amgdt.getCharShape(ch131, 10)).toBeDefined()
+    },
+    60_000
+  )
+
+  it(
+    'getCharShapeFromSymbolFonts skips gdt.ttf and uses amgdt when configured',
+    async () => {
+      FontManager.instance.release()
+      FontManager.instance.enableFontCache = false
+      FontManager.instance.setDefaultFonts('minimal')
+
+      registerFont('txt', await loadFont('txt', 'txt.shx'))
+      registerFont('amgdt', await loadFont('amgdt', 'amgdt.shx'))
+      registerFont('gdt', await loadFont('gdt', 'gdt.ttf', 'mesh'))
+
+      const shape130 = FontManager.instance.getCharShapeFromSymbolFonts(ch130, 10)
+      const shape131 = FontManager.instance.getCharShapeFromSymbolFonts(ch131, 10)
+
+      expect(shape130).toBeDefined()
+      expect(shape131).toBeDefined()
+    },
+    60_000
+  )
+})

--- a/packages/mtext-renderer/test/font/shx-symbol-font-fallback.test.ts
+++ b/packages/mtext-renderer/test/font/shx-symbol-font-fallback.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { FontData } from '../../src/font/font'
+import { FontFactory } from '../../src/font/fontFactory'
+import { FontManager } from '../../src/font/fontManager'
+import { MeshFont } from '../../src/font/meshFont'
+import { ShxFont } from '../../src/font/shxFont'
+
+const FONT_BASE = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data/fonts/'
+
+async function loadFont(name: string, file: string, type: 'shx' | 'mesh' = 'shx') {
+  const response = await fetch(FONT_BASE + file)
+  const fontData: FontData = {
+    name,
+    type,
+    data: await response.arrayBuffer(),
+    alias: [name]
+  }
+  return FontFactory.instance.createFont(fontData) as ShxFont | MeshFont
+}
+
+function registerFont(name: string, font: ShxFont | MeshFont) {
+  const key = name.toLowerCase()
+  font.names.add(key)
+  ;(
+    FontManager.instance as unknown as { loadedFontMap: Map<string, unknown> }
+  ).loadedFontMap.set(key, font)
+}
+
+describe('symbolFonts config (integration)', () => {
+  it('uses amgdt degree and plus/minus instead of simsun', async () => {
+    FontManager.instance.release()
+    FontManager.instance.enableFontCache = false
+    FontManager.instance.setDefaultFonts('modern')
+
+    registerFont('hztxt', await loadFont('hztxt', 'hztxt.shx'))
+    registerFont('simsun', await loadFont('simsun', 'simsun.ttf', 'mesh'))
+    registerFont('amgdt', await loadFont('amgdt', 'amgdt.shx'))
+
+    const degree = FontManager.instance.getCharShapeFromSymbolFonts('°', 10)
+    const pm = FontManager.instance.getCharShapeFromSymbolFonts('±', 10)
+
+    expect(degree?.width).toBeCloseTo(2.857142857142857, 5)
+    expect(pm?.width).toBeCloseTo(9.285714285714286, 5)
+
+    expect(FontManager.instance.getCharShapeFromDefaults('°', 10)?.width).toBe(
+      10
+    )
+    expect(FontManager.instance.getCharShapeFromDefaults('±', 10)?.width).toBe(
+      10
+    )
+  }, 120_000)
+})

--- a/packages/mtext-renderer/test/renderer/mtext.glyph-fallback.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.glyph-fallback.test.ts
@@ -272,6 +272,89 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
     expect(getCharShapeFromDefaults).toHaveBeenCalledWith(cjkChar, 10)
   })
 
+  it.each([
+    {
+      label: '%%c diameter',
+      char: 'Ø',
+      lookupChars: [String.fromCharCode(129), '\u2205'],
+      primaryWidth: 10,
+      symbolWidth: 6.78
+    },
+    {
+      label: '%%d degree',
+      char: '°',
+      lookupChars: [String.fromCharCode(126), String.fromCharCode(176)],
+      primaryWidth: 4.6,
+      symbolWidth: 2.85
+    },
+    {
+      label: '%%p plus/minus',
+      char: '±',
+      lookupChars: [String.fromCharCode(177)],
+      primaryWidth: 5.4,
+      symbolWidth: 9.28
+    }
+  ])(
+    'prefers SHX symbol-font control codes for $label before primary font',
+    ({ char, lookupChars, primaryWidth, symbolWidth }) => {
+      const primaryShape = createShape(primaryWidth)
+      const symbolShape = createShape(symbolWidth)
+      const glyphs: Record<string, Record<string, GlyphShape | undefined>> = {
+        isocp: { [char]: primaryShape },
+        simsun: Object.fromEntries(
+          [
+            String.fromCharCode(127),
+            String.fromCharCode(128),
+            String.fromCharCode(126),
+            String.fromCharCode(129),
+            '°',
+            '±',
+            '\u2205'
+          ].map(ch => [ch, createShape(99)])
+        ),
+        amgdt: Object.fromEntries(
+          lookupChars.map(lookupChar => [lookupChar, symbolShape])
+        )
+      }
+
+      const getCharShape = vi.fn((lookupChar: string, fontName: string) =>
+        resolveCharShape(lookupChar, fontName, glyphs)
+      )
+      const getCharShapeFromSymbolFonts = vi.fn((lookupChar: string) => {
+        for (const fontName of ['amgdt', 'simsun']) {
+          const shape = resolveCharShape(lookupChar, fontName, glyphs)
+          if (shape) return shape
+        }
+        return undefined
+      })
+
+      const processor = createGlyphFallbackProcessor(
+        { font: 'isocp', bigFont: 'intecad' },
+        {
+          getFontScaleFactor: () => 1,
+          getFontType: () => 'shx' as const,
+          findAndReplaceFont: (name: string) => name,
+          getCharShape,
+          getCharShapeFromDefaults: vi.fn(),
+          getCharShapeFromSymbolFonts,
+          getNotFoundTextShape: () => undefined
+        }
+      )
+
+      getCharShape.mockClear()
+      getCharShapeFromSymbolFonts.mockClear()
+
+      const shape = (processor as any).getCharShape(char)
+
+      expect(shape).toBe(symbolShape)
+      expect(getCharShapeFromSymbolFonts).toHaveBeenCalledTimes(1)
+      expect(lookupChars).toContain(
+        getCharShapeFromSymbolFonts.mock.calls[0][0]
+      )
+      expect(getCharShape).not.toHaveBeenCalled()
+    }
+  )
+
   it('stops at primary font when the glyph is present there', () => {
     const primaryShape = createShape(1)
     const bigShape = createShape(2)
@@ -351,6 +434,7 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
 
     const getCharShape = vi.fn(() => undefined)
     const getCharShapeFromDefaults = vi.fn(() => undefined)
+    const getCharShapeFromSymbolFonts = vi.fn(() => undefined)
     const getNotFoundTextShape = vi.fn(() => notFoundShape)
 
     const processor = createGlyphFallbackProcessor(
@@ -361,12 +445,14 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
         findAndReplaceFont: (name: string) => name,
         getCharShape,
         getCharShapeFromDefaults,
+        getCharShapeFromSymbolFonts,
         getNotFoundTextShape
       }
     )
 
     getCharShape.mockClear()
     getCharShapeFromDefaults.mockClear()
+    getCharShapeFromSymbolFonts.mockClear()
     getNotFoundTextShape.mockClear()
 
     const shape = (processor as any).getCharShape(cjkChar)
@@ -375,6 +461,7 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
     expect(getCharShape).toHaveBeenCalledWith(cjkChar, primaryFont, 10)
     expect(getCharShape).toHaveBeenCalledWith(cjkChar, bigFontName, 10)
     expect(getCharShapeFromDefaults).toHaveBeenCalledWith(cjkChar, 10)
+    expect(getCharShapeFromSymbolFonts).toHaveBeenCalledWith(cjkChar, 10)
     expect(getNotFoundTextShape).toHaveBeenCalledWith(10)
   })
 })

--- a/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
@@ -165,6 +165,7 @@ function createProcessor(
       }
     },
     getCharShapeFromDefaults: () => undefined,
+    getCharShapeFromSymbolFonts: () => undefined,
     getNotFoundTextShape: () => undefined
   }
 
@@ -480,6 +481,7 @@ describe('MTextProcessor format state', () => {
         }
       },
       getCharShapeFromDefaults: () => undefined,
+      getCharShapeFromSymbolFonts: () => undefined,
       getNotFoundTextShape: () => undefined
     }
 

--- a/packages/mtext-renderer/test/renderer/percentControlCodes.test.ts
+++ b/packages/mtext-renderer/test/renderer/percentControlCodes.test.ts
@@ -1,0 +1,80 @@
+import { MTextParser, TokenType } from '@mlightcad/mtext-parser'
+import { describe, expect, it } from 'vitest'
+
+import { expandPercentControlCodes } from '../../src/renderer/percentControlCodes'
+
+function parseWithPropertyCommands(text: string) {
+  const parser = new MTextParser(text, undefined, {
+    yieldPropertyCommands: true
+  })
+  return [...parser.parse()]
+}
+
+function propertyCommands(text: string) {
+  return parseWithPropertyCommands(text)
+    .filter(token => token.type === TokenType.PROPERTIES_CHANGED)
+    .map(token => token.data?.command)
+}
+
+describe('expandPercentControlCodes', () => {
+  it('expands explicit on/off stroke codes', () => {
+    expect(expandPercentControlCodes('%%konstruck%%koff')).toBe(
+      '\\Kstruck\\k'
+    )
+    expect(expandPercentControlCodes('%%oonover%%ooff')).toBe('\\Oover\\o')
+    expect(expandPercentControlCodes('%%uonunder%%uoff')).toBe('\\Lunder\\l')
+  })
+
+  it('toggles standard %%k, %%o, and %%u codes', () => {
+    expect(expandPercentControlCodes('%%kstruck%%k normal')).toBe(
+      '\\Kstruck\\k normal'
+    )
+    expect(expandPercentControlCodes('%%oover%%o normal')).toBe('\\Oover\\o normal')
+    expect(expandPercentControlCodes('%%uunder%%u normal')).toBe(
+      '\\Lunder\\l normal'
+    )
+  })
+
+  it('is case-insensitive for explicit and toggle codes', () => {
+    expect(expandPercentControlCodes('%%KONx%%KOFF')).toBe('\\Kx\\k')
+    expect(expandPercentControlCodes('%%OONx%%OOFF')).toBe('\\Ox\\o')
+    expect(expandPercentControlCodes('%%UONx%%UOFF')).toBe('\\Lx\\l')
+    expect(expandPercentControlCodes('%%Kx%%K')).toBe('\\Kx\\k')
+  })
+
+  it('does not alter symbol or numeric percent codes', () => {
+    expect(expandPercentControlCodes('%%c %%d %%p %%% %%130')).toBe(
+      '%%c %%d %%p %%% %%130'
+    )
+  })
+
+  it('produces parser-visible decoration commands after expansion', () => {
+    const expanded = expandPercentControlCodes(
+      '%%konstruck%%koff %%oover%%o %%uunder%%u'
+    )
+    expect(propertyCommands(expanded)).toEqual(['K', 'k', 'O', 'o', 'L', 'l'])
+  })
+
+  it('matches the controlCode example stroke sequences', () => {
+    const exampleStrokeText =
+      '%%kstruck%%k normal\\P%%konstruck%%koff normal\\P' +
+      '%%oover%%o normal\\P%%oonover%%ooff normal\\P' +
+      '%%uunder%%u normal\\P%%uonunder%%uoff normal'
+
+    const expanded = expandPercentControlCodes(exampleStrokeText)
+    expect(propertyCommands(expanded)).toEqual([
+      'K',
+      'k',
+      'K',
+      'k',
+      'O',
+      'o',
+      'O',
+      'o',
+      'L',
+      'l',
+      'L',
+      'l'
+    ])
+  })
+})

--- a/packages/mtext-renderer/test/renderer/shxSymbolControlCodes.test.ts
+++ b/packages/mtext-renderer/test/renderer/shxSymbolControlCodes.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES,
+  getShxControlCodeCandidates,
+  isAutoCadPercentSymbolChar
+} from '../../src/renderer/shxSymbolControlCodes'
+
+describe('shxSymbolControlCodes', () => {
+  it('maps all named AutoCAD percent symbols to SHX control-code candidates', () => {
+    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.c).toEqual([129])
+    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.d).toEqual([126, 176])
+    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.p).toEqual([177])
+  })
+
+  it('recognizes Unicode expansions for %%c, %%d, and %%p', () => {
+    expect(isAutoCadPercentSymbolChar('Ø')).toBe(true)
+    expect(isAutoCadPercentSymbolChar('∅')).toBe(true)
+    expect(isAutoCadPercentSymbolChar('°')).toBe(true)
+    expect(isAutoCadPercentSymbolChar('±')).toBe(true)
+    expect(isAutoCadPercentSymbolChar('9')).toBe(false)
+  })
+
+  it('returns ordered candidates for each percent-symbol Unicode expansion', () => {
+    expect(getShxControlCodeCandidates('Ø')).toEqual([
+      String.fromCharCode(129),
+      '\u2205'
+    ])
+    expect(getShxControlCodeCandidates('∅')).toEqual([
+      String.fromCharCode(129),
+      '\u2205'
+    ])
+    expect(getShxControlCodeCandidates('°')).toEqual([
+      String.fromCharCode(126),
+      String.fromCharCode(176)
+    ])
+    expect(getShxControlCodeCandidates('±')).toEqual([String.fromCharCode(177)])
+    expect(getShxControlCodeCandidates('A')).toEqual([])
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,15 +100,15 @@ importers:
         specifier: ^8.0.3
         version: 8.0.3
       opentype.js:
-        specifier: ^1.3.4
-        version: 1.3.4
+        specifier: ^2.0.0
+        version: 2.0.0
       three:
         specifier: ^0.172.0
         version: 0.172.0
     devDependencies:
       '@types/opentype.js':
-        specifier: ^1.3.8
-        version: 1.3.8
+        specifier: ^1.3.10
+        version: 1.3.10
       '@types/three':
         specifier: ^0.172.0
         version: 0.172.0
@@ -1308,8 +1308,8 @@ packages:
   '@types/node@20.17.46':
     resolution: {integrity: sha512-0PQHLhZPWOxGW4auogW0eOQAuNIlCYvibIpG67ja0TOJ6/sehu+1en7sfceUn+QQtx4Rk3GxbLNwPh0Cav7TWw==}
 
-  '@types/opentype.js@1.3.8':
-    resolution: {integrity: sha512-H6qeTp03jrknklSn4bpT1/9+1xCAEIU2CnjcWPkicJy8A1SKuthanbvoHYMiv79/2W3Xn1XE4gfSJFzt2U3JSw==}
+  '@types/opentype.js@1.3.10':
+    resolution: {integrity: sha512-F67EFyk6j02okHz5JCgata3ZRAcZi9GLnzmkHw/rzJq3OCc8/ZVdoKrxMTYjcQP6IYHGBz2cav1cpzkOkPiPCQ==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -2645,9 +2645,8 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  opentype.js@1.3.4:
-    resolution: {integrity: sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==}
-    engines: {node: '>= 8.0.0'}
+  opentype.js@2.0.0:
+    resolution: {integrity: sha512-kCyjv6xdDY1W/jLWZ/L3QhhTlKUqDZMQ5+Jdlw12b3dXkKNpYBqqlMMj0YDQPShWFTMwgZI1hG14kN3XUDSg/A==}
     hasBin: true
 
   optionator@0.9.4:
@@ -2987,9 +2986,6 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
-  string.prototype.codepointat@0.2.1:
-    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
-
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -3054,9 +3050,6 @@ packages:
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-
-  tiny-inflate@1.0.3:
-    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4776,7 +4769,7 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
-  '@types/opentype.js@1.3.8': {}
+  '@types/opentype.js@1.3.10': {}
 
   '@types/parse-json@4.0.2': {}
 
@@ -6166,10 +6159,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  opentype.js@1.3.4:
-    dependencies:
-      string.prototype.codepointat: 0.2.1
-      tiny-inflate: 1.0.3
+  opentype.js@2.0.0: {}
 
   optionator@0.9.4:
     dependencies:
@@ -6499,8 +6489,6 @@ snapshots:
       get-east-asian-width: 1.4.0
       strip-ansi: 7.1.2
 
-  string.prototype.codepointat@0.2.1: {}
-
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -6561,8 +6549,6 @@ snapshots:
   three@0.172.0: {}
 
   through@2.3.8: {}
-
-  tiny-inflate@1.0.3: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## Summary
- Propagate default font fallback chain to Web Workers via `setDefaultFonts` on UnifiedRenderer and worker message handling
- Add separate SHX symbol font fallback chain (`symbolFonts`) for AutoCAD control-code glyphs (`%%c`, `%%d`, `%%p`)
- Expand `%%k` / `%%o` / `%%u` stroke toggle percent codes before mtext-parser parsing
- Example app: preset selector, `defaultFonts` / `controlCode` samples, and status showing text + symbol chain order
- Fix LineSegments geometry merge when mixing indexed SHX glyphs with non-indexed fraction/divider decorations
- Upgrade `opentype.js` to ^2.0.0

## Test plan
- [ ] Run example app, switch Default Fonts Preset and re-render
- [ ] Open `defaultFonts` sample; verify Latin/CJK/symbol fallback with each preset
- [ ] Open `controlCode` sample; verify `%%c`/`%%d`/`%%p` symbols and `%%k`/`%%o`/`%%u` toggles
- [ ] Render stacking/fraction examples in worker mode; confirm no merge geometry errors
- [ ] Verify main-thread render mode still applies preset correctly
- [ ] `pnpm --filter @mlightcad/mtext-renderer test`