### PR TITLE
feat: lazy-load UnifiedRenderer workers and add terminateWorkers

### DIFF
--- a/packages/example/vite.config.ts
+++ b/packages/example/vite.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
   base: './',
   resolve: {
     alias: {
+      // Use package source in dev so worker lazy-loading changes apply without rebuilding dist.
+      '@mlightcad/mtext-renderer': resolve(
+        __dirname,
+        '../mtext-renderer/src/index.ts'
+      ),
       // iconv-lite (used by SHX bigfont encoding) probes stream.Transform at init.
       stream: resolve(__dirname, 'src/shims/stream.ts')
     }

--- a/packages/mtext-renderer/src/worker/unifiedRenderer.ts
+++ b/packages/mtext-renderer/src/worker/unifiedRenderer.ts
@@ -17,10 +17,12 @@ export type RenderMode = 'main' | 'worker'
  * Unified renderer that can work in both main thread and web worker modes
  */
 export class UnifiedRenderer {
-  private webWorkerRenderer: WebWorkerRenderer
+  private webWorkerRenderer: WebWorkerRenderer | null = null
   private mainThreadRenderer: MainThreadRenderer
   private renderer: MTextBaseRenderer
   private defaultMode: RenderMode
+  private workerConfig: WebWorkerRendererConfig
+  private webWorkerConfigured = false
   /**
    * Constructor
    *
@@ -33,12 +35,33 @@ export class UnifiedRenderer {
     workerConfig: WebWorkerRendererConfig = {}
   ) {
     this.defaultMode = defaultMode
+    this.workerConfig = workerConfig
     this.mainThreadRenderer = new MainThreadRenderer()
-    this.webWorkerRenderer = new WebWorkerRenderer(workerConfig)
     this.renderer = this.mainThreadRenderer
     if (defaultMode === 'worker') {
-      this.renderer = this.webWorkerRenderer
+      this.renderer = this.ensureWebWorkerRenderer()
     }
+  }
+
+  private ensureWebWorkerRenderer(): WebWorkerRenderer {
+    if (!this.webWorkerRenderer) {
+      this.webWorkerRenderer = new WebWorkerRenderer(this.workerConfig)
+      this.webWorkerRenderer.styleManager = this.mainThreadRenderer.styleManager
+      this.webWorkerConfigured = false
+    }
+    return this.webWorkerRenderer
+  }
+
+  private async activateWebWorkerRenderer(): Promise<WebWorkerRenderer> {
+    const renderer = this.ensureWebWorkerRenderer()
+    if (!this.webWorkerConfigured) {
+      await renderer.setDefaultFonts(
+        [...FontManager.instance.defaultFonts],
+        [...FontManager.instance.symbolFonts]
+      )
+      this.webWorkerConfigured = true
+    }
+    return renderer
   }
 
   /**
@@ -53,7 +76,9 @@ export class UnifiedRenderer {
    */
   setStyleManager(value: StyleManager) {
     this.mainThreadRenderer.styleManager = value
-    this.webWorkerRenderer.styleManager = value
+    if (this.webWorkerRenderer) {
+      this.webWorkerRenderer.styleManager = value
+    }
   }
 
   /**
@@ -66,7 +91,7 @@ export class UnifiedRenderer {
     }
     this.defaultMode = mode
     if (mode === 'worker') {
-      this.renderer = this.webWorkerRenderer
+      this.renderer = this.ensureWebWorkerRenderer()
     } else {
       this.renderer = this.mainThreadRenderer
     }
@@ -98,17 +123,16 @@ export class UnifiedRenderer {
     colorSettings: ColorSettings = createDefaultColorSettings(),
     mode?: RenderMode
   ): Promise<MTextObject> {
-    if (mode) {
-      const renderer =
-        mode === 'worker' ? this.webWorkerRenderer : this.mainThreadRenderer
+    const effectiveMode = mode ?? this.defaultMode
+    if (effectiveMode === 'worker') {
+      const renderer = await this.activateWebWorkerRenderer()
       return renderer.asyncRenderMText(mtextContent, textStyle, colorSettings)
-    } else {
-      return this.renderer.asyncRenderMText(
-        mtextContent,
-        textStyle,
-        colorSettings
-      )
     }
+    return this.mainThreadRenderer.asyncRenderMText(
+      mtextContent,
+      textStyle,
+      colorSettings
+    )
   }
 
   /**
@@ -160,10 +184,13 @@ export class UnifiedRenderer {
     fonts: DefaultFontsPreset | string | readonly string[]
   ): Promise<void> {
     FontManager.instance.setDefaultFonts(fonts)
-    await this.webWorkerRenderer.setDefaultFonts(
-      [...FontManager.instance.defaultFonts],
-      [...FontManager.instance.symbolFonts]
-    )
+    if (this.webWorkerRenderer) {
+      await this.webWorkerRenderer.setDefaultFonts(
+        [...FontManager.instance.defaultFonts],
+        [...FontManager.instance.symbolFonts]
+      )
+      this.webWorkerConfigured = true
+    }
   }
 
   /**
@@ -209,12 +236,24 @@ export class UnifiedRenderer {
   }
 
   /**
+   * Terminate web workers and release their memory.
+   *
+   * The unified renderer keeps working on the main thread. Workers are
+   * recreated lazily the next time worker rendering is requested.
+   * Safe to call when no workers were created.
+   */
+  terminateWorkers(): void {
+    this.webWorkerRenderer?.terminate()
+    this.webWorkerRenderer = null
+    this.webWorkerConfigured = false
+    this.renderer = this.mainThreadRenderer
+  }
+
+  /**
    * Clean up resources
    */
   destroy(): void {
-    if (this.webWorkerRenderer) {
-      this.webWorkerRenderer.terminate()
-    }
+    this.terminateWorkers()
     this.mainThreadRenderer.destroy()
   }
 }

--- a/packages/mtext-renderer/test/worker/unifiedRenderer.test.ts
+++ b/packages/mtext-renderer/test/worker/unifiedRenderer.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const workerConstructor = vi.fn()
+const workerInstances: MockWorker[] = []
+
+class MockWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: ErrorEvent) => void) | null = null
+
+  postMessage = vi.fn()
+  terminate = vi.fn()
+
+  constructor(url: string | URL, options?: WorkerOptions) {
+    workerConstructor(url, options)
+    workerInstances.push(this)
+  }
+}
+
+vi.stubGlobal('Worker', MockWorker)
+
+import { UnifiedRenderer } from '../../src/worker/unifiedRenderer'
+
+describe('UnifiedRenderer', () => {
+  afterEach(() => {
+    workerConstructor.mockClear()
+    workerInstances.length = 0
+  })
+
+  it('does not create web workers when default mode is main', () => {
+    new UnifiedRenderer('main', { poolSize: 2 })
+
+    expect(workerConstructor).not.toHaveBeenCalled()
+  })
+
+  it('creates web workers when default mode is worker', () => {
+    new UnifiedRenderer('worker', { poolSize: 2 })
+
+    expect(workerConstructor).toHaveBeenCalledTimes(2)
+  })
+
+  it('creates web workers only after switching to worker mode', () => {
+    const renderer = new UnifiedRenderer('main', { poolSize: 2 })
+
+    expect(workerConstructor).not.toHaveBeenCalled()
+
+    renderer.setDefaultMode('worker')
+
+    expect(workerConstructor).toHaveBeenCalledTimes(2)
+  })
+
+  it('terminateWorkers is a no-op when no workers were created', () => {
+    const renderer = new UnifiedRenderer('main', { poolSize: 2 })
+
+    renderer.terminateWorkers()
+
+    expect(workerConstructor).not.toHaveBeenCalled()
+  })
+
+  it('terminateWorkers terminates existing workers', () => {
+    const renderer = new UnifiedRenderer('worker', { poolSize: 2 })
+
+    renderer.terminateWorkers()
+
+    expect(workerInstances).toHaveLength(2)
+    for (const worker of workerInstances) {
+      expect(worker.terminate).toHaveBeenCalledTimes(1)
+    }
+  })
+
+  it('recreates workers after terminateWorkers when worker mode is used again', () => {
+    const renderer = new UnifiedRenderer('worker', { poolSize: 2 })
+    expect(workerConstructor).toHaveBeenCalledTimes(2)
+
+    renderer.terminateWorkers()
+    renderer.setDefaultMode('main')
+    renderer.setDefaultMode('worker')
+
+    expect(workerConstructor).toHaveBeenCalledTimes(4)
+  })
+
+  it('destroy terminates workers via terminateWorkers', () => {
+    const renderer = new UnifiedRenderer('worker', { poolSize: 2 })
+
+    renderer.destroy()
+
+    expect(workerInstances).toHaveLength(2)
+    for (const worker of workerInstances) {
+      expect(worker.terminate).toHaveBeenCalledTimes(1)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Defer Web Worker pool creation until worker render mode is actually used (switch to worker mode or asyncRenderMText in worker mode).
- Add terminateWorkers() so callers can release worker memory while keeping main-thread rendering available.
- Point the example Vite dev alias at package source so pnpm dev picks up worker changes without rebuilding dist.

## Test plan
- [ ] pnpm dev — Chrome Task Manager shows no Dedicated Workers on startup in Main Thread mode
- [ ] Switch Render Mode to Web Worker — workers appear (default pool size up to 4)
- [ ] pnpm --filter @mlightcad/mtext-renderer test -- test/worker/unifiedRenderer.test.ts