### PR TITLE
feat: add local font caching with IndexedDB persistence and example UI

### DIFF
--- a/packages/example/index.html
+++ b/packages/example/index.html
@@ -130,6 +130,31 @@
             color: #bbb;
             margin: 4px 0 8px;
         }
+        .font-cache-panel {
+            margin: 10px 0;
+            padding: 10px;
+            border: 1px dashed #666;
+            border-radius: 4px;
+            background: #2a2a2a;
+        }
+        .font-cache-panel label {
+            display: block;
+            margin-bottom: 6px;
+        }
+        .font-cache-actions {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+        .font-cache-actions input[type="file"] {
+            flex: 1;
+            min-width: 220px;
+            color: #ddd;
+        }
+        .font-cache-actions button {
+            margin: 0;
+        }
     </style>
 </head>
 <body>
@@ -166,6 +191,14 @@
                     <option value="worker">Web Worker</option>
                 </select>
             </div>
+        </div>
+        <div class="font-cache-panel">
+            <label for="font-cache-input">Cache Local Font (.shx, .ttf, .otf, .woff):</label>
+            <div class="font-cache-actions">
+                <input type="file" id="font-cache-input" accept=".shx,.ttf,.otf,.woff,application/font-sfnt,font/woff" />
+                <button type="button" id="font-cache-btn">Cache Font</button>
+            </div>
+            <p class="hint">Cached fonts appear in the font lists with a <code>[cached]</code> label and can be used for MText / SHAPE rendering.</p>
         </div>
         <div class="row">
             <div class="field">

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -6,6 +6,18 @@
   "type": "module",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",
+  "nx": {
+    "implicitDependencies": [
+      "@mlightcad/mtext-renderer"
+    ],
+    "targets": {
+      "build": {
+        "dependsOn": [
+          "@mlightcad/mtext-renderer:build"
+        ]
+      }
+    }
+  },
   "scripts": {
     "build": "tsc && vite build",
     "clean": "rimraf dist lib tsconfig.tsbuildinfo",

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -2,6 +2,7 @@ import {
   CharBox,
   CharBoxType,
   DefaultFontsPreset,
+  FontInfo,
   LineLayout,
   MTextAttachmentPoint,
   MTextColor,
@@ -47,7 +48,15 @@ class MTextRendererExample {
   private renderModeSelect: HTMLSelectElement
   private byLayerColorInput: HTMLInputElement
   private byBlockColorInput: HTMLInputElement
+  private fontCacheInput: HTMLInputElement
+  private fontCacheBtn: HTMLButtonElement
   private readonly defaultLayerName = '0'
+  private readonly supportedFontExtensions = new Set([
+    '.shx',
+    '.ttf',
+    '.otf',
+    '.woff'
+  ])
 
   // Example texts
   private readonly exampleTexts = {
@@ -162,6 +171,12 @@ class MTextRendererExample {
     this.byBlockColorInput = document.getElementById(
       'by-block-color'
     ) as HTMLInputElement
+    this.fontCacheInput = document.getElementById(
+      'font-cache-input'
+    ) as HTMLInputElement
+    this.fontCacheBtn = document.getElementById(
+      'font-cache-btn'
+    ) as HTMLButtonElement
 
     // Add lights
     this.setupLights()
@@ -312,6 +327,15 @@ class MTextRendererExample {
     this.byBlockColorInput.addEventListener('change', async () => {
       await this.renderCurrentContent()
     })
+
+    this.fontCacheBtn.addEventListener('click', async () => {
+      await this.cacheSelectedFontFile()
+    })
+    this.fontCacheInput.addEventListener('change', () => {
+      const file = this.fontCacheInput.files?.[0]
+      this.fontCacheBtn.disabled = !file
+    })
+    this.fontCacheBtn.disabled = !this.fontCacheInput.files?.[0]
   }
 
   private updateContentPanels(): void {
@@ -353,42 +377,132 @@ class MTextRendererExample {
     this.statusDiv.style.color = '#0f0'
   }
 
+  private getFontExtension(fileName: string): string {
+    const dotIndex = fileName.lastIndexOf('.')
+    if (dotIndex < 0) {
+      return ''
+    }
+    return fileName.slice(dotIndex).toLowerCase()
+  }
+
+  private isSupportedFontFile(file: File): boolean {
+    return this.supportedFontExtensions.has(this.getFontExtension(file.name))
+  }
+
+  private formatFontLabel(font: FontInfo): string {
+    const label = font.name[0]
+    return font.source === 'cache' ? `${label} [cached]` : label
+  }
+
+  private populateFontSelects(
+    fonts: FontInfo[],
+    selectedTextFont?: string,
+    selectedShapeFont?: string
+  ): void {
+    const previousTextFont = selectedTextFont ?? this.fontSelect.value
+    const previousShapeFont = selectedShapeFont ?? this.shapeFontSelect.value
+
+    this.fontSelect.innerHTML = ''
+    this.shapeFontSelect.innerHTML = ''
+
+    let textFontMatched = false
+    let shapeFontMatched = false
+
+    const matchesSelection = (
+      font: FontInfo,
+      selectedName: string
+    ): boolean =>
+      font.name.some(
+        name => name.toLowerCase() === selectedName.toLowerCase()
+      )
+
+    fonts.forEach(font => {
+      const option = document.createElement('option')
+      option.value = font.name[0]
+      option.textContent = this.formatFontLabel(font)
+      if (matchesSelection(font, previousTextFont)) {
+        option.selected = true
+        textFontMatched = true
+      } else if (!textFontMatched && font.name[0] === 'simkai') {
+        option.selected = true
+        textFontMatched = true
+      }
+      this.fontSelect.appendChild(option)
+
+      if (font.type === 'shx' || font.file.toLowerCase().endsWith('.shx')) {
+        const shapeOption = document.createElement('option')
+        shapeOption.value = font.name[0]
+        shapeOption.textContent = this.formatFontLabel(font)
+        if (matchesSelection(font, previousShapeFont)) {
+          shapeOption.selected = true
+          shapeFontMatched = true
+        } else if (!shapeFontMatched && font.name[0] === 'complex') {
+          shapeOption.selected = true
+          shapeFontMatched = true
+        }
+        this.shapeFontSelect.appendChild(shapeOption)
+      }
+    })
+  }
+
+  private async refreshAvailableFonts(
+    selectedTextFont?: string,
+    selectedShapeFont?: string
+  ): Promise<FontInfo[]> {
+    const result = await this.unifiedRenderer.getAvailableFonts()
+    const fonts = result.fonts as FontInfo[]
+    this.populateFontSelects(fonts, selectedTextFont, selectedShapeFont)
+    return fonts
+  }
+
+  private async cacheSelectedFontFile(): Promise<void> {
+    const file = this.fontCacheInput.files?.[0]
+    if (!file) {
+      this.statusDiv.textContent = 'Select a font file to cache'
+      this.statusDiv.style.color = '#f00'
+      return
+    }
+
+    if (!this.isSupportedFontFile(file)) {
+      this.statusDiv.textContent =
+        'Unsupported font type. Use .shx, .ttf, .otf, or .woff'
+      this.statusDiv.style.color = '#f00'
+      return
+    }
+
+    try {
+      this.statusDiv.textContent = `Caching ${file.name}...`
+      this.statusDiv.style.color = '#ffa500'
+      this.fontCacheBtn.disabled = true
+
+      const status = await this.unifiedRenderer.cacheFont(file)
+      if (status.status !== 'Success') {
+        this.statusDiv.textContent = `Failed to cache ${file.name}`
+        this.statusDiv.style.color = '#f00'
+        return
+      }
+
+      await this.refreshAvailableFonts(status.fontName, status.fontName)
+
+      await this.applyDefaultFontsPreset()
+      await this.renderCurrentContent()
+
+      this.statusDiv.textContent = `Cached and loaded ${file.name} (${status.fontName})`
+      this.statusDiv.style.color = '#0f0'
+      this.fontCacheInput.value = ''
+    } catch (error) {
+      console.error('Error caching font:', error)
+      this.statusDiv.textContent = 'Error caching font'
+      this.statusDiv.style.color = '#f00'
+    } finally {
+      this.fontCacheBtn.disabled = !this.fontCacheInput.files?.[0]
+    }
+  }
+
   private async initializeFonts(isResetAvaiableFonts = true): Promise<void> {
     try {
       if (isResetAvaiableFonts) {
-        // Load available fonts for the dropdown
-        const result = await this.unifiedRenderer.getAvailableFonts()
-        const fonts = result.fonts
-
-        // Clear existing options
-        this.fontSelect.innerHTML = ''
-        this.shapeFontSelect.innerHTML = ''
-
-        // Add all available fonts to dropdown
-        fonts.forEach(rawFont => {
-          const font = rawFont as {
-            name: string[]
-            file?: string
-            type?: 'mesh' | 'shx'
-          }
-          const option = document.createElement('option')
-          option.value = font.name[0]
-          option.textContent = font.name[0] // Use the first name from the array
-          if (font.name[0] === 'simkai') {
-            option.selected = true
-          }
-          this.fontSelect.appendChild(option)
-
-          if (font.type === 'shx' || font.file?.toLowerCase().endsWith('.shx')) {
-            const shapeOption = document.createElement('option')
-            shapeOption.value = font.name[0]
-            shapeOption.textContent = font.name[0]
-            if (font.name[0] === 'complex') {
-              shapeOption.selected = true
-            }
-            this.shapeFontSelect.appendChild(shapeOption)
-          }
-        })
+        await this.refreshAvailableFonts()
       }
 
       await this.applyDefaultFontsPreset()

--- a/packages/example/vite.config.ts
+++ b/packages/example/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
     viteStaticCopy({
       targets: [
         {
-          src: './node_modules/@mlightcad/mtext-renderer/dist/mtext-renderer-worker.js',
+          src: '../mtext-renderer/dist/mtext-renderer-worker.js',
           dest: 'assets'
         }
       ]

--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -24,6 +24,16 @@
     "README.md",
     "package.json"
   ],
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/lib"
+        ]
+      }
+    }
+  },
   "scripts": {
     "build": "tsc && vite build -c vite.config.main.ts && vite build -c vite.config.worker.ts",
     "build:main": "vite build -c vite.config.main.ts",

--- a/packages/mtext-renderer/src/cache/fontCacheManager.ts
+++ b/packages/mtext-renderer/src/cache/fontCacheManager.ts
@@ -1,5 +1,6 @@
 import { type IDBPDatabase, openDB } from 'idb'
 
+import { getFileNameWithoutExtension } from '../common'
 import { FontData } from '../font'
 import { DB_STORES, DbFontCacheSchema, dbSchema } from './schema'
 
@@ -51,6 +52,27 @@ export class FontCacheManager {
   public async get(fileName: string): Promise<FontData | undefined> {
     const db = await this.getDatabase()
     return await db.get(DB_STORES.fonts, fileName)
+  }
+
+  /**
+   * Finds a font in the cache by primary name or alias.
+   * Font names may include or omit a file extension (e.g. `romans` or `romans.shx`).
+   * @param fontName The font name or alias to look up
+   * @returns The font data if found, undefined otherwise
+   */
+  public async find(fontName: string): Promise<FontData | undefined> {
+    const normalized = getFileNameWithoutExtension(fontName).toLowerCase()
+    const direct = await this.get(normalized)
+    if (direct) {
+      return direct
+    }
+
+    const all = await this.getAll()
+    return all.find(
+      font =>
+        font.name === normalized ||
+        font.alias?.some(alias => alias.toLowerCase() === normalized)
+    )
   }
 
   /**

--- a/packages/mtext-renderer/src/font/defaultFontLoader.ts
+++ b/packages/mtext-renderer/src/font/defaultFontLoader.ts
@@ -120,21 +120,25 @@ export class DefaultFontLoader implements FontLoader {
     ;[...alreadyLoadedStatuses, ...newlyLoadedStatuses].forEach(s => {
       statusMap[s.fontName] = s
     })
-    return fontNames.map(font => {
+
+    const statuses: FontLoadStatus[] = []
+    for (const font of fontNames) {
       const lowerCaseFontName = font.toLowerCase()
       const directStatus = statusMap[lowerCaseFontName]
       if (directStatus) {
-        return directStatus
+        statuses.push(directStatus)
+        continue
       }
 
       const fontInfo = requestedFontInfos.get(lowerCaseFontName)
       if (fontInfo) {
         if (FontManager.instance.isFontLoaded(lowerCaseFontName)) {
-          return {
+          statuses.push({
             fontName: lowerCaseFontName,
             url: fontInfo.url,
             status: 'Success'
-          }
+          })
+          continue
         }
 
         const fileBaseName = getFileNameWithoutExtension(
@@ -142,20 +146,31 @@ export class DefaultFontLoader implements FontLoader {
         ).toLowerCase()
         const loadedByFile = statusMap[fileBaseName]
         if (loadedByFile) {
-          return {
+          statuses.push({
             fontName: lowerCaseFontName,
             url: fontInfo.url,
             status: loadedByFile.status
-          }
+          })
+          continue
         }
       }
 
-      return {
+      if (await FontManager.instance.loadFontFromCache(font)) {
+        statuses.push({
+          fontName: lowerCaseFontName,
+          url: '',
+          status: 'Success'
+        })
+        continue
+      }
+
+      statuses.push({
         fontName: lowerCaseFontName,
         url: '',
         status: 'NotFound'
-      }
-    })
+      })
+    }
+    return statuses
   }
 
   /**

--- a/packages/mtext-renderer/src/font/fontLoader.ts
+++ b/packages/mtext-renderer/src/font/fontLoader.ts
@@ -15,6 +15,8 @@ export interface FontInfo {
    * https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API/Encodings
    */
   encoding?: string
+  /** Where this font entry comes from */
+  source?: 'remote' | 'cache'
 }
 
 /**

--- a/packages/mtext-renderer/src/font/fontManager.ts
+++ b/packages/mtext-renderer/src/font/fontManager.ts
@@ -3,6 +3,7 @@ import * as THREE from 'three'
 import { FontCacheManager } from '../cache'
 import {
   EventManager,
+  getExtension,
   getFileName,
   getFileNameWithoutExtension
 } from '../common'
@@ -199,12 +200,35 @@ export class FontManager {
 
   /**
    * Retrieves information about all available fonts in the system.
-   * Loads font metadata from a CDN if not already loaded.
+   * Merges remote font metadata with fonts stored in IndexedDB (cache-only
+   * entries are included; remote entries win when names collide).
    * @returns Promise that resolves to an array of FontInfo objects
    * @throws {Error} If font metadata cannot be loaded from the CDN
    */
-  async getAvailableFonts() {
-    return await this.fontLoader.getAvailableFonts()
+  async getAvailableFonts(): Promise<FontInfo[]> {
+    const remoteFonts = await this.fontLoader.getAvailableFonts()
+    if (!this.enableFontCache) {
+      return remoteFonts.map(font => ({ ...font, source: 'remote' as const }))
+    }
+
+    const fontMap = new Map<string, FontInfo>()
+    for (const font of remoteFonts) {
+      const key = getFileNameWithoutExtension(font.file).toLowerCase()
+      fontMap.set(key, { ...font, source: 'remote' })
+    }
+
+    const cachedFonts = await FontCacheManager.instance.getAll()
+    for (const cached of cachedFonts) {
+      const key = cached.name.toLowerCase()
+      if (fontMap.has(key)) {
+        continue
+      }
+      fontMap.set(key, this.cachedFontDataToFontInfo(cached))
+    }
+
+    return [...fontMap.values()].sort((a, b) =>
+      a.name[0].localeCompare(b.name[0], undefined, { sensitivity: 'base' })
+    )
   }
 
   /**
@@ -238,6 +262,135 @@ export class FontManager {
   ): Promise<FontLoadStatus[]> {
     const list = typeof names === 'string' ? [names] : [...names]
     return await this.fontLoader.load(list)
+  }
+
+  /**
+   * Parses a user-uploaded font file, registers it for rendering, and stores
+   * it in IndexedDB when {@link enableFontCache} is true.
+   *
+   * Supported formats: `.shx`, `.ttf`, `.otf`, `.woff`.
+   *
+   * @param data - Font file contents or a browser `File` selected by the user
+   * @param fileName - Font file name (e.g. `custom.shx`, `simkai.ttf`). Required when `data` is an `ArrayBuffer`
+   * @param aliases - Optional alias names for the font (e.g. AutoCAD style names)
+   * @param encoding - Optional character encoding for SHX bigfonts
+   * @returns Promise that resolves to the font load status
+   */
+  async cacheFont(
+    data: ArrayBuffer | File,
+    fileName?: string,
+    aliases?: string[],
+    encoding?: string
+  ): Promise<FontLoadStatus> {
+    let buffer: ArrayBuffer
+    let resolvedFileName: string
+
+    if (typeof File !== 'undefined' && data instanceof File) {
+      buffer = await data.arrayBuffer()
+      resolvedFileName = fileName ?? data.name
+    } else {
+      buffer = data as ArrayBuffer
+      resolvedFileName = fileName ?? ''
+    }
+
+    if (!resolvedFileName) {
+      throw new Error('fileName is required when caching an ArrayBuffer')
+    }
+
+    const fontName = getFileNameWithoutExtension(resolvedFileName).toLowerCase()
+    if (!fontName) {
+      return {
+        fontName: '',
+        url: '',
+        status: 'FailedToLoad'
+      }
+    }
+
+    const fontType = this.resolveUploadedFontType(resolvedFileName)
+    if (!fontType) {
+      return {
+        fontName,
+        url: '',
+        status: 'FailedToLoad'
+      }
+    }
+
+    if (this.isFontLoaded(fontName)) {
+      return {
+        fontName,
+        url: '',
+        status: 'Success'
+      }
+    }
+
+    const aliasList = this.buildUploadedFontAliases(
+      fontName,
+      resolvedFileName,
+      aliases
+    )
+    const fontData: FontData = {
+      name: fontName,
+      alias: aliasList,
+      type: fontType,
+      encoding,
+      data: buffer
+    }
+
+    try {
+      const font = FontFactory.instance.createFont(fontData)
+      aliasList.forEach(name => font.names.add(name))
+      this.registerFontInMap(fontName, font)
+
+      if (this.enableFontCache) {
+        await FontCacheManager.instance.set(fontName, fontData)
+      }
+
+      this.events.fontLoaded.dispatch({ fontName })
+      return {
+        fontName,
+        url: '',
+        status: 'Success'
+      }
+    } catch {
+      return {
+        fontName,
+        url: '',
+        status: 'FailedToLoad'
+      }
+    }
+  }
+
+  /**
+   * Loads a font from IndexedDB by primary name or alias.
+   * No-op when {@link enableFontCache} is false.
+   *
+   * @param fontName - Font name or alias (with or without file extension)
+   * @returns True if the font was found in cache and registered for rendering
+   */
+  async loadFontFromCache(fontName: string): Promise<boolean> {
+    if (!this.enableFontCache || !fontName) {
+      return false
+    }
+
+    const normalized = getFileNameWithoutExtension(fontName).toLowerCase()
+    if (this.isFontLoaded(normalized)) {
+      return true
+    }
+
+    const fontData = await FontCacheManager.instance.find(fontName)
+    if (!fontData) {
+      return false
+    }
+
+    try {
+      const font = FontFactory.instance.createFont(fontData)
+      fontData.alias?.forEach(name => font.names.add(name))
+      this.registerFontInMap(fontData.name, font)
+      this.events.fontLoaded.dispatch({ fontName: fontData.name })
+      return true
+    } catch {
+      return false
+    }
   }
 
   /**
@@ -555,6 +708,47 @@ export class FontManager {
       const font = FontFactory.instance.createFont(fontFileData)
       this.registerFontInMap(name, font)
     }
+  }
+
+  private cachedFontDataToFontInfo(data: FontData): FontInfo {
+    const file = `${data.name}.${data.type === 'shx' ? 'shx' : 'ttf'}`
+    const names =
+      data.alias && data.alias.length > 0 ? [...data.alias] : [data.name]
+    return {
+      name: names,
+      file,
+      type: data.type,
+      url: '',
+      encoding: data.encoding,
+      source: 'cache'
+    }
+  }
+
+  private resolveUploadedFontType(fileName: string): FontType | undefined {
+    const ext = getExtension(fileName).toLowerCase()
+    if (ext === 'shx') {
+      return 'shx'
+    }
+    if (['ttf', 'otf', 'woff'].includes(ext)) {
+      return 'mesh'
+    }
+    return undefined
+  }
+
+  private buildUploadedFontAliases(
+    fontName: string,
+    fileName: string,
+    aliases?: string[]
+  ): string[] {
+    const names = new Set<string>()
+    names.add(fontName)
+    names.add(getFileNameWithoutExtension(fileName))
+    aliases?.forEach(alias => {
+      if (alias) {
+        names.add(alias)
+      }
+    })
+    return [...names]
   }
 
   /**

--- a/packages/mtext-renderer/src/worker/unifiedRenderer.ts
+++ b/packages/mtext-renderer/src/worker/unifiedRenderer.ts
@@ -1,4 +1,4 @@
-import { DefaultFontsPreset, FontManager } from '../font'
+import { DefaultFontsPreset, FontLoadStatus, FontManager } from '../font'
 import { StyleManager } from '../renderer'
 import {
   ColorSettings,
@@ -192,6 +192,20 @@ export class UnifiedRenderer {
    */
   async getAvailableFonts(): Promise<{ fonts: Array<{ name: string[] }> }> {
     return this.renderer.getAvailableFonts()
+  }
+
+  /**
+   * Parse and cache a user-uploaded font file in IndexedDB.
+   * Always runs on the main-thread {@link FontManager} so the cache is shared
+   * with the web worker renderer.
+   */
+  async cacheFont(
+    data: ArrayBuffer | File,
+    fileName?: string,
+    aliases?: string[],
+    encoding?: string
+  ): Promise<FontLoadStatus> {
+    return FontManager.instance.cacheFont(data, fileName, aliases, encoding)
   }
 
   /**

--- a/packages/mtext-renderer/test/font/defaultFontLoader.test.ts
+++ b/packages/mtext-renderer/test/font/defaultFontLoader.test.ts
@@ -4,7 +4,8 @@ vi.mock('../../src/font/fontManager', () => ({
   FontManager: {
     instance: {
       isFontLoaded: vi.fn().mockReturnValue(false),
-      loadFonts: vi.fn().mockResolvedValue([])
+      loadFonts: vi.fn().mockResolvedValue([]),
+      loadFontFromCache: vi.fn().mockResolvedValue(false)
     }
   }
 }))
@@ -41,6 +42,7 @@ describe('DefaultFontLoader', () => {
   beforeEach(() => {
     vi.mocked(FontManager.instance.isFontLoaded).mockReturnValue(false)
     vi.mocked(FontManager.instance.loadFonts).mockResolvedValue([])
+    vi.mocked(FontManager.instance.loadFontFromCache).mockResolvedValue(false)
     vi.stubGlobal(
       'fetch',
       vi
@@ -224,6 +226,39 @@ describe('DefaultFontLoader', () => {
       {
         fontName: 'old',
         url: 'https://cdn.example.com/fonts/old.shx',
+        status: 'Success'
+      }
+    ])
+  })
+
+  it('loads fonts from IndexedDB cache when they are missing from the remote repository', async () => {
+    vi.mocked(FontManager.instance.loadFonts).mockResolvedValue([
+      {
+        fontName: 'old',
+        url: 'https://cdn.example.com/fonts/old.shx',
+        status: 'Success'
+      }
+    ])
+    vi.mocked(FontManager.instance.loadFontFromCache).mockImplementation(
+      async fontName => fontName.toLowerCase() === 'cachedfont'
+    )
+    const loader = new DefaultFontLoader()
+    loader.baseUrl = 'https://cdn.example.com/fonts/'
+
+    const statuses = await loader.load(['old', 'CachedFont'])
+
+    expect(FontManager.instance.loadFontFromCache).toHaveBeenCalledWith(
+      'CachedFont'
+    )
+    expect(statuses).toEqual([
+      {
+        fontName: 'old',
+        url: 'https://cdn.example.com/fonts/old.shx',
+        status: 'Success'
+      },
+      {
+        fontName: 'cachedfont',
+        url: '',
         status: 'Success'
       }
     ])

--- a/packages/mtext-renderer/test/font/fontManager.test.ts
+++ b/packages/mtext-renderer/test/font/fontManager.test.ts
@@ -5,7 +5,9 @@ vi.mock('../../src/cache', () => ({
     instance: {
       get: vi.fn().mockResolvedValue(undefined),
       set: vi.fn().mockResolvedValue(undefined),
-      getAll: vi.fn().mockResolvedValue([])
+      getAll: vi.fn().mockResolvedValue([]),
+      find: vi.fn().mockResolvedValue(undefined),
+      has: vi.fn().mockResolvedValue(false)
     }
   }
 }))
@@ -97,13 +99,68 @@ describe('FontManager', () => {
     ]
     const loader = createFontLoader('https://cdn.example.com/fonts/')
     vi.mocked(loader.getAvailableFonts).mockResolvedValue(fonts)
+    vi.mocked(FontCacheManager.instance.getAll).mockResolvedValue([])
     const manager = FontManager.instance
 
     manager.setFontLoader(loader)
     const result = await manager.getAvailableFonts()
 
     expect(loader.getAvailableFonts).toHaveBeenCalledOnce()
-    expect(result).toBe(fonts)
+    expect(result).toEqual([
+      {
+        name: ['TestFont'],
+        file: 'test.shx',
+        type: 'shx',
+        url: 'https://cdn.example.com/fonts/test.shx',
+        source: 'remote'
+      }
+    ])
+  })
+
+  it('merges cache-only fonts into the available font list', async () => {
+    const loader = createFontLoader('https://cdn.example.com/fonts/')
+    vi.mocked(loader.getAvailableFonts).mockResolvedValue([
+      {
+        name: ['Romans'],
+        file: 'romans.shx',
+        type: 'shx',
+        url: 'https://cdn.example.com/fonts/romans.shx'
+      }
+    ])
+    vi.mocked(FontCacheManager.instance.getAll).mockResolvedValue([
+      {
+        name: 'customfont',
+        alias: ['customfont', 'MyCustom'],
+        type: 'shx',
+        data: new ArrayBuffer(4)
+      },
+      {
+        name: 'romans',
+        alias: ['Romans'],
+        type: 'shx',
+        data: new ArrayBuffer(4)
+      }
+    ])
+    FontManager.instance.setFontLoader(loader)
+
+    const result = await FontManager.instance.getAvailableFonts()
+
+    expect(result).toEqual([
+      {
+        name: ['customfont', 'MyCustom'],
+        file: 'customfont.shx',
+        type: 'shx',
+        url: '',
+        source: 'cache'
+      },
+      {
+        name: ['Romans'],
+        file: 'romans.shx',
+        type: 'shx',
+        url: 'https://cdn.example.com/fonts/romans.shx',
+        source: 'remote'
+      }
+    ])
   })
 
   it('loads fonts by names through the configured font loader', async () => {
@@ -433,6 +490,197 @@ describe('FontManager', () => {
     expect(FontManager.instance.isFontLoaded('simfang')).toBe(false)
     expect(FontManager.instance.isFontLoaded('仿宋_GB2312')).toBe(false)
     expect(manager.loadedFontMap.size).toBe(0)
+  })
+
+  it('adds cached fonts to the available font library after cacheFont succeeds', async () => {
+    const cacheStore = new Map<
+      string,
+      {
+        name: string
+        alias?: string[]
+        type: 'shx' | 'mesh'
+        encoding?: string
+        data: ArrayBuffer
+      }
+    >()
+    vi.mocked(FontCacheManager.instance.set).mockImplementation(
+      async (name, fontData) => {
+        cacheStore.set(name, fontData)
+      }
+    )
+    vi.mocked(FontCacheManager.instance.getAll).mockImplementation(async () => [
+      ...cacheStore.values()
+    ])
+
+    const loader = createFontLoader('https://cdn.example.com/fonts/')
+    vi.mocked(loader.getAvailableFonts).mockResolvedValue([
+      {
+        name: ['Romans'],
+        file: 'romans.shx',
+        type: 'shx',
+        url: 'https://cdn.example.com/fonts/romans.shx'
+      }
+    ])
+    FontManager.instance.setFontLoader(loader)
+
+    const buffer = new ArrayBuffer(8)
+    const font = createFakeFont({
+      names: new Set(['customfont', 'CustomFont', 'MyCustom'])
+    })
+    vi.mocked(FontFactory.instance.createFont).mockReturnValue(font as any)
+
+    const status = await FontManager.instance.cacheFont(
+      buffer,
+      'CustomFont.shx',
+      ['MyCustom']
+    )
+    expect(status.status).toBe('Success')
+
+    const available = await FontManager.instance.getAvailableFonts()
+
+    expect(available).toEqual([
+      {
+        name: ['customfont', 'CustomFont', 'MyCustom'],
+        file: 'customfont.shx',
+        type: 'shx',
+        url: '',
+        encoding: undefined,
+        source: 'cache'
+      },
+      {
+        name: ['Romans'],
+        file: 'romans.shx',
+        type: 'shx',
+        url: 'https://cdn.example.com/fonts/romans.shx',
+        source: 'remote'
+      }
+    ])
+  })
+
+  it('caches uploaded SHX fonts and registers them for rendering', async () => {
+    const manager = FontManager.instance as any
+    const buffer = new ArrayBuffer(8)
+    const font = createFakeFont({ names: new Set(['custom', 'CustomFont']) })
+    vi.mocked(FontFactory.instance.createFont).mockReturnValue(font as any)
+
+    const status = await FontManager.instance.cacheFont(
+      buffer,
+      'CustomFont.shx',
+      ['MyCustom']
+    )
+
+    expect(FontFactory.instance.createFont).toHaveBeenCalledWith({
+      name: 'customfont',
+      alias: ['customfont', 'CustomFont', 'MyCustom'],
+      type: 'shx',
+      encoding: undefined,
+      data: buffer
+    })
+    expect(FontCacheManager.instance.set).toHaveBeenCalledWith('customfont', {
+      name: 'customfont',
+      alias: ['customfont', 'CustomFont', 'MyCustom'],
+      type: 'shx',
+      encoding: undefined,
+      data: buffer
+    })
+    expect(FontManager.instance.isFontLoaded('customfont')).toBe(true)
+    expect(FontManager.instance.isFontLoaded('MyCustom')).toBe(true)
+    expect(status).toEqual({
+      fontName: 'customfont',
+      url: '',
+      status: 'Success'
+    })
+    expect(manager.fileNames).toEqual([])
+  })
+
+  it('caches uploaded TTF and WOFF fonts as mesh fonts', async () => {
+    const buffer = new ArrayBuffer(8)
+    const ttfFont = createFakeFont({
+      names: new Set(['simkai']),
+      type: 'mesh'
+    })
+    const woffFont = createFakeFont({
+      names: new Set(['simfang']),
+      type: 'mesh'
+    })
+    vi.mocked(FontFactory.instance.createFont)
+      .mockReturnValueOnce(ttfFont as any)
+      .mockReturnValueOnce(woffFont as any)
+
+    const ttfStatus = await FontManager.instance.cacheFont(
+      buffer,
+      'simkai.ttf',
+      ['楷体']
+    )
+    const woffStatus = await FontManager.instance.cacheFont(
+      buffer,
+      'simfang.woff'
+    )
+
+    expect(FontFactory.instance.createFont).toHaveBeenNthCalledWith(1, {
+      name: 'simkai',
+      alias: ['simkai', '楷体'],
+      type: 'mesh',
+      encoding: undefined,
+      data: buffer
+    })
+    expect(FontFactory.instance.createFont).toHaveBeenNthCalledWith(2, {
+      name: 'simfang',
+      alias: ['simfang'],
+      type: 'mesh',
+      encoding: undefined,
+      data: buffer
+    })
+    expect(FontManager.instance.isFontLoaded('simkai')).toBe(true)
+    expect(FontManager.instance.isFontLoaded('楷体')).toBe(true)
+    expect(FontManager.instance.isFontLoaded('simfang')).toBe(true)
+    expect(ttfStatus.status).toBe('Success')
+    expect(woffStatus.status).toBe('Success')
+  })
+
+  it('rejects unsupported uploaded font extensions', async () => {
+    const status = await FontManager.instance.cacheFont(
+      new ArrayBuffer(8),
+      'custom.woff2'
+    )
+
+    expect(FontFactory.instance.createFont).not.toHaveBeenCalled()
+    expect(status).toEqual({
+      fontName: 'custom',
+      url: '',
+      status: 'FailedToLoad'
+    })
+  })
+
+  it('loads fonts on demand from IndexedDB cache by name or alias', async () => {
+    const manager = FontManager.instance as any
+    const font = createFakeFont({ names: new Set(['customfont', 'MyCustom']) })
+    const cachedFontData = {
+      name: 'customfont',
+      alias: ['customfont', 'MyCustom'],
+      type: 'shx' as const,
+      encoding: undefined,
+      data: new ArrayBuffer(4)
+    }
+    vi.mocked(FontCacheManager.instance.find).mockResolvedValue(cachedFontData)
+    vi.mocked(FontFactory.instance.createFont).mockReturnValue(font as any)
+
+    const loaded = await FontManager.instance.loadFontFromCache('MyCustom.shx')
+
+    expect(FontCacheManager.instance.find).toHaveBeenCalledWith('MyCustom.shx')
+    expect(FontFactory.instance.createFont).toHaveBeenCalledWith(cachedFontData)
+    expect(FontManager.instance.isFontLoaded('customfont')).toBe(true)
+    expect(FontManager.instance.isFontLoaded('MyCustom')).toBe(true)
+    expect(loaded).toBe(true)
+  })
+
+  it('skips IndexedDB lookup when font caching is disabled', async () => {
+    FontManager.instance.enableFontCache = false
+
+    const loaded = await FontManager.instance.loadFontFromCache('customfont')
+
+    expect(FontCacheManager.instance.find).not.toHaveBeenCalled()
+    expect(loaded).toBe(false)
   })
 
   it('loads fonts from cache without requesting the font URL', async () => {


### PR DESCRIPTION
## Summary

- Add `cacheFont` API on `UnifiedRenderer` / `FontManager` to persist uploaded .shx, .ttf, .otf, and .woff fonts in IndexedDB and register them for immediate rendering
- Merge cache-only fonts into `getAvailableFonts` results with a `source: 'cache'` marker; `DefaultFontLoader` falls back to `loadFontFromCache` when a remote font is unavailable
- Extend the example app with a font-cache panel so users can upload local fonts, see `[cached]` labels in font dropdowns, and render with cached fonts
- Add unit tests covering cache upload, alias lookup, available-font merging, and loader fallback behavior

## Test plan

- [x] `npm test -- --run test/font/fontManager.test.ts test/font/defaultFontLoader.test.ts` (37 tests passed)
- [ ] Run the example app and upload a .shx / .ttf font via the Cache Font panel
- [ ] Verify the cached font appears in text and shape font dropdowns with a `[cached]` label
- [ ] Render MText / SHAPE content using the cached font and confirm glyphs display correctly
- [ ] Reload the page and confirm cached fonts are still listed and load on demand