### PR TITLE
feat: render AutoCAD percent symbols via parser tokens and SHX code lookup

### DIFF
--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -42,7 +42,7 @@
     "3d-text"
   ],
   "dependencies": {
-    "@mlightcad/mtext-parser": "^1.4.1",
+    "@mlightcad/mtext-parser": "^1.5.0",
     "@mlightcad/shx-parser": "^1.3.4",
     "iconv-lite": "^0.7.0",
     "idb": "^8.0.3",

--- a/packages/mtext-renderer/src/font/defaultFontsPresets.ts
+++ b/packages/mtext-renderer/src/font/defaultFontsPresets.ts
@@ -40,11 +40,11 @@ export const SYMBOL_FONTS_PRESETS: Record<
   DefaultFontsPreset,
   readonly string[]
 > = {
-  minimal: ['amgdt'],
-  r12r14: ['amgdt'],
-  modern: ['amgdt'],
-  international: ['amgdt'],
-  cjk: ['amgdt']
+  minimal: ['simplex', 'amgdt'],
+  r12r14: ['simplex', 'amgdt'],
+  modern: ['simplex', 'amgdt'],
+  international: ['simplex', 'amgdt'],
+  cjk: ['simplex', 'amgdt']
 }
 
 export function isDefaultFontsPreset(

--- a/packages/mtext-renderer/src/font/fontManager.ts
+++ b/packages/mtext-renderer/src/font/fontManager.ts
@@ -73,7 +73,7 @@ export class FontManager {
    * `%%nnn`, etc.). Separate from {@link defaultFonts} so text fallbacks are not
    * polluted by symbol-font code-point matches.
    */
-  public symbolFonts = new Set<string>(['amgdt'])
+  public symbolFonts = new Set<string>(['simplex', 'amgdt'])
 
   /** Event managers for font-related events */
   public readonly events = {
@@ -408,16 +408,20 @@ export class FontManager {
   }
 
   /**
-   * Gets the text shape from configured GDT / symbol fonts (e.g. `amgdt.shx`).
-   * Used for AutoCAD percent codes and other symbol-font code points.
+   * Gets the text shape from configured GDT / symbol fonts (e.g. `amgdt.shx`)
+   * by font-internal character code.
+   *
+   * AutoCAD `%%` symbols resolve against SHX code points (e.g. 126, 129, 132),
+   * not Unicode text semantics. Use {@link BaseFont.getCodeShape} so BIGFONT and
+   * Unicode SHX fonts are queried consistently.
    */
-  public getCharShapeFromSymbolFonts(
-    char: string,
+  public getCodeShapeFromSymbolFonts(
+    code: number,
     size: number
   ): BaseTextShape | undefined {
     for (const fontName of this.symbolFonts) {
       const font = this.loadedFontMap.get(fontName.toLowerCase())
-      const shape = font?.getCharShape(char, size)
+      const shape = font?.getCodeShape(code, size)
       if (shape) {
         return shape
       }

--- a/packages/mtext-renderer/src/renderer/mtext.ts
+++ b/packages/mtext-renderer/src/renderer/mtext.ts
@@ -613,7 +613,8 @@ export class MText extends THREE.Object3D {
     )
     const parser = new MTextParser(expandPercentControlCodes(mtextData.text), context, {
       resetParagraphParameters: true,
-      yieldPropertyCommands: true
+      yieldPropertyCommands: true,
+      yieldPercentSymbols: true
     })
     const tokens = parser.parse()
     const object = textLine.processText(tokens)

--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -3,6 +3,7 @@ import {
   MTextContext,
   MTextParagraphAlignment,
   MTextToken,
+  PercentSymbolData,
   TokenType
 } from '@mlightcad/mtext-parser'
 import * as THREE from 'three'
@@ -16,10 +17,7 @@ import {
   LINE_SPACING_SCALE_FACTOR,
   STACK_VERTICAL_SHIFT_FACTOR
 } from './constants'
-import {
-  getShxControlCodeCandidates,
-  isAutoCadNumericPercentControlCodeChar
-} from './shxSymbolControlCodes'
+import { getPercentSymbolLookupCodes } from './shxSymbolControlCodes'
 import { StyleManager } from './styleManager'
 import {
   CharBox,
@@ -1014,6 +1012,14 @@ export class MTextProcessor {
         }
       } else if (token.type === TokenType.SPACE) {
         this.processBlank(meshCharBoxes, lineCharBoxes)
+      } else if (token.type === TokenType.PERCENT_SYMBOL) {
+        this.processPercentSymbol(
+          token.data as PercentSymbolData,
+          geometries,
+          lineGeometries,
+          meshCharBoxes,
+          lineCharBoxes
+        )
       } else if (token.type === TokenType.PROPERTIES_CHANGED) {
         // FLUSH before changing style: ensures all geometries up to this point use the previous style.
         // This is critical for correct color/formatting application within a line.
@@ -1590,14 +1596,38 @@ export class MTextProcessor {
     })
   }
 
-  private processChar(
-    char: string,
+  private processPercentSymbol(
+    data: PercentSymbolData,
     geometries: THREE.BufferGeometry[],
     lineGeometries: THREE.BufferGeometry[],
     meshCharBoxes: CharBox[],
     lineCharBoxes: CharBox[]
   ): void {
-    const shape = this.getCharShape(char)
+    if (data.kind === 'literal') {
+      this.processChar(data.char, geometries, lineGeometries, meshCharBoxes, lineCharBoxes)
+      return
+    }
+
+    const shape = this.resolvePercentSymbolShape(data)
+    this.processChar(
+      data.char,
+      geometries,
+      lineGeometries,
+      meshCharBoxes,
+      lineCharBoxes,
+      shape
+    )
+  }
+
+  private processChar(
+    char: string,
+    geometries: THREE.BufferGeometry[],
+    lineGeometries: THREE.BufferGeometry[],
+    meshCharBoxes: CharBox[],
+    lineCharBoxes: CharBox[],
+    shapeOverride?: BaseTextShape
+  ): void {
+    const shape = shapeOverride ?? this.getCharShape(char)
     if (!shape) {
       this.processBlank(meshCharBoxes, lineCharBoxes)
       return
@@ -1832,41 +1862,25 @@ export class MTextProcessor {
     return char === ' ' && shape.width > 0
   }
 
+  private resolvePercentSymbolShape(
+    data: PercentSymbolData
+  ): BaseTextShape | undefined {
+    for (const lookupCode of getPercentSymbolLookupCodes(data)) {
+      const symbolShape = this.fontManager.getCodeShapeFromSymbolFonts(
+        lookupCode,
+        this.currentFontSize
+      )
+      if (symbolShape && this.shapeHasStrokeGeometry(symbolShape, data.char)) {
+        if (this.currentFontSize > this._maxFontSize) {
+          this._maxFontSize = this.currentFontSize
+        }
+        return symbolShape
+      }
+    }
+    return this.getCharShape(data.char)
+  }
+
   private getCharShape(char: string) {
-    // Named AutoCAD percent codes (%%c/%%d/%%p) are expanded to Unicode by
-    // mtext-parser before rendering, but AutoCAD itself resolves those symbols
-    // from GDT/symbol SHX fonts (e.g. amgdt.shx) via legacy control-code code
-    // points—not from the primary text font's Unicode glyphs. Try the ordered
-    // SHX control-code candidates in the default symbol-font chain first so
-    // rendering matches AutoCAD and avoids incorrect glyphs from the text font.
-    for (const controlChar of getShxControlCodeCandidates(char)) {
-      const symbolShape = this.fontManager.getCharShapeFromSymbolFonts(
-        controlChar,
-        this.currentFontSize
-      )
-      if (symbolShape && this.shapeHasStrokeGeometry(symbolShape, char)) {
-        if (this.currentFontSize > this._maxFontSize) {
-          this._maxFontSize = this.currentFontSize
-        }
-        return symbolShape
-      }
-    }
-
-    // Numeric `%%ddd` codes (e.g. %%130, %%132) expand to raw byte values and
-    // must be resolved from symbol SHX fonts before the primary text font.
-    if (isAutoCadNumericPercentControlCodeChar(char)) {
-      const symbolShape = this.fontManager.getCharShapeFromSymbolFonts(
-        char,
-        this.currentFontSize
-      )
-      if (symbolShape && this.shapeHasStrokeGeometry(symbolShape, char)) {
-        if (this.currentFontSize > this._maxFontSize) {
-          this._maxFontSize = this.currentFontSize
-        }
-        return symbolShape
-      }
-    }
-
     let shape = this.fontManager.getCharShape(
       char,
       this.currentFont,
@@ -1887,10 +1901,13 @@ export class MTextProcessor {
       )
     }
     if (!shape) {
-      shape = this.fontManager.getCharShapeFromSymbolFonts(
-        char,
-        this.currentFontSize
-      )
+      const code = char.codePointAt(0)
+      if (code != null) {
+        shape = this.fontManager.getCodeShapeFromSymbolFonts(
+          code,
+          this.currentFontSize
+        )
+      }
     }
     if (!shape || !this.shapeHasStrokeGeometry(shape, char)) {
       shape = this.fontManager.getNotFoundTextShape(this.currentFontSize)

--- a/packages/mtext-renderer/src/renderer/shxSymbolControlCodes.ts
+++ b/packages/mtext-renderer/src/renderer/shxSymbolControlCodes.ts
@@ -1,25 +1,19 @@
+import type { PercentSymbolData } from '@mlightcad/mtext-parser'
+
 /**
  * AutoCAD percent-sign symbol codes (`%%c`, `%%d`, `%%p`) and their SHX
  * symbol-font code points.
  *
- * Named percent codes are expanded by {@link @mlightcad/mtext-parser} into Unicode
- * before rendering. AutoCAD itself does not rely on those Unicode code points in
- * the primary text font; it resolves the symbols through GDT / symbol SHX fonts
- * such as `amgdt.shx` using legacy control-code code points.
- *
- * References:
- * - AutoCAD "Text Symbols and Special Characters"
- * - AutoCAD "Control Codes and Special Characters" (`%%nnn`)
- * - Legacy SHX convention: 127 = degree, 128 = plus/minus, 129 = diameter
- * - Modern `amgdt.shx`: degree at 126/176, ± at 177, diameter at U+2205 (∅);
- *   code 130 = angle (∠). Legacy bytes 127–128 must not be used when CJK mesh
- *   fonts in the fallback chain expose unrelated glyphs at those code points.
+ * When {@link MTextParserOptions.yieldPercentSymbols} is enabled, the parser
+ * emits {@link TokenType.PERCENT_SYMBOL} tokens for these codes. AutoCAD itself
+ * does not rely on the Unicode expansions in the primary text font; it resolves
+ * the symbols through GDT / symbol SHX fonts such as `amgdt.shx` using legacy
+ * control-code code points.
  */
 export type AutoCadPercentSymbolCode = 'c' | 'd' | 'p'
 
 /**
  * Ordered SHX byte-code candidates for each named AutoCAD percent symbol.
- * Earlier entries are preferred when present in the symbol-font fallback chain
  * Earlier entries are preferred when present in {@link FontManager.symbolFonts}.
  */
 export const AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES: Readonly<
@@ -34,72 +28,36 @@ export const AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES: Readonly<
 }
 
 /**
- * Unicode characters to try in GDT / symbol SHX fonts when legacy control codes
+ * Unicode code points to try in GDT / symbol SHX fonts when legacy control codes
  * are absent (e.g. `amgdt.shx` stores diameter at U+2205, not at byte 129/130).
  */
 const PERCENT_SYMBOL_FONT_UNICODE_ALTERNATES: Readonly<
-  Record<AutoCadPercentSymbolCode, readonly string[]>
+  Record<AutoCadPercentSymbolCode, readonly number[]>
 > = {
-  c: ['\u2205'], // ∅ — AutoCAD .NET diameter; present in amgdt.shx
+  c: [0x2205], // ∅ — AutoCAD .NET diameter; present in amgdt.shx
   d: [],
   p: []
 }
 
 /**
- * Unicode characters produced from percent codes (or documented AutoCAD aliases)
- * mapped back to their percent-symbol key.
+ * Returns ordered font code points to try for a parser-emitted percent symbol.
  */
-const UNICODE_TO_PERCENT_SYMBOL: Readonly<
-  Record<string, AutoCadPercentSymbolCode>
-> = {
-  '\u00D8': 'c', // Ø — used by mtext-parser for %%c
-  '\u2205': 'c', // ∅ — documented in AutoCAD .NET API for diameter
-  '\u00B0': 'd', // ° — %%d
-  '\u00B1': 'p' // ± — %%p
-}
-
-/**
- * Returns whether a character originated from an AutoCAD named percent symbol.
- */
-export function isAutoCadPercentSymbolChar(char: string): boolean {
-  return UNICODE_TO_PERCENT_SYMBOL[char] != null
-}
-
-/**
- * Returns whether a character likely came from an AutoCAD numeric percent code
- * (`%%ddd`) expanded by mtext-parser into {@link String.fromCharCode}.
- *
- * AutoCAD resolves these byte-oriented SHX code points from GDT / symbol fonts
- * (e.g. `amgdt.shx`), not from the primary text font—even when the text font
- * defines a glyph at the same code (as with `txt.shx` at code 132).
- */
-export function isAutoCadNumericPercentControlCodeChar(char: string): boolean {
-  if (char.length !== 1 || isAutoCadPercentSymbolChar(char)) {
-    return false
+export function getPercentSymbolLookupCodes(
+  data: PercentSymbolData
+): readonly number[] {
+  switch (data.kind) {
+    case 'named':
+      return [
+        ...AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES[data.code],
+        ...PERCENT_SYMBOL_FONT_UNICODE_ALTERNATES[data.code]
+      ]
+    case 'numeric':
+      return [data.charCode]
+    case 'literal':
+      return []
+    default: {
+      const exhaustiveCheck: never = data
+      return exhaustiveCheck
+    }
   }
-  const code = char.charCodeAt(0)
-  // Legacy GDT / SHX symbol bytes produced by `%%126`–`%%255`.
-  return code >= 126 && code <= 255
-}
-
-/**
- * Returns ordered SHX control-code characters to try in symbol-font fallbacks
- * for an AutoCAD percent-symbol Unicode expansion.
- */
-export function getShxControlCodeCandidates(char: string): readonly string[] {
-  const symbol = UNICODE_TO_PERCENT_SYMBOL[char]
-  if (symbol == null) {
-    return []
-  }
-  const controlCodes = AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES[symbol].map(code =>
-    String.fromCharCode(code)
-  )
-  return [...controlCodes, ...PERCENT_SYMBOL_FONT_UNICODE_ALTERNATES[symbol]]
-}
-
-/**
- * @deprecated Use {@link getShxControlCodeCandidates} instead.
- */
-export function getShxControlCodeChar(char: string): string | undefined {
-  return getShxControlCodeCandidates(char)[0]
 }

--- a/packages/mtext-renderer/test/font/fontManager.test.ts
+++ b/packages/mtext-renderer/test/font/fontManager.test.ts
@@ -50,6 +50,7 @@ function createFakeFont(overrides: Record<string, unknown> = {}) {
     unsupportedChars: { '?': 1 },
     hasChar: vi.fn().mockReturnValue(false),
     getCharShape: vi.fn(),
+    getCodeShape: vi.fn(),
     getScaleFactor: vi.fn().mockReturnValue(1),
     getNotFoundTextShape: vi.fn(),
     ...overrides
@@ -219,8 +220,8 @@ describe('FontManager', () => {
       getCharShape: vi.fn().mockReturnValue(meshShape)
     })
     const symbol = createFakeFont({
-      hasChar: vi.fn((char: string) => char === '°'),
-      getCharShape: vi.fn().mockReturnValue(symbolShape)
+      hasCode: vi.fn((code: number) => code === 0xb0),
+      getCodeShape: vi.fn().mockReturnValue(symbolShape)
     })
     manager.defaultFonts = new Set(['simsun'])
     manager.symbolFonts = new Set(['amgdt'])
@@ -230,11 +231,11 @@ describe('FontManager', () => {
     expect(FontManager.instance.getCharShapeFromDefaults('°', 10)).toBe(
       meshShape
     )
-    expect(FontManager.instance.getCharShapeFromSymbolFonts('°', 10)).toBe(
+    expect(FontManager.instance.getCodeShapeFromSymbolFonts(0xb0, 10)).toBe(
       symbolShape
     )
     expect(mesh.getCharShape).toHaveBeenCalled()
-    expect(symbol.getCharShape).toHaveBeenCalled()
+    expect(symbol.getCodeShape).toHaveBeenCalledWith(0xb0, 10)
   })
 
   it('finds fonts by character without using getCharShape on a missing font name', () => {
@@ -373,7 +374,7 @@ describe('FontManager', () => {
 
     await manager.loadDefaultFont()
 
-    expect(loader.load).toHaveBeenCalledWith(['hztxt', 'simsun', 'amgdt'])
+    expect(loader.load).toHaveBeenCalledWith(['hztxt', 'simsun', 'simplex', 'amgdt'])
   })
 
   it('resolves fonts by alias names after loading', async () => {

--- a/packages/mtext-renderer/test/font/shx-control-code-glyphs.test.ts
+++ b/packages/mtext-renderer/test/font/shx-control-code-glyphs.test.ts
@@ -47,7 +47,7 @@ describe('AutoCAD percent symbols with isocp primary font (integration)', () => 
         {
           label: '%%c',
           unicodeChar: 'Ø',
-          symbolChar: '\u2205',
+          symbolCode: 0x2205,
           isocpWidth: 12.230769230769234,
           symbolWidth: 6.785714285714286
         },
@@ -73,12 +73,12 @@ describe('AutoCAD percent symbols with isocp primary font (integration)', () => 
           'isocp',
           10
         )
-        const symbolLookupChar =
-          'symbolChar' in testCase
-            ? testCase.symbolChar
-            : String.fromCharCode(testCase.controlCode)
-        const symbolShape = FontManager.instance.getCharShapeFromSymbolFonts(
-          symbolLookupChar,
+        const symbolLookupCode =
+          'symbolCode' in testCase
+            ? testCase.symbolCode
+            : testCase.controlCode
+        const symbolShape = FontManager.instance.getCodeShapeFromSymbolFonts(
+          symbolLookupCode,
           10
         )
 
@@ -125,7 +125,7 @@ describe('%%130 %%131 glyph fallback (integration)', () => {
   )
 
   it(
-    'getCharShapeFromSymbolFonts skips gdt.ttf and uses amgdt when configured',
+    'getCodeShapeFromSymbolFonts skips gdt.ttf and uses amgdt when configured',
     async () => {
       FontManager.instance.release()
       FontManager.instance.enableFontCache = false
@@ -135,8 +135,8 @@ describe('%%130 %%131 glyph fallback (integration)', () => {
       registerFont('amgdt', await loadFont('amgdt', 'amgdt.shx'))
       registerFont('gdt', await loadFont('gdt', 'gdt.ttf', 'mesh'))
 
-      const shape130 = FontManager.instance.getCharShapeFromSymbolFonts(ch130, 10)
-      const shape131 = FontManager.instance.getCharShapeFromSymbolFonts(ch131, 10)
+      const shape130 = FontManager.instance.getCodeShapeFromSymbolFonts(130, 10)
+      const shape131 = FontManager.instance.getCodeShapeFromSymbolFonts(131, 10)
 
       expect(shape130).toBeDefined()
       expect(shape131).toBeDefined()

--- a/packages/mtext-renderer/test/font/shx-symbol-font-fallback.test.ts
+++ b/packages/mtext-renderer/test/font/shx-symbol-font-fallback.test.ts
@@ -37,8 +37,8 @@ describe('symbolFonts config (integration)', () => {
     registerFont('simsun', await loadFont('simsun', 'simsun.ttf', 'mesh'))
     registerFont('amgdt', await loadFont('amgdt', 'amgdt.shx'))
 
-    const degree = FontManager.instance.getCharShapeFromSymbolFonts('°', 10)
-    const pm = FontManager.instance.getCharShapeFromSymbolFonts('±', 10)
+    const degree = FontManager.instance.getCodeShapeFromSymbolFonts(0xb0, 10)
+    const pm = FontManager.instance.getCodeShapeFromSymbolFonts(0xb1, 10)
 
     expect(degree?.width).toBeCloseTo(2.857142857142857, 5)
     expect(pm?.width).toBeCloseTo(9.285714285714286, 5)

--- a/packages/mtext-renderer/test/renderer/mtext.control-code.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.control-code.test.ts
@@ -77,7 +77,7 @@ describe('controlCode example %%1326@600 (integration)', () => {
       registerFont('amgdt', await loadShx('amgdt', 'amgdt.shx'))
 
       const ch132 = String.fromCharCode(132)
-      const amgdt132 = FontManager.instance.getCharShapeFromSymbolFonts(ch132, 10)
+      const amgdt132 = FontManager.instance.getCodeShapeFromSymbolFonts(132, 10)
       const geometry = amgdt132?.toGeometry()
       geometry?.computeBoundingBox()
 

--- a/packages/mtext-renderer/test/renderer/mtext.glyph-fallback.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.glyph-fallback.test.ts
@@ -147,6 +147,15 @@ function resolveCharShape(
   return fontGlyphs?.[char]
 }
 
+function resolveCodeShape(
+  code: number,
+  fontName: string,
+  glyphs: Record<string, Record<number, GlyphShape | undefined>>
+): GlyphShape | undefined {
+  const fontGlyphs = glyphs[fontName]
+  return fontGlyphs?.[code]
+}
+
 describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
   const primaryFont = 'txt'
   const bigFontName = 'hztxt'
@@ -275,54 +284,54 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
   it.each([
     {
       label: '%%c diameter',
+      symbolData: { kind: 'named', code: 'c', char: 'Ø' },
       char: 'Ø',
-      lookupChars: [String.fromCharCode(129), '\u2205'],
+      lookupCodes: [129, 0x2205],
       primaryWidth: 10,
       symbolWidth: 6.78
     },
     {
       label: '%%d degree',
+      symbolData: { kind: 'named', code: 'd', char: '°' },
       char: '°',
-      lookupChars: [String.fromCharCode(126), String.fromCharCode(176)],
+      lookupCodes: [126, 176],
       primaryWidth: 4.6,
       symbolWidth: 2.85
     },
     {
       label: '%%p plus/minus',
+      symbolData: { kind: 'named', code: 'p', char: '±' },
       char: '±',
-      lookupChars: [String.fromCharCode(177)],
+      lookupCodes: [177],
       primaryWidth: 5.4,
       symbolWidth: 9.28
     }
-  ])(
+  ] as const)(
     'prefers SHX symbol-font control codes for $label before primary font',
-    ({ char, lookupChars, primaryWidth, symbolWidth }) => {
+    ({ char, symbolData, lookupCodes, primaryWidth, symbolWidth }) => {
       const primaryShape = createShape(primaryWidth)
       const symbolShape = createShape(symbolWidth)
-      const glyphs: Record<string, Record<string, GlyphShape | undefined>> = {
-        isocp: { [char]: primaryShape },
+      const charGlyphs: Record<string, Record<string, GlyphShape | undefined>> = {
+        isocp: { [char]: primaryShape }
+      }
+      const codeGlyphs: Record<string, Record<number, GlyphShape | undefined>> = {
         simsun: Object.fromEntries(
-          [
-            String.fromCharCode(127),
-            String.fromCharCode(128),
-            String.fromCharCode(126),
-            String.fromCharCode(129),
-            '°',
-            '±',
-            '\u2205'
-          ].map(ch => [ch, createShape(99)])
+          [127, 128, 126, 129, 0xb0, 0xb1, 0x2205].map(code => [
+            code,
+            createShape(99)
+          ])
         ),
         amgdt: Object.fromEntries(
-          lookupChars.map(lookupChar => [lookupChar, symbolShape])
+          lookupCodes.map(lookupCode => [lookupCode, symbolShape])
         )
       }
 
       const getCharShape = vi.fn((lookupChar: string, fontName: string) =>
-        resolveCharShape(lookupChar, fontName, glyphs)
+        resolveCharShape(lookupChar, fontName, charGlyphs)
       )
-      const getCharShapeFromSymbolFonts = vi.fn((lookupChar: string) => {
+      const getCodeShapeFromSymbolFonts = vi.fn((lookupCode: number) => {
         for (const fontName of ['amgdt', 'simsun']) {
-          const shape = resolveCharShape(lookupChar, fontName, glyphs)
+          const shape = resolveCodeShape(lookupCode, fontName, codeGlyphs)
           if (shape) return shape
         }
         return undefined
@@ -336,20 +345,20 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
           findAndReplaceFont: (name: string) => name,
           getCharShape,
           getCharShapeFromDefaults: vi.fn(),
-          getCharShapeFromSymbolFonts,
+          getCodeShapeFromSymbolFonts,
           getNotFoundTextShape: () => undefined
         }
       )
 
       getCharShape.mockClear()
-      getCharShapeFromSymbolFonts.mockClear()
+      getCodeShapeFromSymbolFonts.mockClear()
 
-      const shape = (processor as any).getCharShape(char)
+      const shape = (processor as any).resolvePercentSymbolShape(symbolData)
 
       expect(shape).toBe(symbolShape)
-      expect(getCharShapeFromSymbolFonts).toHaveBeenCalledTimes(1)
-      expect(lookupChars).toContain(
-        getCharShapeFromSymbolFonts.mock.calls[0][0]
+      expect(getCodeShapeFromSymbolFonts).toHaveBeenCalledTimes(1)
+      expect(lookupCodes).toContain(
+        getCodeShapeFromSymbolFonts.mock.calls[0][0]
       )
       expect(getCharShape).not.toHaveBeenCalled()
     }
@@ -359,25 +368,27 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
     const ch132 = String.fromCharCode(132)
     const defaultShape = createShape(0)
     const symbolShape = createShape(6.5)
-    const glyphs: Record<string, Record<string, GlyphShape | undefined>> = {
+    const charGlyphs: Record<string, Record<string, GlyphShape | undefined>> = {
       txt: {},
-      simkai: { [ch132]: defaultShape },
-      amgdt: { [ch132]: symbolShape }
+      simkai: { [ch132]: defaultShape }
+    }
+    const codeGlyphs: Record<string, Record<number, GlyphShape | undefined>> = {
+      amgdt: { 132: symbolShape }
     }
 
     const getCharShape = vi.fn((lookupChar: string, fontName: string) =>
-      resolveCharShape(lookupChar, fontName, glyphs)
+      resolveCharShape(lookupChar, fontName, charGlyphs)
     )
     const getCharShapeFromDefaults = vi.fn((lookupChar: string) => {
       for (const fontName of ['txt', 'simkai']) {
-        const shape = resolveCharShape(lookupChar, fontName, glyphs)
+        const shape = resolveCharShape(lookupChar, fontName, charGlyphs)
         if (shape) return shape
       }
       return undefined
     })
-    const getCharShapeFromSymbolFonts = vi.fn((lookupChar: string) => {
+    const getCodeShapeFromSymbolFonts = vi.fn((lookupCode: number) => {
       for (const fontName of ['amgdt']) {
-        const shape = resolveCharShape(lookupChar, fontName, glyphs)
+        const shape = resolveCodeShape(lookupCode, fontName, codeGlyphs)
         if (shape) return shape
       }
       return undefined
@@ -391,19 +402,23 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
         findAndReplaceFont: (name: string) => name,
         getCharShape,
         getCharShapeFromDefaults,
-        getCharShapeFromSymbolFonts,
+        getCodeShapeFromSymbolFonts,
         getNotFoundTextShape: () => undefined
       }
     )
 
     getCharShape.mockClear()
     getCharShapeFromDefaults.mockClear()
-    getCharShapeFromSymbolFonts.mockClear()
+    getCodeShapeFromSymbolFonts.mockClear()
 
-    const shape = (processor as any).getCharShape(ch132)
+    const shape = (processor as any).resolvePercentSymbolShape({
+      kind: 'numeric',
+      charCode: 132,
+      char: ch132
+    })
 
     expect(shape).toBe(symbolShape)
-    expect(getCharShapeFromSymbolFonts).toHaveBeenCalledWith(ch132, 10)
+    expect(getCodeShapeFromSymbolFonts).toHaveBeenCalledWith(132, 10)
     expect(getCharShapeFromDefaults).not.toHaveBeenCalled()
     expect(getCharShape).not.toHaveBeenCalled()
   })
@@ -412,17 +427,19 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
     const ch132 = String.fromCharCode(132)
     const primaryShape = createShape(0)
     const symbolShape = createShape(6.5)
-    const glyphs: Record<string, Record<string, GlyphShape | undefined>> = {
-      txt: { [ch132]: primaryShape },
-      amgdt: { [ch132]: symbolShape }
+    const charGlyphs: Record<string, Record<string, GlyphShape | undefined>> = {
+      txt: { [ch132]: primaryShape }
+    }
+    const codeGlyphs: Record<string, Record<number, GlyphShape | undefined>> = {
+      amgdt: { 132: symbolShape }
     }
 
     const getCharShape = vi.fn((lookupChar: string, fontName: string) =>
-      resolveCharShape(lookupChar, fontName, glyphs)
+      resolveCharShape(lookupChar, fontName, charGlyphs)
     )
-    const getCharShapeFromSymbolFonts = vi.fn((lookupChar: string) => {
+    const getCodeShapeFromSymbolFonts = vi.fn((lookupCode: number) => {
       for (const fontName of ['amgdt']) {
-        const shape = resolveCharShape(lookupChar, fontName, glyphs)
+        const shape = resolveCodeShape(lookupCode, fontName, codeGlyphs)
         if (shape) return shape
       }
       return undefined
@@ -436,19 +453,68 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
         findAndReplaceFont: (name: string) => name,
         getCharShape,
         getCharShapeFromDefaults: vi.fn(),
-        getCharShapeFromSymbolFonts,
+        getCodeShapeFromSymbolFonts,
         getNotFoundTextShape: () => undefined
       }
     )
 
     getCharShape.mockClear()
-    getCharShapeFromSymbolFonts.mockClear()
+    getCodeShapeFromSymbolFonts.mockClear()
 
-    const shape = (processor as any).getCharShape(ch132)
+    const shape = (processor as any).resolvePercentSymbolShape({
+      kind: 'numeric',
+      charCode: 132,
+      char: ch132
+    })
 
     expect(shape).toBe(symbolShape)
-    expect(getCharShapeFromSymbolFonts).toHaveBeenCalledWith(ch132, 10)
+    expect(getCodeShapeFromSymbolFonts).toHaveBeenCalledWith(132, 10)
     expect(getCharShape).not.toHaveBeenCalled()
+  })
+
+  it('prefers primary font for superscript ² instead of amgdt symbol fallback', () => {
+    const superscriptTwo = '²'
+    const primaryShape = createShape(3)
+    const symbolShape = createShape(20)
+    const charGlyphs: Record<string, Record<string, GlyphShape | undefined>> = {
+      'gost common': { [superscriptTwo]: primaryShape }
+    }
+    const codeGlyphs: Record<string, Record<number, GlyphShape | undefined>> = {
+      amgdt: { 0xb2: symbolShape }
+    }
+
+    const getCharShape = vi.fn((lookupChar: string, fontName: string) =>
+      resolveCharShape(lookupChar, fontName, charGlyphs)
+    )
+    const getCodeShapeFromSymbolFonts = vi.fn((lookupCode: number) => {
+      for (const fontName of ['amgdt']) {
+        const shape = resolveCodeShape(lookupCode, fontName, codeGlyphs)
+        if (shape) return shape
+      }
+      return undefined
+    })
+
+    const processor = createGlyphFallbackProcessor(
+      { font: 'GOST Common', bigFont: '' },
+      {
+        getFontScaleFactor: () => 1,
+        getFontType: () => 'shx' as const,
+        findAndReplaceFont: (name: string) => name,
+        getCharShape,
+        getCharShapeFromDefaults: vi.fn(),
+        getCodeShapeFromSymbolFonts,
+        getNotFoundTextShape: () => undefined
+      }
+    )
+
+    getCharShape.mockClear()
+    getCodeShapeFromSymbolFonts.mockClear()
+
+    const shape = (processor as any).getCharShape(superscriptTwo)
+
+    expect(shape).toBe(primaryShape)
+    expect(getCharShape).toHaveBeenCalledWith(superscriptTwo, 'gost common', 10)
+    expect(getCodeShapeFromSymbolFonts).not.toHaveBeenCalled()
   })
 
   it('stops at primary font when the glyph is present there', () => {
@@ -530,7 +596,7 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
 
     const getCharShape = vi.fn(() => undefined)
     const getCharShapeFromDefaults = vi.fn(() => undefined)
-    const getCharShapeFromSymbolFonts = vi.fn(() => undefined)
+    const getCodeShapeFromSymbolFonts = vi.fn(() => undefined)
     const getNotFoundTextShape = vi.fn(() => notFoundShape)
 
     const processor = createGlyphFallbackProcessor(
@@ -541,14 +607,14 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
         findAndReplaceFont: (name: string) => name,
         getCharShape,
         getCharShapeFromDefaults,
-        getCharShapeFromSymbolFonts,
+        getCodeShapeFromSymbolFonts,
         getNotFoundTextShape
       }
     )
 
     getCharShape.mockClear()
     getCharShapeFromDefaults.mockClear()
-    getCharShapeFromSymbolFonts.mockClear()
+    getCodeShapeFromSymbolFonts.mockClear()
     getNotFoundTextShape.mockClear()
 
     const shape = (processor as any).getCharShape(cjkChar)
@@ -557,7 +623,10 @@ describe('MTextProcessor TextStyle glyph fallback (AutoCAD semantics)', () => {
     expect(getCharShape).toHaveBeenCalledWith(cjkChar, primaryFont, 10)
     expect(getCharShape).toHaveBeenCalledWith(cjkChar, bigFontName, 10)
     expect(getCharShapeFromDefaults).toHaveBeenCalledWith(cjkChar, 10)
-    expect(getCharShapeFromSymbolFonts).toHaveBeenCalledWith(cjkChar, 10)
+    expect(getCodeShapeFromSymbolFonts).toHaveBeenCalledWith(
+      cjkChar.codePointAt(0),
+      10
+    )
     expect(getNotFoundTextShape).toHaveBeenCalledWith(10)
   })
 })

--- a/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.processor.test.ts
@@ -165,7 +165,7 @@ function createProcessor(
       }
     },
     getCharShapeFromDefaults: () => undefined,
-    getCharShapeFromSymbolFonts: () => undefined,
+    getCodeShapeFromSymbolFonts: () => undefined,
     getNotFoundTextShape: () => undefined
   }
 
@@ -481,7 +481,7 @@ describe('MTextProcessor format state', () => {
         }
       },
       getCharShapeFromDefaults: () => undefined,
-      getCharShapeFromSymbolFonts: () => undefined,
+      getCodeShapeFromSymbolFonts: () => undefined,
       getNotFoundTextShape: () => undefined
     }
 

--- a/packages/mtext-renderer/test/renderer/shxSymbolControlCodes.test.ts
+++ b/packages/mtext-renderer/test/renderer/shxSymbolControlCodes.test.ts
@@ -1,53 +1,41 @@
-import { describe, expect, it } from 'vitest'
-
-import {
-  AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES,
-  getShxControlCodeCandidates,
-  isAutoCadNumericPercentControlCodeChar,
-  isAutoCadPercentSymbolChar
-} from '../../src/renderer/shxSymbolControlCodes'
-
-describe('shxSymbolControlCodes', () => {
-  it('maps all named AutoCAD percent symbols to SHX control-code candidates', () => {
-    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.c).toEqual([129])
-    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.d).toEqual([126, 176])
-    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.p).toEqual([177])
-  })
-
-  it('recognizes Unicode expansions for %%c, %%d, and %%p', () => {
-    expect(isAutoCadPercentSymbolChar('Ø')).toBe(true)
-    expect(isAutoCadPercentSymbolChar('∅')).toBe(true)
-    expect(isAutoCadPercentSymbolChar('°')).toBe(true)
-    expect(isAutoCadPercentSymbolChar('±')).toBe(true)
-    expect(isAutoCadPercentSymbolChar('9')).toBe(false)
-  })
-
-  it('returns ordered candidates for each percent-symbol Unicode expansion', () => {
-    expect(getShxControlCodeCandidates('Ø')).toEqual([
-      String.fromCharCode(129),
-      '\u2205'
-    ])
-    expect(getShxControlCodeCandidates('∅')).toEqual([
-      String.fromCharCode(129),
-      '\u2205'
-    ])
-    expect(getShxControlCodeCandidates('°')).toEqual([
-      String.fromCharCode(126),
-      String.fromCharCode(176)
-    ])
-    expect(getShxControlCodeCandidates('±')).toEqual([String.fromCharCode(177)])
-    expect(getShxControlCodeCandidates('A')).toEqual([])
-  })
-
-  it('recognizes numeric %%ddd SHX control-code characters', () => {
-    expect(isAutoCadNumericPercentControlCodeChar(String.fromCharCode(130))).toBe(
-      true
-    )
-    expect(isAutoCadNumericPercentControlCodeChar(String.fromCharCode(132))).toBe(
-      true
-    )
-    expect(isAutoCadNumericPercentControlCodeChar('°')).toBe(false)
-    expect(isAutoCadNumericPercentControlCodeChar('A')).toBe(false)
-    expect(isAutoCadNumericPercentControlCodeChar('9')).toBe(false)
-  })
-})
+import type { PercentSymbolData } from '@mlightcad/mtext-parser'
+import { describe, expect, it } from 'vitest'
+
+import {
+  AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES,
+  getPercentSymbolLookupCodes
+} from '../../src/renderer/shxSymbolControlCodes'
+
+describe('shxSymbolControlCodes', () => {
+  it('maps all named AutoCAD percent symbols to SHX control-code candidates', () => {
+    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.c).toEqual([129])
+    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.d).toEqual([126, 176])
+    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.p).toEqual([177])
+  })
+
+  it('returns ordered lookup codes for named percent-symbol tokens', () => {
+    const diameter: PercentSymbolData = { kind: 'named', code: 'c', char: 'Ø' }
+    const degree: PercentSymbolData = { kind: 'named', code: 'd', char: '°' }
+    const plusMinus: PercentSymbolData = { kind: 'named', code: 'p', char: '±' }
+
+    expect(getPercentSymbolLookupCodes(diameter)).toEqual([129, 0x2205])
+    expect(getPercentSymbolLookupCodes(degree)).toEqual([126, 176])
+    expect(getPercentSymbolLookupCodes(plusMinus)).toEqual([177])
+  })
+
+  it('returns lookup code for numeric percent-symbol tokens', () => {
+    const ch132: PercentSymbolData = {
+      kind: 'numeric',
+      charCode: 132,
+      char: String.fromCharCode(132)
+    }
+
+    expect(getPercentSymbolLookupCodes(ch132)).toEqual([132])
+  })
+
+  it('returns no symbol-font lookups for literal percent tokens', () => {
+    const literal: PercentSymbolData = { kind: 'literal', char: '%' }
+    expect(getPercentSymbolLookupCodes(literal)).toEqual([])
+  })
+})
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
   packages/mtext-renderer:
     dependencies:
       '@mlightcad/mtext-parser':
-        specifier: ^1.4.1
-        version: 1.4.1
+        specifier: ^1.5.0
+        version: 1.5.0
       '@mlightcad/shx-parser':
         specifier: ^1.3.4
         version: 1.3.4
@@ -995,8 +995,8 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
-  '@mlightcad/mtext-parser@1.4.1':
-    resolution: {integrity: sha512-PU7D5H/k25vZpTERabpdn5HVAs8+SBNRqgi08wRPiplxTE1eB/zBZRNRrSwHqyWx6xMeQmZ9mhh9DPNpte3gYQ==}
+  '@mlightcad/mtext-parser@1.5.0':
+    resolution: {integrity: sha512-Yl/IQmSIGV1UUl/TyUptoOpNBunywcEE7yh4k9SFDXljHDTTI92VmqkVFxf4eYzhoWF4MNXIl4qgQV1P1Rbn6g==}
 
   '@mlightcad/shx-parser@1.3.4':
     resolution: {integrity: sha512-y0clXQIBslAOwTMFtUnQqzZqhtD5lxUCiJA7lYTYvzO2dzBtsd2LVhUYdyA6R6DwjygOzjegXcP/4oCIsDiZhg==}
@@ -4468,7 +4468,7 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
-  '@mlightcad/mtext-parser@1.4.1': {}
+  '@mlightcad/mtext-parser@1.5.0': {}
 
   '@mlightcad/shx-parser@1.3.4': {}
 


### PR DESCRIPTION
## Summary
- Bump `@mlightcad/mtext-parser` to ^1.5.0 and consume `yieldPercentSymbols` / `PERCENT_SYMBOL` tokens for `%%c`, `%%d`, `%%p`, and numeric `%%ddd` codes.
- Resolve percent symbols from symbol SHX fonts by internal code point via `getCodeShapeFromSymbolFonts`, with `simplex` added to the default symbol-font chain.
- Avoid incorrect symbol-font fallback for regular Unicode glyphs (e.g. superscript ²) by separating percent-symbol lookup from general glyph fallback.

## Test plan
- [x] Unit tests for `shxSymbolControlCodes`, `MTextProcessor` glyph fallback, and font manager symbol lookup
- [x] Integration tests for `%%c`/`%%d`/`%%p` and `%%130`/`%%131`/`%%132` control codes
- [ ] Verify `shx-symbol-font-fallback.test.ts` passes in CI (CDN font fetch timed out locally)