### PR TITLE
feat: add SHX SHAPE entity rendering

### DIFF
--- a/packages/example/index.html
+++ b/packages/example/index.html
@@ -112,12 +112,37 @@
         .example-btn:hover {
             background: #555;
         }
+        .content-panel {
+            margin: 10px 0;
+        }
+        .content-panel.hidden {
+            display: none;
+        }
+        .content-panel input[type="number"],
+        .content-panel input[type="text"] {
+            width: 100%;
+            padding: 5px;
+            margin: 5px 0;
+            box-sizing: border-box;
+        }
+        .hint {
+            font-size: 12px;
+            color: #bbb;
+            margin: 4px 0 8px;
+        }
     </style>
 </head>
 <body>
     <div id="controls">
         <h2>MText Renderer Example</h2>
         <div class="row">
+            <div class="field">
+                <label for="content-type">Content Type:</label>
+                <select id="content-type">
+                    <option value="mtext" selected>MText</option>
+                    <option value="shape">SHAPE (SHX shape entity)</option>
+                </select>
+            </div>
             <div class="field">
                 <label for="font-select">Text Style Font:</label>
                 <select id="font-select">
@@ -152,8 +177,43 @@
                 <input type="color" id="by-block-color" value="#ffffff">
             </div>
         </div>
-        <label for="mtext-input">MText:</label>
-        <textarea id="mtext-input" placeholder="Enter MText content here... (Special characters: %%c=Ø, %%d=°, %%p=±)">{\C1;Hello World}\P{\C2;This is a test}\P{\C3;MText Renderer}</textarea>
+        <div id="mtext-panel" class="content-panel">
+            <label for="mtext-input">MText:</label>
+            <textarea id="mtext-input" placeholder="Enter MText content here... (Special characters: %%c=Ø, %%d=°, %%p=±)">{\C1;Hello World}\P{\C2;This is a test}\P{\C3;MText Renderer}</textarea>
+        </div>
+        <div id="shape-panel" class="content-panel hidden">
+            <div class="row">
+                <div class="field">
+                    <label for="shape-font-select">Shape Font (SHX):</label>
+                    <select id="shape-font-select">
+                        <option value="complex" selected>complex</option>
+                    </select>
+                </div>
+                <div class="field">
+                    <label for="shape-name">Shape Name (optional):</label>
+                    <input type="text" id="shape-name" placeholder="e.g. GRS when defined in font">
+                </div>
+            </div>
+            <div class="row">
+                <div class="field">
+                    <label for="shape-number">Shape Number:</label>
+                    <input type="number" id="shape-number" value="128" min="1" max="65535">
+                </div>
+                <div class="field">
+                    <label for="shape-size">Height:</label>
+                    <input type="number" id="shape-size" value="24" min="1" step="1">
+                </div>
+                <div class="field">
+                    <label for="shape-width-factor">Width Factor:</label>
+                    <input type="number" id="shape-width-factor" value="1" min="0.1" step="0.1">
+                </div>
+                <div class="field">
+                    <label for="shape-rotation">Rotation (deg):</label>
+                    <input type="number" id="shape-rotation" value="0" step="1">
+                </div>
+            </div>
+            <p class="hint">Uses <code>complex.shx</code> by default. Shape number 128–132 render distinct glyphs; name lookup is tried first when provided.</p>
+        </div>
         <div style="display: flex; align-items: center; gap: 10px;">
             <button id="render-btn">Render</button>
             <div class="checkbox-container" style="margin: 0;">
@@ -177,6 +237,7 @@
             <button class="example-btn" data-example="color">Color</button>
             <button class="example-btn" data-example="font">Font</button>
             <button class="example-btn" data-example="defaultFonts">Default Fonts</button>
+            <button class="example-btn" data-example="shapes">SHX Shapes</button>
             <button class="example-btn" data-example="alignment">Alignment</button>
             <button class="example-btn" data-example="paragraph">Paragraph</button>
             <button class="example-btn" data-example="stacking">Stacking</button>

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -8,6 +8,7 @@ import {
   MTextData,
   MTextObject,
   RenderMode,
+  ShapeData,
   TextStyle,
   UnifiedRenderer
 } from '@mlightcad/mtext-renderer'
@@ -31,6 +32,15 @@ class MTextRendererExample {
   private statusDiv: HTMLDivElement
   private fontSelect: HTMLSelectElement
   private defaultFontsPresetSelect: HTMLSelectElement
+  private contentTypeSelect: HTMLSelectElement
+  private mtextPanel: HTMLDivElement
+  private shapePanel: HTMLDivElement
+  private shapeFontSelect: HTMLSelectElement
+  private shapeNameInput: HTMLInputElement
+  private shapeNumberInput: HTMLInputElement
+  private shapeSizeInput: HTMLInputElement
+  private shapeWidthFactorInput: HTMLInputElement
+  private shapeRotationInput: HTMLInputElement
   private showBoundingBoxCheckbox: HTMLInputElement
   private showCharBoxesCheckbox: HTMLInputElement
   private showLineBoxesCheckbox: HTMLInputElement
@@ -59,6 +69,8 @@ class MTextRendererExample {
     paragraph:
       '{\\pql;\\P{\\pqi;\\pxi2;\\pxl5;\\pxr5;This paragraph has an indent of 2 units, left margin of 5 units, and right margin of 5 units. The first line is indented.}\\P{\\pqi;\\pxi2;\\pxl5;\\pxr5;This is the second line of the same paragraph, showing the effect of margins.}}',
     multiple: 'multiple', // Special marker for multiple MText rendering
+    /** Grid of SHX shape glyphs from complex.shx (shape numbers 128–132). */
+    shapes: 'shapes',
     /** DXF group 71 attachment points 1–12; renders a grid with insertion crosshairs */
     attachmentGrid: 'attachmentGrid'
   }
@@ -109,6 +121,29 @@ class MTextRendererExample {
     this.defaultFontsPresetSelect = document.getElementById(
       'default-fonts-preset'
     ) as HTMLSelectElement
+    this.contentTypeSelect = document.getElementById(
+      'content-type'
+    ) as HTMLSelectElement
+    this.mtextPanel = document.getElementById('mtext-panel') as HTMLDivElement
+    this.shapePanel = document.getElementById('shape-panel') as HTMLDivElement
+    this.shapeFontSelect = document.getElementById(
+      'shape-font-select'
+    ) as HTMLSelectElement
+    this.shapeNameInput = document.getElementById(
+      'shape-name'
+    ) as HTMLInputElement
+    this.shapeNumberInput = document.getElementById(
+      'shape-number'
+    ) as HTMLInputElement
+    this.shapeSizeInput = document.getElementById(
+      'shape-size'
+    ) as HTMLInputElement
+    this.shapeWidthFactorInput = document.getElementById(
+      'shape-width-factor'
+    ) as HTMLInputElement
+    this.shapeRotationInput = document.getElementById(
+      'shape-rotation'
+    ) as HTMLInputElement
     this.showBoundingBoxCheckbox = document.getElementById(
       'show-bounding-box'
     ) as HTMLInputElement
@@ -138,7 +173,7 @@ class MTextRendererExample {
     this.initializeFonts(true)
       .then(() => {
         // Initial render after fonts are loaded
-        void this.renderMText(this.mtextInput.value)
+        void this.renderCurrentContent()
       })
       .catch(error => {
         console.error('Failed to initialize fonts:', error)
@@ -177,20 +212,40 @@ class MTextRendererExample {
 
     // Render button
     this.renderBtn.addEventListener('click', async () => {
-      const content = this.mtextInput.value
-      await this.renderMText(content)
+      await this.renderCurrentContent()
+    })
+
+    this.contentTypeSelect.addEventListener('change', () => {
+      this.updateContentPanels()
+      void this.renderCurrentContent()
+    })
+    this.updateContentPanels()
+
+    ;[
+      this.shapeFontSelect,
+      this.shapeNameInput,
+      this.shapeNumberInput,
+      this.shapeSizeInput,
+      this.shapeWidthFactorInput,
+      this.shapeRotationInput
+    ].forEach(element => {
+      element.addEventListener('change', () => {
+        if (this.contentTypeSelect.value === 'shape') {
+          void this.renderCurrentContent()
+        }
+      })
     })
 
     // Text style font selection
     this.fontSelect.addEventListener('change', async () => {
       await this.applyDefaultFontsPreset()
-      await this.renderMText(this.mtextInput.value)
+      await this.renderCurrentContent()
     })
 
     // Default fonts preset (fallback chain)
     this.defaultFontsPresetSelect.addEventListener('change', async () => {
       await this.applyDefaultFontsPreset()
-      await this.renderMText(this.mtextInput.value)
+      await this.renderCurrentContent()
     })
 
     // Example buttons
@@ -204,13 +259,19 @@ class MTextRendererExample {
           const content =
             this.exampleTexts[exampleType as keyof typeof this.exampleTexts]
 
-          if (content === 'multiple' || content === 'attachmentGrid') {
-            // Preset grids: don't overwrite the textarea
-            await this.renderMText(content)
+          if (content === 'shapes') {
+            this.contentTypeSelect.value = 'shape'
+            this.updateContentPanels()
+            await this.renderCurrentContent('shapes')
+          } else if (content === 'multiple' || content === 'attachmentGrid') {
+            this.contentTypeSelect.value = 'mtext'
+            this.updateContentPanels()
+            await this.renderCurrentContent(content)
           } else {
-            // For regular examples, update textarea and render
+            this.contentTypeSelect.value = 'mtext'
+            this.updateContentPanels()
             this.mtextInput.value = content
-            await this.renderMText(content)
+            await this.renderCurrentContent(content)
           }
         }
       })
@@ -241,16 +302,33 @@ class MTextRendererExample {
       await this.initializeFonts(false)
 
       // Re-render with current content to reflect the new mode
-      await this.renderMText(this.mtextInput.value)
+      await this.renderCurrentContent()
     })
 
     // Color settings
     this.byLayerColorInput.addEventListener('change', async () => {
-      await this.renderMText(this.mtextInput.value)
+      await this.renderCurrentContent()
     })
     this.byBlockColorInput.addEventListener('change', async () => {
-      await this.renderMText(this.mtextInput.value)
+      await this.renderCurrentContent()
     })
+  }
+
+  private updateContentPanels(): void {
+    const isShape = this.contentTypeSelect.value === 'shape'
+    this.mtextPanel.classList.toggle('hidden', isShape)
+    this.shapePanel.classList.toggle('hidden', !isShape)
+    this.renderBtn.textContent = isShape ? 'Render Shape' : 'Render'
+    this.showCharBoxesCheckbox.disabled = isShape
+    this.showLineBoxesCheckbox.disabled = isShape
+  }
+
+  private async renderCurrentContent(content?: string): Promise<void> {
+    if (this.contentTypeSelect.value === 'shape') {
+      await this.renderShape(content)
+      return
+    }
+    await this.renderMText(content ?? this.mtextInput.value)
   }
 
   private getSelectedDefaultFontsPreset(): DefaultFontsPreset {
@@ -263,7 +341,12 @@ class MTextRendererExample {
     const textChain = this.unifiedRenderer.getDefaultFontsPreset(preset)
     const symbolChain = this.unifiedRenderer.getSymbolFontsPreset(preset)
     const fontsToLoad = [
-      ...new Set([...textChain, ...symbolChain, this.fontSelect.value])
+      ...new Set([
+        ...textChain,
+        ...symbolChain,
+        this.fontSelect.value,
+        this.shapeFontSelect.value
+      ])
     ]
     await this.unifiedRenderer.loadFonts(fontsToLoad)
     this.statusDiv.textContent = `Preset "${preset}": text ${textChain.join(' → ')} | symbol ${symbolChain.join(' → ')}`
@@ -279,9 +362,15 @@ class MTextRendererExample {
 
         // Clear existing options
         this.fontSelect.innerHTML = ''
+        this.shapeFontSelect.innerHTML = ''
 
         // Add all available fonts to dropdown
-        fonts.forEach(font => {
+        fonts.forEach(rawFont => {
+          const font = rawFont as {
+            name: string[]
+            file?: string
+            type?: 'mesh' | 'shx'
+          }
           const option = document.createElement('option')
           option.value = font.name[0]
           option.textContent = font.name[0] // Use the first name from the array
@@ -289,6 +378,16 @@ class MTextRendererExample {
             option.selected = true
           }
           this.fontSelect.appendChild(option)
+
+          if (font.type === 'shx' || font.file?.toLowerCase().endsWith('.shx')) {
+            const shapeOption = document.createElement('option')
+            shapeOption.value = font.name[0]
+            shapeOption.textContent = font.name[0]
+            if (font.name[0] === 'complex') {
+              shapeOption.selected = true
+            }
+            this.shapeFontSelect.appendChild(shapeOption)
+          }
         })
       }
 
@@ -811,6 +910,214 @@ class MTextRendererExample {
     }
   }
 
+  private createShapeTextStyle(font: string, size: number): TextStyle {
+    return {
+      name: 'Standard',
+      standardFlag: 0,
+      fixedTextHeight: size,
+      widthFactor: 1,
+      obliqueAngle: 0,
+      textGenerationFlag: 0,
+      lastHeight: size,
+      font,
+      bigFont: ''
+    }
+  }
+
+  private buildShapeDataFromInputs(): ShapeData {
+    const size = Number(this.shapeSizeInput.value) || 24
+    const widthFactor = Number(this.shapeWidthFactorInput.value) || 1
+    const rotationDeg = Number(this.shapeRotationInput.value) || 0
+    const shapeNumber = Number(this.shapeNumberInput.value)
+    const shapeName = this.shapeNameInput.value.trim()
+
+    const shapeData: ShapeData = {
+      size,
+      widthFactor,
+      position: new THREE.Vector3(120, 420, 0),
+      rotation: (rotationDeg * Math.PI) / 180
+    }
+
+    if (shapeName) {
+      shapeData.name = shapeName
+    }
+    if (Number.isFinite(shapeNumber) && shapeNumber > 0) {
+      shapeData.shapeNumber = shapeNumber
+    }
+
+    return shapeData
+  }
+
+  private createShapeTestData(): {
+    shapeData: ShapeData
+    textStyle: TextStyle
+  }[] {
+    const font = this.shapeFontSelect.value || 'complex'
+    const size = 28
+    const shapeNumbers = [128, 129, 130, 131, 132]
+    const originX = 90
+    const originY = 420
+    const gapX = 110
+
+    return shapeNumbers.map((shapeNumber, index) => ({
+      shapeData: {
+        shapeNumber,
+        size,
+        widthFactor: 1,
+        position: new THREE.Vector3(originX + index * gapX, originY, 0)
+      },
+      textStyle: this.createShapeTextStyle(font, size)
+    }))
+  }
+
+  private clearSceneContent(): void {
+    if (this.currentMText) {
+      this.scene.remove(this.currentMText)
+      this.currentMText = null
+    }
+    if (this.mtextBox) {
+      this.scene.remove(this.mtextBox)
+      this.mtextBox = null
+    }
+    this.charBoxOverlays = []
+    this.lineBoxOverlays = []
+  }
+
+  private isShapeRenderEmpty(shapeObj: MTextObject): boolean {
+    return shapeObj.children.length === 0 || shapeObj.box.isEmpty()
+  }
+
+  private validateShapeInputs(shapeData: ShapeData, font: string): string | null {
+    const name = shapeData.name?.trim()
+    const number = shapeData.shapeNumber
+    const hasName = Boolean(name)
+    const hasNumber = number != null && number > 0
+
+    if (!hasName && !hasNumber) {
+      return 'Provide a shape name or shape number'
+    }
+    if (hasName && !hasNumber) {
+      return `Shape name "${name}" not found in ${font}.shx`
+    }
+    if (!hasName && hasNumber) {
+      return `Shape number ${number} not found in ${font}.shx`
+    }
+    return `Shape name "${name}" and number ${number} not found in ${font}.shx`
+  }
+
+  private async renderShape(content?: string): Promise<void> {
+    try {
+      const startTime = performance.now()
+      this.statusDiv.textContent = 'Rendering SHAPE...'
+      this.statusDiv.style.color = '#ffa500'
+
+      this.clearSceneContent()
+      const colorSettings = this.getColorSettings()
+      const shapeFont = this.shapeFontSelect.value || 'complex'
+      await this.unifiedRenderer.loadFonts([shapeFont])
+
+      const isGrid = content === 'shapes'
+
+      if (!isGrid) {
+        const shapeData = this.buildShapeDataFromInputs()
+        const hasName = Boolean(shapeData.name?.trim())
+        const hasNumber =
+          shapeData.shapeNumber != null && shapeData.shapeNumber > 0
+        if (!hasName && !hasNumber) {
+          this.statusDiv.textContent = 'Provide a shape name or shape number'
+          this.statusDiv.style.color = '#f00'
+          return
+        }
+      }
+
+      const items = isGrid
+        ? this.createShapeTestData()
+        : [
+            {
+              shapeData: this.buildShapeDataFromInputs(),
+              textStyle: this.createShapeTextStyle(
+                shapeFont,
+                Number(this.shapeSizeInput.value) || 24
+              )
+            }
+          ]
+
+      const shapeObjects = await Promise.all(
+        items.map(({ shapeData, textStyle }) =>
+          this.unifiedRenderer.asyncRenderShape(
+            shapeData,
+            textStyle,
+            colorSettings
+          )
+        )
+      )
+
+      if (!isGrid) {
+        const shapeObj = shapeObjects[0]
+        if (this.isShapeRenderEmpty(shapeObj)) {
+          this.statusDiv.textContent = this.validateShapeInputs(
+            items[0].shapeData,
+            shapeFont
+          )
+          this.statusDiv.style.color = '#f00'
+          return
+        }
+      }
+
+      const group = new THREE.Group()
+      let combinedBox: THREE.Box3 | null = null
+
+      if (isGrid) {
+        items.forEach(({ shapeData }) => {
+          group.add(
+            this.createInsertionCrosshair(
+              shapeData.position.x,
+              shapeData.position.y,
+              14
+            )
+          )
+        })
+      } else {
+        const { position } = items[0].shapeData
+        group.add(
+          this.createInsertionCrosshair(position.x, position.y, 18)
+        )
+      }
+
+      shapeObjects.forEach(shapeObj => {
+        group.add(shapeObj)
+        if (shapeObj.box && !shapeObj.box.isEmpty()) {
+          if (combinedBox === null) {
+            combinedBox = shapeObj.box.clone()
+          } else {
+            combinedBox.union(shapeObj.box)
+          }
+          if (
+            this.showBoundingBoxCheckbox.checked &&
+            !shapeObj.box.isEmpty()
+          ) {
+            group.add(this.createMTextBox(shapeObj.box))
+          }
+        }
+      })
+
+      ;(group as unknown as MTextObject).box = combinedBox ?? new THREE.Box3()
+      this.currentMText = group as unknown as MTextObject
+      this.scene.add(this.currentMText)
+
+      const renderTime = performance.now() - startTime
+      const label = isGrid
+        ? `${shapeObjects.length} SHX shapes (128–132)`
+        : `SHAPE #${items[0].shapeData.shapeNumber ?? items[0].shapeData.name ?? '?'}`
+      this.statusDiv.textContent = `Rendered ${label} in ${renderTime.toFixed(2)}ms (main thread; SHAPE uses sync path)`
+      this.statusDiv.style.color = '#0f0'
+    } catch (error) {
+      console.error('Error rendering SHAPE:', error)
+      this.statusDiv.textContent = 'Error rendering SHAPE'
+      this.statusDiv.style.color = '#f00'
+    }
+  }
+
   private async renderMText(content: string): Promise<void> {
     try {
       const startTime = performance.now()
@@ -819,18 +1126,8 @@ class MTextRendererExample {
       this.statusDiv.textContent = 'Rendering MText...'
       this.statusDiv.style.color = '#ffa500'
 
-      // Remove existing MText if any
-      if (this.currentMText) {
-        this.scene.remove(this.currentMText)
-      }
-
-      // Remove existing bounding boxes
-      if (this.mtextBox) {
-        this.scene.remove(this.mtextBox)
-        this.mtextBox = null
-      }
-      this.charBoxOverlays = []
-      this.lineBoxOverlays = []
+      // Remove existing content if any
+      this.clearSceneContent()
 
       let renderTime: number
       const colorSettings = this.getColorSettings()

--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-renderer",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "AutoCAD MText renderer based on Three.js",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",

--- a/packages/mtext-renderer/src/font/baseFont.ts
+++ b/packages/mtext-renderer/src/font/baseFont.ts
@@ -73,6 +73,13 @@ export abstract class BaseFont {
   abstract getCodeShape(code: number, size: number): BaseTextShape | undefined
 
   /**
+   * Gets a named SHX shape glyph when supported by the font implementation.
+   */
+  getShapeByName(_name: string, _size: number): BaseTextShape | undefined {
+    return undefined
+  }
+
+  /**
    * Gets the scale factor for this font.
    * This is used to adjust the size of characters when rendering.
    * @returns The scale factor as a number

--- a/packages/mtext-renderer/src/font/fontManager.ts
+++ b/packages/mtext-renderer/src/font/fontManager.ts
@@ -366,6 +366,30 @@ export class FontManager {
   }
 
   /**
+   * Resolves a named SHX shape glyph from the specified font.
+   */
+  public getShapeByName(
+    name: string,
+    fontName: string,
+    size: number
+  ): BaseTextShape | undefined {
+    const currentFont = this.getFontByName(fontName)
+    return currentFont?.getShapeByName(name, size)
+  }
+
+  /**
+   * Resolves an SHX shape glyph by numeric character code from the specified font.
+   */
+  public getShapeByCode(
+    code: number,
+    fontName: string,
+    size: number
+  ): BaseTextShape | undefined {
+    const currentFont = this.getFontByName(fontName)
+    return currentFont?.getCodeShape(code, size)
+  }
+
+  /**
    * Gets the text shape from the first loaded default font that contains the character.
    * Used after primary and optional bigFont lookups per AutoCAD text-style semantics.
    */

--- a/packages/mtext-renderer/src/font/shxFont.ts
+++ b/packages/mtext-renderer/src/font/shxFont.ts
@@ -119,6 +119,20 @@ export class ShxFont extends BaseFont {
     return new ShxTextShape(code, size, shape, this)
   }
 
+  /**
+   * Gets the shape data for a named SHX shape at a given size.
+   *
+   * Shape names are matched case-insensitively via the underlying SHX parser.
+   */
+  public getShapeByName(name: string, size: number) {
+    const shape = this.font.getShapeByName(name, size)
+    if (!shape || !ShxFont.hasRenderableStrokes(shape)) {
+      return undefined
+    }
+    const code = this.font.getShapeCode(name)
+    return new ShxTextShape(code ?? 0, size, shape, this)
+  }
+
   /** True when the SHX glyph has drawable strokes or a non-zero pen advance. */
   private static hasRenderableStrokes(shape: ShxShape): boolean {
     if (shape.polylines.some(line => line.length >= 2)) {

--- a/packages/mtext-renderer/src/renderer/index.ts
+++ b/packages/mtext-renderer/src/renderer/index.ts
@@ -1,6 +1,7 @@
 export * from './colorUtils'
 export * from './constants'
 export * from './mtext'
+export * from './shape'
 export * from './mtextDataUtils'
 export * from './styleManager'
 export * from './types'

--- a/packages/mtext-renderer/src/renderer/mtext.ts
+++ b/packages/mtext-renderer/src/renderer/mtext.ts
@@ -24,6 +24,7 @@ import {
   MTextFlowDirection,
   MTextLayout,
   Point2d,
+  ShapeData,
   TextStyle
 } from './types'
 
@@ -320,6 +321,41 @@ export class MText extends THREE.Object3D {
       return undefined
     }
 
+    return this.finalizePlacement(object, mtextData, layoutHeight)
+  }
+
+  /**
+   * Builds and places one SHX shape glyph.
+   */
+  loadShape(shapeData: ShapeData, style: TextStyle) {
+    const { object, height: layoutHeight } = this.createShapeGroup(
+      shapeData,
+      style
+    )
+    if (!object) {
+      return undefined
+    }
+
+    const placementData: MTextData = {
+      text: '',
+      height: shapeData.size,
+      width: Infinity,
+      widthFactor: shapeData.widthFactor ?? style.widthFactor ?? 1,
+      position: shapeData.position,
+      rotation: shapeData.rotation,
+      directionVector: shapeData.directionVector,
+      attachmentPoint: MTextAttachmentPoint.BaselineLeft,
+      drawingDirection: MTextFlowDirection.BOTTOM_TO_TOP,
+      collectCharBoxes: false
+    }
+    return this.finalizePlacement(object, placementData, layoutHeight)
+  }
+
+  private finalizePlacement(
+    object: THREE.Object3D,
+    mtextData: MTextData,
+    layoutHeight: number
+  ) {
     // When the caller does not pre-declare the text width (e.g. AcDbText
     // and AcDbAttribute, which let the renderer's own font metrics drive
     // layout), `mtextData.width` is `Infinity`. Using that value verbatim
@@ -414,6 +450,40 @@ export class MText extends THREE.Object3D {
     object.updateMatrix()
     object.updateMatrixWorld(true)
     return object
+  }
+
+  private createShapeGroup(shapeData: ShapeData, style: TextStyle) {
+    const defaultFontSize = shapeData.size || style.fixedTextHeight || 0
+    const defaultWidthFactor =
+      shapeData.widthFactor ?? style.widthFactor ?? 1.0
+    const textLineFormatOptions: MTextFormatOptions = {
+      fontSize: defaultFontSize,
+      widthFactor: defaultWidthFactor,
+      lineSpaceFactor: 0.3,
+      horizontalAlignment: MTextParagraphAlignment.LEFT,
+      maxWidth: 0,
+      flowDirection: MTextFlowDirection.BOTTOM_TO_TOP,
+      byBlockColor: this._colorSettings.byBlockColor,
+      byLayerColor: this._colorSettings.byLayerColor,
+      removeFontExtension: true,
+      collectCharBoxes: false
+    }
+
+    const textLine = new MTextProcessor(
+      style,
+      this._colorSettings,
+      this._styleManager,
+      this._fontManager,
+      textLineFormatOptions
+    )
+    const object = textLine.processShapeGlyph(
+      shapeData.name,
+      shapeData.shapeNumber
+    )
+    return {
+      object,
+      height: textLine.totalHeight
+    }
   }
 
   /**

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -806,6 +806,170 @@ export class MTextProcessor {
   }
 
   /**
+   * Renders one SHX shape glyph for AutoCAD SHAPE entities.
+   *
+   * The glyph is resolved by {@link shapeName} first, then by {@link shapeNumber}.
+   */
+  processShapeGlyph(
+    shapeName?: string,
+    shapeNumber?: number
+  ): THREE.Object3D | undefined {
+    const resolved = this.resolveShapeGlyph(shapeName, shapeNumber)
+    if (!resolved) {
+      return undefined
+    }
+
+    const geometries: THREE.BufferGeometry[] = []
+    const lineGeometries: THREE.BufferGeometry[] = []
+    const meshCharBoxes: CharBox[] = []
+    const lineCharBoxes: CharBox[] = []
+    const charY =
+      this.flowDirection === MTextFlowDirection.BOTTOM_TO_TOP
+        ? 0
+        : -this.currentLayoutFontSize
+
+    const advance = this.buildShapeGeometry(
+      resolved.shape,
+      resolved.label,
+      0,
+      charY,
+      geometries,
+      lineGeometries,
+      meshCharBoxes,
+      lineCharBoxes
+    )
+
+    this._totalHeight = this.currentLayoutFontSize
+    this._maxFontSize = this.currentLayoutFontSize
+    this._maxLineAdvance = advance
+
+    const object = this.toThreeObject(
+      geometries,
+      lineGeometries,
+      meshCharBoxes,
+      lineCharBoxes,
+      CharBoxType.CHAR
+    )
+    if (object) {
+      object.userData.logicalAdvanceWidth = advance
+    }
+    return object
+  }
+
+  private resolveShapeGlyph(
+    shapeName?: string,
+    shapeNumber?: number
+  ): { shape: BaseTextShape; label: string } | undefined {
+    const size = this.currentLayoutFontSize
+    const fontName = this.textStyle.font.toLowerCase()
+    const trimmedName = shapeName?.trim()
+    const hasNumber = shapeNumber != null && shapeNumber !== 0
+
+    if (trimmedName) {
+      const byName = this.fontManager.getShapeByName(trimmedName, fontName, size)
+      if (byName) {
+        return { shape: byName, label: trimmedName }
+      }
+    }
+
+    if (hasNumber) {
+      const byCode = this.fontManager.getShapeByCode(shapeNumber!, fontName, size)
+      if (byCode) {
+        return { shape: byCode, label: String.fromCharCode(shapeNumber!) }
+      }
+    }
+
+    // SHAPE entities have no "?" placeholder when name/number lookup fails.
+    return undefined
+  }
+
+  /**
+   * Builds geometry for one glyph and appends it to the output buffers.
+   *
+   * @returns Horizontal advance width after width factor and oblique skew.
+   */
+  private buildShapeGeometry(
+    shape: BaseTextShape,
+    label: string,
+    charX: number,
+    charY: number,
+    geometries: THREE.BufferGeometry[],
+    lineGeometries: THREE.BufferGeometry[],
+    meshCharBoxes: CharBox[],
+    lineCharBoxes: CharBox[]
+  ): number {
+    const geometry = shape.toGeometry()
+    geometry.scale(this.currentWidthFactor, 1, 1)
+    const charHeight = this.currentLayoutFontSize
+
+    let obliqueAngle = this._currentContext.oblique
+    if (this._currentContext.italic) {
+      obliqueAngle += 15
+    }
+    let obliqueExtraAdvance = 0
+    if (obliqueAngle) {
+      const angleRad = (obliqueAngle * Math.PI) / 180
+      const skewMatrix = new THREE.Matrix4()
+      skewMatrix.set(
+        1,
+        Math.tan(angleRad),
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1
+      )
+      geometry.applyMatrix4(skewMatrix)
+      obliqueExtraAdvance = Math.tan(angleRad) * charHeight
+    }
+
+    const fontType = this.fontManager.getFontType(this.currentFont)
+    if (this._currentContext.bold && fontType === 'mesh') {
+      geometry.scale(1.06, 1.06, 1)
+    }
+
+    geometry.translate(charX, charY, 0)
+    geometries.push(geometry)
+
+    if (this._options.collectCharBoxes !== false) {
+      geometry.userData.char = label
+      if (!geometry.boundingBox) {
+        geometry.computeBoundingBox()
+      }
+      const box = new THREE.Box3().copy(geometry.boundingBox!)
+      if (geometry instanceof THREE.ShapeGeometry) {
+        meshCharBoxes.push({
+          type: CharBoxType.CHAR,
+          box,
+          char: label,
+          children: []
+        })
+      } else {
+        lineCharBoxes.push({
+          type: CharBoxType.CHAR,
+          box,
+          char: label,
+          children: []
+        })
+      }
+    }
+
+    return (
+      shape.width * this.currentWidthFactor +
+      obliqueExtraAdvance * this.currentWidthFactor
+    )
+  }
+
+  /**
    * Render the specified texts
    * @param item Input texts to render
    */

--- a/packages/mtext-renderer/src/renderer/shape.ts
+++ b/packages/mtext-renderer/src/renderer/shape.ts
@@ -1,0 +1,122 @@
+import * as THREE from 'three'
+
+import { FontManager } from '../font'
+import { MText } from './mtext'
+import { StyleManager } from './styleManager'
+import {
+  ColorSettings,
+  createDefaultColorSettings,
+  MTextAttachmentPoint,
+  MTextFlowDirection,
+  MTextLayout,
+  ShapeData,
+  TextStyle
+} from './types'
+
+/**
+ * Represents one AutoCAD SHAPE entity in Three.js.
+ */
+export class Shape extends THREE.Object3D {
+  private _shapeData: ShapeData
+  private _style: TextStyle
+  private _fontsInStyleLoaded: boolean
+  private _styleManager: StyleManager
+  private _fontManager: FontManager
+  private _colorSettings: ColorSettings
+  private _box: THREE.Box3
+
+  constructor(
+    shapeData: ShapeData,
+    style: TextStyle,
+    styleManager: StyleManager,
+    fontManager: FontManager,
+    colorSettings: ColorSettings = createDefaultColorSettings()
+  ) {
+    super()
+    this._shapeData = shapeData
+    this._style = style
+    this._styleManager = styleManager
+    this._fontManager = fontManager
+    this._colorSettings = {
+      byLayerColor: colorSettings.byLayerColor,
+      byBlockColor: colorSettings.byBlockColor,
+      layer: colorSettings.layer,
+      color: colorSettings.color.copy()
+    }
+    this._box = new THREE.Box3()
+    this._fontsInStyleLoaded = false
+  }
+
+  get box() {
+    return this._box
+  }
+
+  get styleManager() {
+    return this._styleManager
+  }
+
+  get textStyle() {
+    return this._style
+  }
+
+  createLayoutData(): MTextLayout {
+    return { lines: [], chars: [] }
+  }
+
+  async asyncDraw() {
+    const fonts: string[] = []
+    if (!this._fontsInStyleLoaded) {
+      for (const key of ['font', 'bigFont', 'extendedFont'] as const) {
+        const fontName = this.getFontName(this._style[key])
+        if (fontName) fonts.push(fontName)
+      }
+    }
+    if (fonts.length > 0) {
+      await this._fontManager.loadFontsByNames(fonts)
+      this._fontsInStyleLoaded = true
+    }
+    this.syncDraw()
+  }
+
+  syncDraw() {
+    const builder = new MText(
+      this.createPlacementData(),
+      this._style,
+      this._styleManager,
+      this._fontManager,
+      this._colorSettings
+    )
+    const obj = builder.loadShape(this._shapeData, this._style)
+    super.clear()
+    if (!obj) {
+      this._box.makeEmpty()
+      return
+    }
+
+    this.add(obj)
+    this._box.setFromObject(obj)
+  }
+
+  private createPlacementData() {
+    return {
+      text: '',
+      height: this._shapeData.size,
+      width: Infinity,
+      widthFactor:
+        this._shapeData.widthFactor ?? this._style.widthFactor ?? 1,
+      position: this._shapeData.position,
+      rotation: this._shapeData.rotation,
+      directionVector: this._shapeData.directionVector,
+      attachmentPoint: MTextAttachmentPoint.BaselineLeft,
+      drawingDirection: MTextFlowDirection.BOTTOM_TO_TOP,
+      collectCharBoxes: false
+    }
+  }
+
+  private getFontName(font?: string) {
+    if (!font) return undefined
+    const normalized = font.trim().toLowerCase()
+    if (!normalized) return undefined
+    return normalized.endsWith('.shx') ? normalized.slice(0, -4) : normalized
+  }
+}

--- a/packages/mtext-renderer/src/renderer/types.ts
+++ b/packages/mtext-renderer/src/renderer/types.ts
@@ -196,6 +196,26 @@ export interface MTextData {
 }
 
 /**
+ * Describes one AutoCAD SHAPE entity for rendering.
+ */
+export interface ShapeData {
+  /** Shape name within the SHX font (DXF group 2). */
+  name?: string
+  /** Numeric shape code within the SHX font. */
+  shapeNumber?: number
+  /** Shape height (DXF group 40). */
+  size: number
+  /** Insertion point in WCS coordinates. */
+  position: Point3d
+  /** Rotation relative to the shape OCS X axis, in radians. */
+  rotation?: number
+  /** Extrusion/normal vector. */
+  directionVector?: Point3d
+  /** Relative X-scale factor. */
+  widthFactor?: number
+}
+
+/**
  * Represents a text style configuration that defines the visual appearance and formatting of text.
  * This interface contains properties that control various aspects of text rendering including font,
  * dimensions, and display characteristics.

--- a/packages/mtext-renderer/src/worker/baseRenderer.ts
+++ b/packages/mtext-renderer/src/worker/baseRenderer.ts
@@ -5,6 +5,7 @@ import {
   ColorSettings,
   MTextData,
   MTextLayout,
+  ShapeData,
   TextStyle
 } from '../renderer/types'
 
@@ -74,6 +75,24 @@ export interface MTextBaseRenderer {
     textStyle: TextStyle,
     colorSettings?: ColorSettings
   ): MTextObject
+
+  /**
+   * Render one SHX shape glyph synchronously.
+   */
+  syncRenderShape(
+    shapeContent: ShapeData,
+    textStyle: TextStyle,
+    colorSettings?: ColorSettings
+  ): MTextObject
+
+  /**
+   * Render one SHX shape glyph asynchronously.
+   */
+  asyncRenderShape(
+    shapeContent: ShapeData,
+    textStyle: TextStyle,
+    colorSettings?: ColorSettings
+  ): Promise<MTextObject>
 
   /**
    * Ensure the specified fonts are available to the renderer.

--- a/packages/mtext-renderer/src/worker/mainThreadRenderer.ts
+++ b/packages/mtext-renderer/src/worker/mainThreadRenderer.ts
@@ -1,11 +1,13 @@
 import { FontManager } from '../font'
 import { DefaultStyleManager } from '../renderer/defaultStyleManager'
 import { MText } from '../renderer/mtext'
+import { Shape } from '../renderer/shape'
 import { StyleManager } from '../renderer/styleManager'
 import {
   ColorSettings,
   createDefaultColorSettings,
   MTextData,
+  ShapeData,
   TextStyle
 } from '../renderer/types'
 import { MTextBaseRenderer, MTextObject } from './baseRenderer'
@@ -84,6 +86,41 @@ export class MainThreadRenderer implements MTextBaseRenderer {
     mtext.syncDraw()
     mtext.updateMatrixWorld(true)
     return mtext as MTextObject
+  }
+
+  async asyncRenderShape(
+    shapeContent: ShapeData,
+    textStyle: TextStyle,
+    colorSettings: ColorSettings = createDefaultColorSettings()
+  ): Promise<MTextObject> {
+    await this.ensureInitialized()
+    const shape = new Shape(
+      shapeContent,
+      textStyle,
+      this.defaultStyleManager,
+      this.fontManager,
+      colorSettings
+    )
+    await shape.asyncDraw()
+    shape.updateMatrixWorld(true)
+    return shape as unknown as MTextObject
+  }
+
+  syncRenderShape(
+    shapeContent: ShapeData,
+    textStyle: TextStyle,
+    colorSettings: ColorSettings = createDefaultColorSettings()
+  ): MTextObject {
+    const shape = new Shape(
+      shapeContent,
+      textStyle,
+      this.defaultStyleManager,
+      this.fontManager,
+      colorSettings
+    )
+    shape.syncDraw()
+    shape.updateMatrixWorld(true)
+    return shape as unknown as MTextObject
   }
 
   /**

--- a/packages/mtext-renderer/src/worker/unifiedRenderer.ts
+++ b/packages/mtext-renderer/src/worker/unifiedRenderer.ts
@@ -4,6 +4,7 @@ import {
   ColorSettings,
   createDefaultColorSettings,
   MTextData,
+  ShapeData,
   TextStyle
 } from '../renderer/types'
 import { MTextBaseRenderer, MTextObject } from './baseRenderer'
@@ -122,6 +123,31 @@ export class UnifiedRenderer {
   ): MTextObject {
     return this.mainThreadRenderer.syncRenderMText(
       mtextContent,
+      textStyle,
+      colorSettings
+    )
+  }
+
+  async asyncRenderShape(
+    shapeContent: ShapeData,
+    textStyle: TextStyle,
+    colorSettings: ColorSettings = createDefaultColorSettings(),
+    _mode?: RenderMode
+  ): Promise<MTextObject> {
+    return this.mainThreadRenderer.asyncRenderShape(
+      shapeContent,
+      textStyle,
+      colorSettings
+    )
+  }
+
+  syncRenderShape(
+    shapeContent: ShapeData,
+    textStyle: TextStyle,
+    colorSettings: ColorSettings = createDefaultColorSettings()
+  ): MTextObject {
+    return this.mainThreadRenderer.syncRenderShape(
+      shapeContent,
       textStyle,
       colorSettings
     )

--- a/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
+++ b/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
@@ -13,6 +13,7 @@ import {
   LineLayout,
   MTextData,
   MTextLayout,
+  ShapeData,
   TextStyle
 } from '../renderer/types'
 import { MTextBaseRenderer, MTextObject } from './baseRenderer'
@@ -478,6 +479,26 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
   ): MTextObject {
     throw new Error(
       'Fuction \'syncRenderMText\' isn\'t supported in \'WebWorkerRenderer\'!'
+    )
+  }
+
+  async asyncRenderShape(
+    _shapeContent: ShapeData,
+    _textStyle: TextStyle,
+    _colorSettings: ColorSettings = createDefaultColorSettings()
+  ): Promise<MTextObject> {
+    throw new Error(
+      'Function \'asyncRenderShape\' isn\'t supported in \'WebWorkerRenderer\'!'
+    )
+  }
+
+  syncRenderShape(
+    _shapeContent: ShapeData,
+    _textStyle: TextStyle,
+    _colorSettings: ColorSettings = createDefaultColorSettings()
+  ): MTextObject {
+    throw new Error(
+      'Function \'syncRenderShape\' isn\'t supported in \'WebWorkerRenderer\'!'
     )
   }
 

--- a/packages/mtext-renderer/test/renderer/shape-glyph.test.ts
+++ b/packages/mtext-renderer/test/renderer/shape-glyph.test.ts
@@ -1,0 +1,109 @@
+import * as THREE from 'three'
+import { describe, expect, it, vi } from 'vitest'
+import { MTextColor } from '@mlightcad/mtext-parser'
+
+import { FontFactory } from '../../src/font/fontFactory'
+import { FontManager } from '../../src/font/fontManager'
+import { ShxFont } from '../../src/font/shxFont'
+import { MTextProcessor } from '../../src/renderer/mtextProcessor'
+import {
+  createDefaultColorSettings,
+  MTextFlowDirection
+} from '../../src/renderer/types'
+import { ShxFont as ShxParserFont, ShxFontData, ShxFontType } from '@mlightcad/shx-parser'
+
+function createNamedShapeFont(): ShxFont {
+  const fontData: ShxFontData = {
+    header: {
+      fontType: ShxFontType.SHAPES,
+      fileHeader: 'AutoCAD-86 shapes V1.0',
+      fileVersion: '1.0'
+    },
+    content: {
+      data: {
+        135: new Uint8Array([
+          ...new TextEncoder().encode('GRS'),
+          0,
+          0x01,
+          0x80,
+          0x02,
+          0x00
+        ])
+      },
+      names: { GRS: 135 },
+      info: '',
+      orientation: 'horizontal',
+      baseUp: 8,
+      baseDown: 2,
+      height: 10,
+      width: 10,
+      isExtended: false
+    }
+  }
+  const parserFont = new ShxParserFont(fontData)
+  return FontFactory.instance.createFont({
+    name: 'testshapes',
+    alias: ['testshapes'],
+    type: 'shx',
+    data: parserFont.fontData
+  }) as ShxFont
+}
+
+describe('MTextProcessor shape glyph rendering', () => {
+  it('renders by shape name and falls back to shape number', () => {
+    const font = createNamedShapeFont()
+    FontManager.instance.loadedFontMap.set('testshapes', font)
+
+    const styleManager = {
+      unsupportedTextStyles: {},
+      getMeshBasicMaterial: vi
+        .fn()
+        .mockReturnValue(new THREE.MeshBasicMaterial({ color: 0xffffff })),
+      getLineBasicMaterial: vi
+        .fn()
+        .mockReturnValue(new THREE.LineBasicMaterial({ color: 0xffffff }))
+    }
+
+    const processor = new MTextProcessor(
+      {
+        name: 'TEST',
+        standardFlag: 0,
+        fixedTextHeight: 0,
+        widthFactor: 1,
+        obliqueAngle: 0,
+        textGenerationFlag: 0,
+        lastHeight: 0,
+        font: 'testshapes',
+        bigFont: ''
+      },
+      {
+        ...createDefaultColorSettings(),
+        color: new MTextColor(256)
+      },
+      styleManager as any,
+      FontManager.instance,
+      {
+        fontSize: 10,
+        widthFactor: 1,
+        lineSpaceFactor: 0.3,
+        horizontalAlignment: 1,
+        maxWidth: 0,
+        flowDirection: MTextFlowDirection.BOTTOM_TO_TOP,
+        byBlockColor: 0xffffff,
+        byLayerColor: 0xffffff,
+        removeFontExtension: true,
+        collectCharBoxes: false
+      }
+    )
+
+    const byName = processor.processShapeGlyph('GRS', undefined)
+    expect(byName).toBeInstanceOf(THREE.Object3D)
+
+    const byNumber = processor.processShapeGlyph(undefined, 135)
+    expect(byNumber).toBeInstanceOf(THREE.Object3D)
+
+    expect(processor.processShapeGlyph('MISSING', undefined)).toBeUndefined()
+    expect(processor.processShapeGlyph('MISSING', 999)).toBeUndefined()
+    expect(processor.processShapeGlyph(undefined, 999)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Add AutoCAD SHAPE entity rendering via new `Shape` class and `UnifiedRenderer` shape APIs
- Resolve SHX shape glyphs by name first, then by shape number; no placeholder glyph on lookup failure
- Extend the example app with a SHAPE content-type panel and `complex.shx` demo grid (shapes 128–132)
- Bump `@mlightcad/mtext-renderer` to v0.11.1

## Test plan
- [ ] Run unit tests: `nx test mtext-renderer` (includes `shape-glyph.test.ts`)
- [ ] Open example app, switch Content Type to **SHAPE (SHX shape entity)**
- [ ] Render shape number 128–132 from `complex.shx` and verify distinct glyphs
- [ ] Try name lookup when a shape name is defined in the font
- [ ] Confirm MText rendering still works when switching back to MText mode
- [ ] Verify bounding box overlay works for single-shape renders

Made with [Cursor](https://cursor.com)