### PR TITLE
feat: preserve worker precision at large coordinates and add remote font loading tests

### DIFF
--- a/packages/mtext-renderer/src/renderer/mtextProcessor.ts
+++ b/packages/mtext-renderer/src/renderer/mtextProcessor.ts
@@ -1467,7 +1467,7 @@ export class MTextProcessor {
           'position',
           new THREE.BufferAttribute(lineVertices, 3)
         )
-        lineGeometry.setIndex(null)
+        lineGeometry.setIndex([0, 1])
         lineGeometry.userData = { isDecoration: true }
         lineGeometries.push(lineGeometry)
       }
@@ -1756,7 +1756,7 @@ export class MTextProcessor {
           3
         )
       )
-      underlineGeom.setIndex(null)
+      underlineGeom.setIndex([0, 1])
       underlineGeom.userData = { isDecoration: true }
       lineGeometries.push(underlineGeom)
     }
@@ -1778,7 +1778,7 @@ export class MTextProcessor {
           3
         )
       )
-      overlineGeom.setIndex(null)
+      overlineGeom.setIndex([0, 1])
       overlineGeom.userData = { isDecoration: true }
       lineGeometries.push(overlineGeom)
     }
@@ -1800,7 +1800,7 @@ export class MTextProcessor {
           3
         )
       )
-      strikeGeom.setIndex(null)
+      strikeGeom.setIndex([0, 1])
       strikeGeom.userData = { isDecoration: true }
       lineGeometries.push(strikeGeom)
     }

--- a/packages/mtext-renderer/src/worker/mtextWorker.ts
+++ b/packages/mtext-renderer/src/worker/mtextWorker.ts
@@ -222,21 +222,23 @@ function serializeMText(mtext: MText): {
   data: unknown
   transferableObjects: ArrayBuffer[]
 } {
-  // Get the world matrix to capture all transformations
-  const worldMatrix = mtext.matrixWorld.clone()
+  // `MText` is a wrapper Object3D; insertion/rotation live on the rendered child group
+  // created in `loadMText`. Keep large drawing coordinates on that root transform, not
+  // in Float32 geometry buffers.
+  const renderRoot = mtext.children[0] as THREE.Object3D | undefined
+  const rootForTransform = renderRoot ?? mtext
+
+  const worldMatrix = rootForTransform.matrixWorld.clone()
   const position = new THREE.Vector3()
   const quaternion = new THREE.Quaternion()
   const scale = new THREE.Vector3()
 
-  // Decompose the world matrix to get the final position, rotation, and scale
   worldMatrix.decompose(position, quaternion, scale)
 
-  // Transform the bounding box to world coordinates
+  // `mtext.box` is already accumulated in world space during `syncDraw`.
   const transformedBox = mtext.box.clone()
-  transformedBox.applyMatrix4(worldMatrix)
 
-  // Serialize children and collect transferable objects
-  const { children, transferableObjects } = serializeChildren(mtext)
+  const { children, transferableObjects } = serializeChildren(rootForTransform)
 
   // Create a comprehensive JSON-serializable representation
   const serialized = {
@@ -277,26 +279,36 @@ function serializeMText(mtext: MText): {
   return { data: serialized, transferableObjects }
 }
 
+const rootWorldInverse = /*@__PURE__*/ new THREE.Matrix4()
+const childRelativeMatrix = /*@__PURE__*/ new THREE.Matrix4()
+
 // Serialize all child objects as JSON with transferable objects
-function serializeChildren(mtext: MText): {
+function serializeChildren(root: THREE.Object3D): {
   children: unknown[]
   transferableObjects: ArrayBuffer[]
 } {
   const children: unknown[] = []
   const allTransferableObjects: ArrayBuffer[] = []
 
-  mtext.traverse(child => {
+  root.updateWorldMatrix(true, true)
+  rootWorldInverse.copy(root.matrixWorld).invert()
+
+  root.traverse(child => {
     if (child instanceof THREE.Mesh || child instanceof THREE.Line) {
       const geometry = child.geometry
       const material = child.material
 
       if (geometry instanceof THREE.BufferGeometry) {
-        // Get world matrix for transformations
-        const worldMatrix = child.matrixWorld.clone()
+        // Keep glyph geometry local and express each child transform relative to
+        // the MText root so large insertion coordinates stay on the root group.
         const position = new THREE.Vector3()
         const quaternion = new THREE.Quaternion()
         const scale = new THREE.Vector3()
-        worldMatrix.decompose(position, quaternion, scale)
+        childRelativeMatrix.multiplyMatrices(
+          rootWorldInverse,
+          child.matrixWorld
+        )
+        childRelativeMatrix.decompose(position, quaternion, scale)
 
         // Serialize geometry attributes using transferable objects
         const attributes: Record<string, unknown> = {}

--- a/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
+++ b/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
@@ -541,6 +541,24 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
     const baseByLayer = colorSettings.color.aci === 256
     const group = new THREE.Group()
 
+    // Large drawing coordinates live on the root transform; glyph geometry stays local.
+    group.position.set(
+      serializedData.position.x,
+      serializedData.position.y,
+      serializedData.position.z
+    )
+    group.quaternion.set(
+      serializedData.rotation.x,
+      serializedData.rotation.y,
+      serializedData.rotation.z,
+      serializedData.rotation.w
+    )
+    group.scale.set(
+      serializedData.scale.x,
+      serializedData.scale.y,
+      serializedData.scale.z
+    )
+
     // Reconstruct all child objects
     serializedData.children.forEach(childData => {
       const geometry = new THREE.BufferGeometry()
@@ -646,7 +664,7 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
         geometry.computeBoundingSphere()
       }
 
-      // Set position, rotation, and scale directly (already in world coordinates)
+      // Child transforms are local to the MText root group.
       object.position.set(
         childData.position.x,
         childData.position.y,

--- a/packages/mtext-renderer/test/font/defaultFontLoader.test.ts
+++ b/packages/mtext-renderer/test/font/defaultFontLoader.test.ts
@@ -133,6 +133,49 @@ describe('DefaultFontLoader', () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 
+  it('downloads non-default fonts from the remote repository when requested by name', async () => {
+    vi.mocked(FontManager.instance.loadFonts).mockResolvedValue([
+      {
+        fontName: 'romans',
+        url: 'https://cdn.example.com/fonts/romans.shx',
+        status: 'Success'
+      }
+    ])
+    const loader = new DefaultFontLoader()
+    loader.baseUrl = 'https://cdn.example.com/fonts/'
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        jsonResponse([
+          {
+            name: ['Romans', 'romans'],
+            file: 'romans.shx',
+            type: 'shx',
+            url: ''
+          }
+        ])
+      )
+    )
+
+    const statuses = await loader.load(['romans'])
+
+    expect(FontManager.instance.loadFonts).toHaveBeenCalledWith([
+      {
+        name: ['Romans', 'romans'],
+        file: 'romans.shx',
+        type: 'shx',
+        url: 'https://cdn.example.com/fonts/romans.shx'
+      }
+    ])
+    expect(statuses).toEqual([
+      {
+        fontName: 'romans',
+        url: 'https://cdn.example.com/fonts/romans.shx',
+        status: 'Success'
+      }
+    ])
+  })
+
   it('loads requested fonts by name and preserves NotFound statuses', async () => {
     vi.mocked(FontManager.instance.loadFonts).mockResolvedValue([
       {

--- a/packages/mtext-renderer/test/renderer/webWorkerRenderer.precision.test.ts
+++ b/packages/mtext-renderer/test/renderer/webWorkerRenderer.precision.test.ts
@@ -1,0 +1,114 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+
+import { createDefaultColorSettings } from '../../src/renderer/types'
+import { WebWorkerRenderer } from '../../src/worker/webWorkerRenderer'
+
+function getGeometryPositionMaxAbs(object: THREE.Object3D) {
+  let maxAbs = 0
+
+  object.traverse(child => {
+    if (!('geometry' in child)) return
+
+    const position = (child.geometry as THREE.BufferGeometry).getAttribute(
+      'position'
+    )
+    if (!position) return
+
+    for (let i = 0; i < position.count; i++) {
+      maxAbs = Math.max(
+        maxAbs,
+        Math.abs(position.getX(i)),
+        Math.abs(position.getY(i)),
+        Math.abs(position.getZ(i))
+      )
+    }
+  })
+
+  return maxAbs
+}
+
+function createQuadGeometry(width: number, height: number) {
+  const geometry = new THREE.BufferGeometry()
+  const positions = new Float32Array([
+    0,
+    0,
+    0,
+    width,
+    0,
+    0,
+    width,
+    height,
+    0,
+    0,
+    height,
+    0
+  ])
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+  geometry.setIndex([0, 1, 1, 2, 2, 3, 3, 0])
+  return geometry
+}
+
+describe('WebWorkerRenderer reconstructMText precision', () => {
+  it('keeps glyph geometry local while insertion lives on the root transform', () => {
+    const position = { x: 38425192.41436505, y: 4069213.352858167, z: 0 }
+    const geometry = createQuadGeometry(10, 12)
+    const positions = geometry.getAttribute('position').array as Float32Array
+
+    const renderer = new WebWorkerRenderer({ poolSize: 0 })
+    const object = renderer.reconstructMText(
+      {
+        type: 'MText',
+        position,
+        rotation: { x: 0, y: 0, z: 0, w: 1 },
+        scale: { x: 1, y: 1, z: 1 },
+        box: {
+          min: { x: position.x, y: position.y, z: 0 },
+          max: { x: position.x + 10, y: position.y + 12, z: 0 }
+        },
+        children: [
+          {
+            type: 'mesh',
+            position: { x: 0, y: 0, z: 0 },
+            rotation: { x: 0, y: 0, z: 0, w: 1 },
+            scale: { x: 1, y: 1, z: 1 },
+            geometry: {
+              attributes: {
+                position: {
+                  arrayBuffer: positions.buffer,
+                  byteOffset: positions.byteOffset,
+                  length: positions.length,
+                  itemSize: 3,
+                  normalized: false
+                }
+              },
+              index: null
+            },
+            material: {
+              type: 'MeshBasicMaterial',
+              color: 0xffffff,
+              transparent: false,
+              opacity: 1
+            }
+          }
+        ]
+      },
+      createDefaultColorSettings()
+    )
+
+    expect(object.position.x).toBeCloseTo(position.x, 3)
+    expect(object.position.y).toBeCloseTo(position.y, 3)
+    expect(getGeometryPositionMaxAbs(object)).toBeLessThan(100)
+
+    const worldPoint = new THREE.Vector3()
+    object.updateWorldMatrix(true, true)
+    object.traverse(child => {
+      if (!(child instanceof THREE.Mesh)) return
+      child.getWorldPosition(worldPoint)
+      expect(worldPoint.x).toBeCloseTo(position.x, 3)
+      expect(worldPoint.y).toBeCloseTo(position.y, 3)
+    })
+
+    renderer.destroy()
+  })
+})

--- a/packages/mtext-renderer/test/worker/render-remote-font-loading.test.ts
+++ b/packages/mtext-renderer/test/worker/render-remote-font-loading.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FontManager } from '../../src/font/fontManager'
+import { DefaultStyleManager } from '../../src/renderer/defaultStyleManager'
+import { MText } from '../../src/renderer/mtext'
+import {
+  createDefaultColorSettings,
+  MTextAttachmentPoint,
+  MTextFlowDirection,
+  TextStyle
+} from '../../src/renderer/types'
+import { MainThreadRenderer } from '../../src/worker/mainThreadRenderer'
+import { WebWorkerRenderer } from '../../src/worker/webWorkerRenderer'
+
+const workerInstances: MockWorker[] = []
+
+class MockWorker {
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: ErrorEvent) => void) | null = null
+
+  postMessage = vi.fn((message: Record<string, unknown>) => {
+    queueMicrotask(() => {
+      const { type, id, data } = message
+      if (type === 'getAvailableFonts') {
+        this.onmessage?.({
+          data: {
+            id,
+            type,
+            success: true,
+            data: { fonts: [] }
+          }
+        } as MessageEvent)
+        return
+      }
+      if (type === 'loadFonts') {
+        this.onmessage?.({
+          data: {
+            id,
+            type,
+            success: true,
+            data: { loaded: (data as { fonts: string[] }).fonts }
+          }
+        } as MessageEvent)
+        return
+      }
+      if (type === 'render') {
+        this.onmessage?.({
+          data: {
+            id,
+            type,
+            success: true,
+            data: {
+              type: 'MText',
+              position: { x: 0, y: 0, z: 0 },
+              rotation: { x: 0, y: 0, z: 0, w: 1 },
+              scale: { x: 1, y: 1, z: 1 },
+              box: {
+                min: { x: 0, y: 0, z: 0 },
+                max: { x: 0, y: 0, z: 0 }
+              },
+              children: []
+            }
+          }
+        } as MessageEvent)
+      }
+    })
+  })
+
+  terminate = vi.fn()
+
+  constructor(_url: string | URL, _options?: WorkerOptions) {
+    workerInstances.push(this)
+  }
+}
+
+vi.stubGlobal('Worker', MockWorker)
+
+const minimalMTextData = {
+  text: '\\fArial|Hello',
+  height: 10,
+  width: 100,
+  position: { x: 0, y: 0, z: 0 },
+  attachmentPoint: MTextAttachmentPoint.BaselineLeft,
+  drawingDirection: MTextFlowDirection.BOTTOM_TO_TOP
+}
+
+const minimalTextStyle: TextStyle = {
+  name: 'Standard',
+  standardFlag: 0,
+  font: 'txt.shx',
+  bigFont: 'hztxt.shx',
+  fixedTextHeight: 10,
+  widthFactor: 1,
+  obliqueAngle: 0,
+  textGenerationFlag: 0,
+  lastHeight: 10
+}
+
+describe('render remote font loading', () => {
+  let loadFontsByNames: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    FontManager.instance.release()
+    FontManager.instance.defaultFonts = new Set(['simkai'])
+    FontManager.instance.symbolFonts = new Set(['amgdt'])
+    loadFontsByNames = vi
+      .spyOn(FontManager.instance, 'loadFontsByNames')
+      .mockResolvedValue([])
+    workerInstances.length = 0
+  })
+
+  afterEach(() => {
+    loadFontsByNames.mockRestore()
+    vi.unstubAllGlobals()
+    vi.stubGlobal('Worker', MockWorker)
+  })
+
+  it('MainThreadRenderer loads default and symbol fonts before the first render', async () => {
+    const renderer = new MainThreadRenderer()
+
+    await renderer.asyncRenderMText(
+      minimalMTextData,
+      minimalTextStyle,
+      createDefaultColorSettings()
+    )
+
+    expect(loadFontsByNames).toHaveBeenCalledWith(['simkai', 'amgdt'])
+  })
+
+  it('MainThreadRenderer does not reload default fonts on subsequent renders', async () => {
+    const renderer = new MainThreadRenderer()
+
+    await renderer.asyncRenderMText(
+      minimalMTextData,
+      minimalTextStyle,
+      createDefaultColorSettings()
+    )
+    loadFontsByNames.mockClear()
+
+    await renderer.asyncRenderMText(
+      minimalMTextData,
+      minimalTextStyle,
+      createDefaultColorSettings()
+    )
+
+    expect(loadFontsByNames).not.toHaveBeenCalledWith(['simkai', 'amgdt'])
+  })
+
+  it('MText.asyncDraw collects inline/style fonts and requests loadFontsByNames before parse', async () => {
+    const styleManager = new DefaultStyleManager()
+    const mtext = new MText(
+      minimalMTextData,
+      minimalTextStyle,
+      styleManager,
+      FontManager.instance,
+      createDefaultColorSettings()
+    )
+
+    await mtext.asyncDraw()
+
+    // arial/txt/hztxt are not defaultFonts; loadFontsByNames still receives them so
+    // DefaultFontLoader can download any match from the remote font repository.
+    expect(loadFontsByNames).toHaveBeenCalledWith(
+      expect.arrayContaining(['arial', 'txt', 'hztxt'])
+    )
+  })
+
+  it('glyph fallback does not trigger remote font loading', () => {
+    const manager = FontManager.instance as any
+    const primary = {
+      names: new Set(['primary']),
+      getCharShape: vi.fn().mockReturnValue(undefined)
+    }
+    const fallback = {
+      names: new Set(['simkai']),
+      getCharShape: vi.fn().mockReturnValue(undefined)
+    }
+    manager.loadedFontMap.set('primary', primary)
+    manager.loadedFontMap.set('simkai', fallback)
+
+    expect(
+      FontManager.instance.getCharShapeFromDefaults('中', 10)
+    ).toBeUndefined()
+    expect(loadFontsByNames).not.toHaveBeenCalled()
+  })
+
+  it('WebWorkerRenderer asks workers to load default fonts on first render', async () => {
+    const renderer = new WebWorkerRenderer({ poolSize: 1, timeOut: 5000 })
+
+    await renderer.asyncRenderMText(
+      minimalMTextData,
+      minimalTextStyle,
+      createDefaultColorSettings()
+    )
+
+    const loadFontsMessages = workerInstances[0].postMessage.mock.calls.filter(
+      ([message]) => (message as { type?: string }).type === 'loadFonts'
+    )
+    expect(loadFontsMessages.length).toBeGreaterThan(0)
+    expect(loadFontsMessages[0]?.[0]).toMatchObject({
+      type: 'loadFonts',
+      data: { fonts: ['simkai', 'amgdt'] }
+    })
+
+    renderer.destroy()
+  })
+
+  it('WebWorkerRenderer loadFonts delegates font names to all workers', async () => {
+    const renderer = new WebWorkerRenderer({ poolSize: 2, timeOut: 5000 })
+
+    await renderer.loadFonts(['txt', 'hztxt'])
+
+    for (const worker of workerInstances) {
+      expect(worker.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'loadFonts',
+          data: { fonts: ['txt', 'hztxt'] }
+        })
+      )
+    }
+
+    renderer.destroy()
+  })
+})


### PR DESCRIPTION
## Summary

- Fix Web Worker serialization so large drawing insertion coordinates stay on the MText root transform instead of being baked into Float32 geometry buffers, preventing precision loss at large CAD coordinates.
- Apply root position/rotation/scale when reconstructing MText on the main thread, and serialize child transforms relative to the render root.
- Fix underline/overline/strikethrough decoration geometries to use explicit line indices instead of setIndex(null).
- Add tests for worker reconstruction precision, remote font loading via DefaultFontLoader, and font loading behavior in MainThreadRenderer / WebWorkerRenderer / MText.asyncDraw.

## Test plan

- [x] pnpm --filter @mlightcad/mtext-renderer test --run test/renderer/webWorkerRenderer.precision.test.ts test/worker/render-remote-font-loading.test.ts test/font/defaultFontLoader.test.ts
- [ ] Verify MText renders correctly at large world coordinates when using Web Worker rendering
- [ ] Confirm underline/overline/strikethrough decorations render as expected
- [ ] Confirm non-default fonts are downloaded from the remote repository when requested by name