### PR TITLE
feat: default fonts preset, SHX symbol fallback, and %%ddd control codes

### DIFF
--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -46,10 +46,10 @@ class MTextRendererExample {
     complex:
       '{\\C1;\\W2;Title}\\P{\\C2;This is a paragraph with different styles.}\\P{\\C3;\\W1.5;Subtitle}\\P{\\C4;• First item\\P• Second item\\P• Third item}\\P{\\T2;Absolute character spacing: 2, }{\\T0.2x;Relative character spacing: 0.2}\\P{\\W0.8;Footer text}',
     controlCode:
-      '{Circle diameter dimensioning symbol: %%c},\\P{Degree symbol: %%d}\\P{Plus/minus tolerance symbol: %%p}\\P{A single percent sign: %%%}\\P{Unicode character: %%130 %%131}\\P{Strikethrough toggle (%%k): %%kstruck%%k normal}\\P{Strikethrough explicit: %%konstruck%%koff normal}\\P{Overscore toggle (%%o): %%oover%%o normal}\\P{Overscore explicit: %%oonover%%ooff normal}\\P{Underscore toggle (%%u): %%uunder%%u normal}\\P{Underscore explicit: %%uonunder%%uoff normal}',
+      '{Circle diameter dimensioning symbol: %%c},\\P{Degree symbol: %%d}\\P{Plus/minus tolerance symbol: %%p}\\P{A single percent sign: %%%}\\P{Unicode character: %%130 %%131 \\Ftssdeng;%%1326@600}\\P{Strikethrough toggle (%%k): %%kstruck%%k normal}\\P{Strikethrough explicit: %%konstruck%%koff normal}\\P{Overscore toggle (%%o): %%oover%%o normal}\\P{Overscore explicit: %%oonover%%ooff normal}\\P{Underscore toggle (%%u): %%uunder%%u normal}\\P{Underscore explicit: %%uonunder%%uoff normal}',
     color:
       '{\\C0;By Block}\\P{\\C1;Red Text}\\P{\\C2;Yellow Text}\\P{\\C3;Green Text}\\P{\\C4;Cyan Text}\\P{\\C5;Blue Text}\\P{\\C6;Magenta Text}\\P{\\C7;White Text}\\P{\\C256;By Layer}\\P{\\c16761035;Pink (0x0FFC0CB)}\\PRestore ByLayer\\P\\C1;Old Context Color: Red, {\\C2; New Context Color: Yellow, } Restored Context Color: Red',
-    font: '{\\C1;\\W2;\\FSimSun;SimSun 宋体}\\P{\\F仿宋_gb2312;SimFang 仿宋（面积、材料、8、①④⑧⑩⑫㉔㉚）}\\P{\\C2;\\W0.5;\\FArial;Arial Text}\\P{\\C3;30;\\Faehalf.shx;SHX Text}\\P{\\C4;\\Fgbcbig.shx;东亚字符集字体}\\P{\\C5;\\Q1;\\FSimHei;SimHei Text，黑体}\\P{\\C6;\\Q0.5;\\FSimKai;SimKai 楷体}',
+    font: '{\\C1;\\W2;\\FSimSun;SimSun 宋体}\\P{\\F仿宋_gb2312;SimFang 仿宋（面积、材料、8、①④⑧⑩⑫㉔㉚）}\\P{\\C2;\\W0.5;\\FArial;Arial Text}\\P{\\C3;30;\\Faehalf.shx;SHX Text “250~280”}\\P{\\C4;\\Fgbcbig.shx;东亚字符集字体}\\P{\\C5;\\Q1;\\FSimHei;SimHei Text，黑体}\\P{\\C6;\\Q0.5;\\FSimKai;SimKai 楷体}',
     defaultFonts:
       '{\\C1;Primary \\Ftxt;txt (SHX) — Latin: Hello %%c50}\\P{\\C2;CJK falls back via preset chain: 材料 装车 直径 你好}\\P{\\C3;Symbol %%c %%d %%p — may use gdt in chain}\\P{\\C4;Switch preset above and re-render to compare fallback order}',
     stacking:

--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "@mlightcad/mtext-parser": "^1.4.1",
-    "@mlightcad/shx-parser": "^1.3.2",
+    "@mlightcad/shx-parser": "^1.3.4",
     "iconv-lite": "^0.7.0",
     "idb": "^8.0.3",
     "opentype.js": "^2.0.0"

--- a/packages/mtext-renderer/src/font/meshTextShape.ts
+++ b/packages/mtext-renderer/src/font/meshTextShape.ts
@@ -6,6 +6,20 @@ import { MeshFont } from './meshFont'
 
 const _tmp = new THREE.Vector2()
 
+function hasFinitePositions(geometry: THREE.BufferGeometry) {
+  const position = geometry.getAttribute('position')
+  if (!position || position.count === 0) {
+    return true
+  }
+  const array = position.array as ArrayLike<number>
+  for (let index = 0; index < array.length; index++) {
+    if (!Number.isFinite(array[index])) {
+      return false
+    }
+  }
+  return true
+}
+
 /**
  * Represents a text shape for mesh-based fonts (e.g., TTF, OTF, WOFF).
  * This class extends BaseTextShape to provide specific functionality for mesh fonts,
@@ -42,6 +56,10 @@ export class MeshTextShape extends BaseTextShape {
     if (geometry == null) {
       const shapes = this.font.generateShapes(this.char, this.fontSize)
       geometry = new THREE.ShapeGeometry(shapes, 4)
+      if (!hasFinitePositions(geometry)) {
+        geometry.dispose()
+        return new THREE.BufferGeometry()
+      }
       // Remove uv and normal to save memory
       if (geometry.hasAttribute('uv')) {
         geometry.deleteAttribute('uv')
@@ -50,6 +68,9 @@ export class MeshTextShape extends BaseTextShape {
         geometry.deleteAttribute('normal')
       }
       return mergeVertices(geometry, 1e-6)
+    }
+    if (!hasFinitePositions(geometry)) {
+      return new THREE.BufferGeometry()
     }
     return geometry
   }

--- a/packages/mtext-renderer/src/font/shxFont.ts
+++ b/packages/mtext-renderer/src/font/shxFont.ts
@@ -2,7 +2,8 @@ import {
   Point,
   ShxFont as ShxFontInternal,
   ShxFontData,
-  ShxFontType
+  ShxFontType,
+  ShxShape
 } from '@mlightcad/shx-parser'
 import iconv from 'iconv-lite'
 
@@ -112,7 +113,19 @@ export class ShxFont extends BaseFont {
    */
   public getCodeShape(code: number, size: number) {
     const shape = this.font.getCharShape(code, size)
-    return shape ? new ShxTextShape(code, size, shape, this) : undefined
+    if (!shape || !ShxFont.hasRenderableStrokes(shape)) {
+      return undefined
+    }
+    return new ShxTextShape(code, size, shape, this)
+  }
+
+  /** True when the SHX glyph has drawable strokes or a non-zero pen advance. */
+  private static hasRenderableStrokes(shape: ShxShape): boolean {
+    if (shape.polylines.some(line => line.length >= 2)) {
+      return true
+    }
+    // Advance-only glyphs (e.g. space) have no stroke geometry but valid width.
+    return (shape.lastPoint?.x ?? 0) > 0
   }
 
   /**

--- a/packages/mtext-renderer/src/font/shxTextShape.ts
+++ b/packages/mtext-renderer/src/font/shxTextShape.ts
@@ -42,12 +42,25 @@ export class ShxTextShape extends BaseTextShape {
   private resolveAdvanceWidth(shape: ShxShape): number {
     const bboxWidth = this.calcWidth()
     const penAdvance = shape.lastPoint?.x ?? 0
+    const bboxMaxX = shape.bbox.maxX
+    const fontType = this.font.data.header.fontType
+    const { width: cellWidth, height: cellHeight } = this.font.data.content
+    const scaledCellWidth =
+      cellHeight > 0 ? (cellWidth / cellHeight) * this.fontSize : 0
 
-    if (this.font.data.header.fontType === ShxFontType.BIGFONT) {
-      const { width: cellWidth, height: cellHeight } = this.font.data.content
-      const scaledCellWidth =
-        cellHeight > 0 ? (cellWidth / cellHeight) * this.fontSize : 0
+    if (fontType === ShxFontType.BIGFONT) {
       return Math.max(bboxWidth, penAdvance, scaledCellWidth)
+    }
+
+    if (fontType === ShxFontType.UNIFONT) {
+      // Unifont GDT symbols (e.g. amgdt %%132) may draw past lastPoint; when
+      // ink extends beyond the pen advance, also enforce the font cell width.
+      const inkExtent = Math.max(bboxWidth, bboxMaxX)
+      let advance = Math.max(penAdvance, inkExtent)
+      if (inkExtent > penAdvance + 1e-6) {
+        advance = Math.max(advance, scaledCellWidth)
+      }
+      return advance
     }
 
     return penAdvance > 0 ? penAdvance : bboxWidth

--- a/packages/mtext-renderer/src/renderer/mtext.ts
+++ b/packages/mtext-renderer/src/renderer/mtext.ts
@@ -378,7 +378,12 @@ export class MText extends THREE.Object3D {
     object.traverse(obj => {
       if ('geometry' in obj) {
         const geometry = obj.geometry as THREE.BufferGeometry
-        geometry.translate(anchorPoint.x, anchorPoint.y, 0)
+        if (
+          Number.isFinite(anchorPoint.x) &&
+          Number.isFinite(anchorPoint.y)
+        ) {
+          geometry.translate(anchorPoint.x, anchorPoint.y, 0)
+        }
       }
       // Char-box metadata is stored alongside geometry for normal glyphs and
       // on placeholder objects for spaces/empty lines, so translate it for both.

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -10,12 +10,16 @@ import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js
 
 import { getColorByIndex } from '../common'
 import { FontManager } from '../font'
+import { BaseTextShape } from '../font/baseTextShape'
 import { resolveMTextColor } from './colorUtils'
 import {
   LINE_SPACING_SCALE_FACTOR,
   STACK_VERTICAL_SHIFT_FACTOR
 } from './constants'
-import { getShxControlCodeCandidates } from './shxSymbolControlCodes'
+import {
+  getShxControlCodeCandidates,
+  isAutoCadNumericPercentControlCodeChar
+} from './shxSymbolControlCodes'
 import { StyleManager } from './styleManager'
 import {
   CharBox,
@@ -1651,6 +1655,19 @@ export class MTextProcessor {
    * @param char Input one character
    * @returns Return the text shape of the specified character
    */
+  private shapeHasStrokeGeometry(shape: BaseTextShape, char: string): boolean {
+    if (typeof shape.toGeometry !== 'function') {
+      return shape.width > 0
+    }
+    const geometry = shape.toGeometry()
+    const vertexCount = geometry.getAttribute('position')?.count ?? 0
+    if (vertexCount > 0) {
+      return true
+    }
+    // SHX space glyphs often have advance width only (no stroke geometry).
+    return char === ' ' && shape.width > 0
+  }
+
   private getCharShape(char: string) {
     // Named AutoCAD percent codes (%%c/%%d/%%p) are expanded to Unicode by
     // mtext-parser before rendering, but AutoCAD itself resolves those symbols
@@ -1663,7 +1680,22 @@ export class MTextProcessor {
         controlChar,
         this.currentFontSize
       )
-      if (symbolShape) {
+      if (symbolShape && this.shapeHasStrokeGeometry(symbolShape, char)) {
+        if (this.currentFontSize > this._maxFontSize) {
+          this._maxFontSize = this.currentFontSize
+        }
+        return symbolShape
+      }
+    }
+
+    // Numeric `%%ddd` codes (e.g. %%130, %%132) expand to raw byte values and
+    // must be resolved from symbol SHX fonts before the primary text font.
+    if (isAutoCadNumericPercentControlCodeChar(char)) {
+      const symbolShape = this.fontManager.getCharShapeFromSymbolFonts(
+        char,
+        this.currentFontSize
+      )
+      if (symbolShape && this.shapeHasStrokeGeometry(symbolShape, char)) {
         if (this.currentFontSize > this._maxFontSize) {
           this._maxFontSize = this.currentFontSize
         }
@@ -1696,7 +1728,7 @@ export class MTextProcessor {
         this.currentFontSize
       )
     }
-    if (!shape) {
+    if (!shape || !this.shapeHasStrokeGeometry(shape, char)) {
       shape = this.fontManager.getNotFoundTextShape(this.currentFontSize)
     }
 
@@ -1845,24 +1877,32 @@ export class MTextProcessor {
       }
     }
 
+    const applyLeftAlignment = () => {
+      const dx = Number.isFinite(this.maxLineWidth)
+        ? this._currentLeftMargin - resolvedBBox.min.x
+        : this._currentLeftMargin
+
+      const translated = new Set<THREE.Object3D>()
+      geometryEntries.forEach(entry => {
+        entry.geometry.translate(dx, 0, 0)
+        if (!translated.has(entry.owner)) {
+          translateCharBoxes(entry.owner, dx)
+          translated.add(entry.owner)
+        }
+      })
+    }
+
     switch (this.currentHorizontalAlignment) {
       case MTextParagraphAlignment.LEFT:
       case MTextParagraphAlignment.JUSTIFIED: {
-        const dx = Number.isFinite(this.maxLineWidth)
-          ? this._currentLeftMargin - resolvedBBox.min.x
-          : this._currentLeftMargin
-
-        const translated = new Set<THREE.Object3D>()
-        geometryEntries.forEach(entry => {
-          entry.geometry.translate(dx, 0, 0)
-          if (!translated.has(entry.owner)) {
-            translateCharBoxes(entry.owner, dx)
-            translated.add(entry.owner)
-          }
-        })
+        applyLeftAlignment()
         break
       }
       case MTextParagraphAlignment.CENTER: {
+        if (!Number.isFinite(this.maxLineWidth)) {
+          applyLeftAlignment()
+          break
+        }
         const dx =
           this._currentLeftMargin +
           (this.maxLineWidth - size.x) / 2 -
@@ -1879,6 +1919,10 @@ export class MTextProcessor {
         break
       }
       case MTextParagraphAlignment.RIGHT: {
+        if (!Number.isFinite(this.maxLineWidth)) {
+          applyLeftAlignment()
+          break
+        }
         const dx =
           this._currentLeftMargin +
           this.maxLineWidth -
@@ -1896,6 +1940,10 @@ export class MTextProcessor {
         break
       }
       case MTextParagraphAlignment.DISTRIBUTED: {
+        if (!Number.isFinite(this.maxLineWidth)) {
+          applyLeftAlignment()
+          break
+        }
         const gap =
           geometryEntries.length > 1
             ? (this.maxLineWidth - size.x) / (geometryEntries.length - 1)

--- a/packages/mtext-renderer/src/renderer/shxSymbolControlCodes.ts
+++ b/packages/mtext-renderer/src/renderer/shxSymbolControlCodes.ts
@@ -66,6 +66,23 @@ export function isAutoCadPercentSymbolChar(char: string): boolean {
 }
 
 /**
+ * Returns whether a character likely came from an AutoCAD numeric percent code
+ * (`%%ddd`) expanded by mtext-parser into {@link String.fromCharCode}.
+ *
+ * AutoCAD resolves these byte-oriented SHX code points from GDT / symbol fonts
+ * (e.g. `amgdt.shx`), not from the primary text font—even when the text font
+ * defines a glyph at the same code (as with `txt.shx` at code 132).
+ */
+export function isAutoCadNumericPercentControlCodeChar(char: string): boolean {
+  if (char.length !== 1 || isAutoCadPercentSymbolChar(char)) {
+    return false
+  }
+  const code = char.charCodeAt(0)
+  // Legacy GDT / SHX symbol bytes produced by `%%126`–`%%255`.
+  return code >= 126 && code <= 255
+}
+
+/**
  * Returns ordered SHX control-code characters to try in symbol-font fallbacks
  * for an AutoCAD percent-symbol Unicode expansion.
  */

--- a/packages/mtext-renderer/test/font/gbcbig-layout.test.ts
+++ b/packages/mtext-renderer/test/font/gbcbig-layout.test.ts
@@ -1,0 +1,59 @@
+import iconv from 'iconv-lite'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { FontData } from '../../src/font/font'
+import { FontFactory } from '../../src/font/fontFactory'
+import { FontManager } from '../../src/font/fontManager'
+import { ShxFont } from '../../src/font/shxFont'
+
+const FONT_BASE = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data/fonts/'
+
+async function loadGbcbig(): Promise<ShxFont> {
+  const response = await fetch(FONT_BASE + 'gbcbig.shx')
+  if (!response.ok) throw new Error('Failed to fetch gbcbig.shx')
+  const fontData: FontData = {
+    name: 'gbcbig',
+    type: 'shx',
+    data: await response.arrayBuffer(),
+    alias: ['gbcbig'],
+    encoding: 'gb2312'
+  }
+  return FontFactory.instance.createFont(fontData) as ShxFont
+}
+
+
+describe('gbcbig.shx CJK layout (integration)', () => {
+  afterEach(() => {
+    FontManager.instance.release()
+  })
+
+  it(
+    'uses uniform cell advance and consistent baseline for 东亚字符集字体',
+    async () => {
+      const font = await loadGbcbig()
+      const size = 10
+      const text = '东亚字符集字体'
+      const cellWidth =
+        (font.data.content.width / font.data.content.height) * size
+
+      const shapes = text.split('').map(ch => {
+        const shape = font.getCharShape(ch, size)
+        expect(shape, ch).toBeDefined()
+        return shape!
+      })
+
+      const minYs: number[] = []
+      for (const shape of shapes) {
+        expect(shape.width).toBeCloseTo(cellWidth, 4)
+        const geometry = shape.toGeometry()
+        geometry.computeBoundingBox()
+        minYs.push(geometry.boundingBox!.min.y)
+      }
+
+      const maxDelta = Math.max(...minYs) - Math.min(...minYs)
+      expect(maxDelta).toBeLessThan(0.01)
+      expect(maxDelta).toBeLessThan(0.01)
+    },
+    120_000
+  )
+})

--- a/packages/mtext-renderer/test/font/shx-control-code-glyphs.test.ts
+++ b/packages/mtext-renderer/test/font/shx-control-code-glyphs.test.ts
@@ -48,7 +48,7 @@ describe('AutoCAD percent symbols with isocp primary font (integration)', () => 
           label: '%%c',
           unicodeChar: 'Ø',
           symbolChar: '\u2205',
-          isocpWidth: 10,
+          isocpWidth: 12.230769230769234,
           symbolWidth: 6.785714285714286
         },
         {
@@ -99,6 +99,7 @@ describe('AutoCAD percent symbols with isocp primary font (integration)', () => 
 describe('%%130 %%131 glyph fallback (integration)', () => {
   const ch130 = String.fromCharCode(130)
   const ch131 = String.fromCharCode(131)
+  const ch132 = String.fromCharCode(132)
 
   it(
     'resolves %%130/%%131 from amgdt.shx; gdt.ttf has no real glyph at those code points',
@@ -113,6 +114,12 @@ describe('%%130 %%131 glyph fallback (integration)', () => {
       expect(gdt.getCharShape(ch130, 10)).toBeUndefined()
       expect(amgdt.getCharShape(ch130, 10)).toBeDefined()
       expect(amgdt.getCharShape(ch131, 10)).toBeDefined()
+
+      const shape132 = amgdt.getCharShape(ch132, 10)
+      expect(shape132).toBeDefined()
+      expect(shape132!.toGeometry().attributes.position?.count ?? 0).toBeGreaterThan(
+        0
+      )
     },
     60_000
   )

--- a/packages/mtext-renderer/test/renderer/mtext.control-code.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.control-code.test.ts
@@ -1,0 +1,131 @@
+import * as THREE from 'three'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { FontData } from '../../src/font/font'
+import { FontFactory } from '../../src/font/fontFactory'
+import { FontManager } from '../../src/font/fontManager'
+import { ShxFont } from '../../src/font/shxFont'
+import { MText } from '../../src/renderer/mtext'
+import {
+  CharBoxType,
+  createDefaultColorSettings,
+  MTextAttachmentPoint,
+  TextStyle
+} from '../../src/renderer/types'
+
+const FONT_BASE = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data/fonts/'
+
+async function loadShx(name: string, file: string): Promise<ShxFont> {
+  const response = await fetch(FONT_BASE + file)
+  if (!response.ok) throw new Error(`Failed to fetch ${file}`)
+  const fontData: FontData = {
+    name,
+    type: 'shx',
+    data: await response.arrayBuffer(),
+    alias: [name]
+  }
+  return FontFactory.instance.createFont(fontData) as ShxFont
+}
+
+function registerFont(name: string, font: ShxFont) {
+  const key = name.toLowerCase()
+  font.names.add(key)
+  ;(
+    FontManager.instance as unknown as { loadedFontMap: Map<string, unknown> }
+  ).loadedFontMap.set(key, font)
+}
+
+function collectCharBoxes(object: THREE.Object3D) {
+  const out: Array<{ char: string; box: THREE.Box3 }> = []
+  object.traverse(node => {
+    const boxes = node.userData?.layout?.chars as
+      | Array<{ type: CharBoxType; char: string; box: THREE.Box3 }>
+      | undefined
+    if (boxes) {
+      for (const entry of boxes) {
+        if (entry.type === CharBoxType.CHAR) {
+          out.push({ char: entry.char, box: entry.box })
+        }
+      }
+    }
+  })
+  return out
+}
+
+describe('controlCode example %%1326@600 (integration)', () => {
+  const styleManager = {
+    unsupportedTextStyles: {},
+    getMeshBasicMaterial: vi
+      .fn()
+      .mockReturnValue(new THREE.MeshBasicMaterial()),
+    getLineBasicMaterial: vi.fn().mockReturnValue(new THREE.LineBasicMaterial())
+  }
+
+  afterEach(() => {
+    FontManager.instance.release()
+    FontManager.instance.enableFontCache = true
+  })
+
+  it(
+    'renders %%132 from amgdt and keeps 6@600 as trailing text',
+    async () => {
+      FontManager.instance.release()
+      FontManager.instance.enableFontCache = false
+      FontManager.instance.setDefaultFonts('minimal')
+
+      registerFont('txt', await loadShx('txt', 'txt.shx'))
+      registerFont('amgdt', await loadShx('amgdt', 'amgdt.shx'))
+
+      const ch132 = String.fromCharCode(132)
+      const amgdt132 = FontManager.instance.getCharShapeFromSymbolFonts(ch132, 10)
+      const geometry = amgdt132?.toGeometry()
+      geometry?.computeBoundingBox()
+
+      expect((geometry?.attributes.position?.count ?? 0) > 0).toBe(true)
+      expect((amgdt132?.width ?? 0) > 7).toBe(true)
+      expect((amgdt132?.width ?? 0)).toBeGreaterThanOrEqual(10)
+
+      const style: TextStyle = {
+        name: 'standard',
+        standardFlag: 0,
+        fixedTextHeight: 10,
+        widthFactor: 1,
+        obliqueAngle: 0,
+        textGenerationFlag: 0,
+        lastHeight: 10,
+        font: 'txt',
+        bigFont: ''
+      }
+
+      const mtext = new MText(
+        {
+          text: '{Unicode character: %%130 %%131 %%1326@600}',
+          height: 10,
+          width: 0,
+          position: { x: 0, y: 0, z: 0 },
+          attachmentPoint: MTextAttachmentPoint.TopLeft,
+          collectCharBoxes: true
+        },
+        style,
+        styleManager as any,
+        FontManager.instance as any,
+        createDefaultColorSettings()
+      )
+
+      mtext.syncDraw()
+
+      const boxes = collectCharBoxes(mtext)
+      const ch132Box = boxes.find(entry => entry.char === ch132)
+      const sixBox = boxes.find(entry => entry.char === '6')
+
+      expect(ch132Box).toBeDefined()
+      expect((ch132Box!.box.max.x - ch132Box!.box.min.x) > 0).toBe(true)
+      expect(sixBox).toBeDefined()
+      expect(sixBox!.box.min.x).toBeGreaterThanOrEqual(ch132Box!.box.max.x - 0.01)
+      const gap132ToSix = sixBox!.box.min.x - ch132Box!.box.max.x
+      expect(gap132ToSix).toBeGreaterThan(1.5)
+      expect(boxes.map(entry => entry.char).join('')).toContain('6@600')
+    },
+    120_000
+  )
+})

--- a/packages/mtext-renderer/test/renderer/mtext.glyph-fallback.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.glyph-fallback.test.ts
@@ -355,6 +355,102 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
     }
   )
 
+  it('prefers SHX symbol-font glyph for %%132 before default-font fallbacks', () => {
+    const ch132 = String.fromCharCode(132)
+    const defaultShape = createShape(0)
+    const symbolShape = createShape(6.5)
+    const glyphs: Record<string, Record<string, GlyphShape | undefined>> = {
+      txt: {},
+      simkai: { [ch132]: defaultShape },
+      amgdt: { [ch132]: symbolShape }
+    }
+
+    const getCharShape = vi.fn((lookupChar: string, fontName: string) =>
+      resolveCharShape(lookupChar, fontName, glyphs)
+    )
+    const getCharShapeFromDefaults = vi.fn((lookupChar: string) => {
+      for (const fontName of ['txt', 'simkai']) {
+        const shape = resolveCharShape(lookupChar, fontName, glyphs)
+        if (shape) return shape
+      }
+      return undefined
+    })
+    const getCharShapeFromSymbolFonts = vi.fn((lookupChar: string) => {
+      for (const fontName of ['amgdt']) {
+        const shape = resolveCharShape(lookupChar, fontName, glyphs)
+        if (shape) return shape
+      }
+      return undefined
+    })
+
+    const processor = createGlyphFallbackProcessor(
+      { font: 'txt', bigFont: '' },
+      {
+        getFontScaleFactor: () => 1,
+        getFontType: () => 'shx' as const,
+        findAndReplaceFont: (name: string) => name,
+        getCharShape,
+        getCharShapeFromDefaults,
+        getCharShapeFromSymbolFonts,
+        getNotFoundTextShape: () => undefined
+      }
+    )
+
+    getCharShape.mockClear()
+    getCharShapeFromDefaults.mockClear()
+    getCharShapeFromSymbolFonts.mockClear()
+
+    const shape = (processor as any).getCharShape(ch132)
+
+    expect(shape).toBe(symbolShape)
+    expect(getCharShapeFromSymbolFonts).toHaveBeenCalledWith(ch132, 10)
+    expect(getCharShapeFromDefaults).not.toHaveBeenCalled()
+    expect(getCharShape).not.toHaveBeenCalled()
+  })
+
+  it('prefers SHX symbol-font glyph for %%132 when primary font has a wrong code-132 shape', () => {
+    const ch132 = String.fromCharCode(132)
+    const primaryShape = createShape(0)
+    const symbolShape = createShape(6.5)
+    const glyphs: Record<string, Record<string, GlyphShape | undefined>> = {
+      txt: { [ch132]: primaryShape },
+      amgdt: { [ch132]: symbolShape }
+    }
+
+    const getCharShape = vi.fn((lookupChar: string, fontName: string) =>
+      resolveCharShape(lookupChar, fontName, glyphs)
+    )
+    const getCharShapeFromSymbolFonts = vi.fn((lookupChar: string) => {
+      for (const fontName of ['amgdt']) {
+        const shape = resolveCharShape(lookupChar, fontName, glyphs)
+        if (shape) return shape
+      }
+      return undefined
+    })
+
+    const processor = createGlyphFallbackProcessor(
+      { font: 'txt', bigFont: '' },
+      {
+        getFontScaleFactor: () => 1,
+        getFontType: () => 'shx' as const,
+        findAndReplaceFont: (name: string) => name,
+        getCharShape,
+        getCharShapeFromDefaults: vi.fn(),
+        getCharShapeFromSymbolFonts,
+        getNotFoundTextShape: () => undefined
+      }
+    )
+
+    getCharShape.mockClear()
+    getCharShapeFromSymbolFonts.mockClear()
+
+    const shape = (processor as any).getCharShape(ch132)
+
+    expect(shape).toBe(symbolShape)
+    expect(getCharShapeFromSymbolFonts).toHaveBeenCalledWith(ch132, 10)
+    expect(getCharShape).not.toHaveBeenCalled()
+  })
+
   it('stops at primary font when the glyph is present there', () => {
     const primaryShape = createShape(1)
     const bigShape = createShape(2)

--- a/packages/mtext-renderer/test/renderer/shxSymbolControlCodes.test.ts
+++ b/packages/mtext-renderer/test/renderer/shxSymbolControlCodes.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES,
   getShxControlCodeCandidates,
+  isAutoCadNumericPercentControlCodeChar,
   isAutoCadPercentSymbolChar
 } from '../../src/renderer/shxSymbolControlCodes'
 
@@ -36,5 +37,17 @@ describe('shxSymbolControlCodes', () => {
     ])
     expect(getShxControlCodeCandidates('±')).toEqual([String.fromCharCode(177)])
     expect(getShxControlCodeCandidates('A')).toEqual([])
+  })
+
+  it('recognizes numeric %%ddd SHX control-code characters', () => {
+    expect(isAutoCadNumericPercentControlCodeChar(String.fromCharCode(130))).toBe(
+      true
+    )
+    expect(isAutoCadNumericPercentControlCodeChar(String.fromCharCode(132))).toBe(
+      true
+    )
+    expect(isAutoCadNumericPercentControlCodeChar('°')).toBe(false)
+    expect(isAutoCadNumericPercentControlCodeChar('A')).toBe(false)
+    expect(isAutoCadNumericPercentControlCodeChar('9')).toBe(false)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1
       '@mlightcad/shx-parser':
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: ^1.3.4
+        version: 1.3.4
       iconv-lite:
         specifier: ^0.7.0
         version: 0.7.0
@@ -998,8 +998,8 @@ packages:
   '@mlightcad/mtext-parser@1.4.1':
     resolution: {integrity: sha512-PU7D5H/k25vZpTERabpdn5HVAs8+SBNRqgi08wRPiplxTE1eB/zBZRNRrSwHqyWx6xMeQmZ9mhh9DPNpte3gYQ==}
 
-  '@mlightcad/shx-parser@1.3.2':
-    resolution: {integrity: sha512-j84hqbWOVMDuepLEjVsYvxeiCXOVxHyJhl4gM4HtgXZ6ChgTLsuSnqs2bNOt2SwriTvFOsv3QLsOu2iJh857JA==}
+  '@mlightcad/shx-parser@1.3.4':
+    resolution: {integrity: sha512-y0clXQIBslAOwTMFtUnQqzZqhtD5lxUCiJA7lYTYvzO2dzBtsd2LVhUYdyA6R6DwjygOzjegXcP/4oCIsDiZhg==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4470,7 +4470,7 @@ snapshots:
 
   '@mlightcad/mtext-parser@1.4.1': {}
 
-  '@mlightcad/shx-parser@1.3.2': {}
+  '@mlightcad/shx-parser@1.3.4': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary

- Add configurable **default fonts presets** (`minimal`, `r12r14`, `modern`, `international`, `cjk`) with ordered text/symbol fallback chains, synced to main-thread and Web Worker renderers; demo UI can switch presets and re-render.
- Implement **AutoCAD percent symbol semantics**: named codes (`%%c`/`%%d`/`%%p`) and numeric `%%ddd` bytes (126–255) resolve through GDT/symbol SHX fonts (e.g. `amgdt.shx`) before the primary text font, with stroke-geometry validation to skip empty SHX stubs.
- Harden SHX/mesh layout: UNIFONT advance covers ink beyond pen position for GDT glyphs like `%%132`, preserve SHX space advance, guard mesh geometry against non-finite vertices, and bump `@mlightcad/shx-parser` to ^1.3.4.

## Review notes

- Fixed regressions found during review: SHX space glyphs (advance-only), targeted UNIFONT cell-width enforcement (not all GDT symbols), updated isocp `Ø` width expectation for shx-parser 1.3.4 pen advance.
- Integration test `shx-symbol-font-fallback.test.ts` depends on CDN font downloads (~10 MB simsun.ttf); may time out on slow networks.

## Test plan

- [x] `pnpm --filter mtext-renderer test` — 111/112 passed locally (1 CDN integration test timed out on network)
- [ ] Verify demo preset switching and control-code example (`%%1326@600`) in browser
- [ ] Confirm symbol fallback (`%%c`, `%%d`, `%%p`, `%%130`–`%%132`) with `minimal` preset
