### PR TITLE
feat: refactor example app with WCS rebase demo and fix worker LineSegments serialization

### DIFF
--- a/packages/example/index.html
+++ b/packages/example/index.html
@@ -5,35 +5,56 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MText Renderer Example</title>
     <style>
-        body { 
-            margin: 0; 
-            padding: 20px;
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            margin: 0;
+            padding: 0;
             font-family: Arial, sans-serif;
+            height: 100vh;
+            overflow: hidden;
+            background: #e8e8e8;
+        }
+        #app-layout {
             display: flex;
-            flex-direction: column;
-            align-items: center;
-            min-height: 100vh;
-            background: #f0f0f0;
+            height: 100vh;
+            width: 100vw;
         }
         #controls {
-            width: 1000px;
+            flex: 0 0 50%;
+            width: 50%;
+            min-width: 360px;
             background: #333;
             color: white;
             padding: 20px;
-            box-sizing: border-box;
-            border-radius: 5px;
-            margin-bottom: 20px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+            overflow-y: auto;
+            border-right: 1px solid #222;
         }
         #render-area {
-            width: 1000px;
-            height: 600px;
+            flex: 1;
+            min-width: 0;
+            height: 100%;
             position: relative;
-            border: 1px solid #ccc;
-            border-radius: 5px;
             overflow: hidden;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-            background: white;
+            background: #fff;
+        }
+        #wcs-coords {
+            position: absolute;
+            top: 8px;
+            left: 50%;
+            transform: translateX(-50%);
+            padding: 4px 12px;
+            background: rgba(0, 0, 0, 0.65);
+            color: #fff;
+            font-family: Consolas, 'Courier New', monospace;
+            font-size: 13px;
+            line-height: 1.4;
+            pointer-events: none;
+            z-index: 10;
+            border-radius: 4px;
+            white-space: nowrap;
+            visibility: hidden;
         }
         canvas { 
             display: block;
@@ -42,13 +63,12 @@
         }
         #mtext-input {
             width: 100%;
-            height: 100px;
+            height: 140px;
             margin: 10px 0;
-            padding: 5px;
-            box-sizing: border-box;
+            padding: 8px;
             resize: vertical;
-            min-height: 50px;
-            max-height: 300px;
+            min-height: 80px;
+            max-height: 360px;
         }
         select {
             width: 100%;
@@ -100,6 +120,12 @@
         .examples {
             margin: 10px 0;
         }
+        .examples h3 {
+            margin: 0 0 8px;
+            font-size: 14px;
+            font-weight: normal;
+            color: #ccc;
+        }
         .example-btn {
             background: #444;
             color: white;
@@ -108,6 +134,7 @@
             margin: 2px;
             cursor: pointer;
             border-radius: 3px;
+            font-size: 12px;
         }
         .example-btn:hover {
             background: #555;
@@ -155,9 +182,20 @@
         .font-cache-actions button {
             margin: 0;
         }
+        .action-row {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            flex-wrap: wrap;
+            margin: 8px 0;
+        }
+        .action-row .checkbox-container {
+            margin: 0;
+        }
     </style>
 </head>
 <body>
+    <div id="app-layout">
     <div id="controls">
         <h2>MText Renderer Example</h2>
         <div class="row">
@@ -168,6 +206,15 @@
                     <option value="shape">SHAPE (SHX shape entity)</option>
                 </select>
             </div>
+            <div class="field">
+                <label for="render-mode">Render Mode:</label>
+                <select id="render-mode">
+                    <option value="main">Main Thread</option>
+                    <option value="worker">Web Worker</option>
+                </select>
+            </div>
+        </div>
+        <div class="row">
             <div class="field">
                 <label for="font-select">Text Style Font:</label>
                 <select id="font-select">
@@ -182,13 +229,6 @@
                     <option value="modern">modern (hztxt → gdt)</option>
                     <option value="international">international (txt → gdt)</option>
                     <option value="cjk">cjk (gbcbig → gdt)</option>
-                </select>
-            </div>
-            <div class="field">
-                <label for="render-mode">Render Mode:</label>
-                <select id="render-mode">
-                    <option value="main">Main Thread</option>
-                    <option value="worker">Web Worker</option>
                 </select>
             </div>
         </div>
@@ -247,17 +287,17 @@
             </div>
             <p class="hint">Uses <code>complex.shx</code> by default. Shape number 128–132 render distinct glyphs; name lookup is tried first when provided.</p>
         </div>
-        <div style="display: flex; align-items: center; gap: 10px;">
+        <div class="action-row">
             <button id="render-btn">Render</button>
-            <div class="checkbox-container" style="margin: 0;">
+            <div class="checkbox-container">
                 <input type="checkbox" id="show-bounding-box" checked>
                 <label for="show-bounding-box">Show Bounding Box</label>
             </div>
-            <div class="checkbox-container" style="margin: 0;">
+            <div class="checkbox-container">
                 <input type="checkbox" id="show-char-boxes">
                 <label for="show-char-boxes">Show Char Boxes</label>
             </div>
-            <div class="checkbox-container" style="margin: 0;">
+            <div class="checkbox-container">
                 <input type="checkbox" id="show-line-boxes">
                 <label for="show-line-boxes">Show Line Boxes</label>
             </div>
@@ -276,10 +316,15 @@
             <button class="example-btn" data-example="stacking">Stacking</button>
             <button class="example-btn" data-example="multiple">Multiple MText</button>
             <button class="example-btn" data-example="attachmentGrid">Attachment Points</button>
+            <button class="example-btn" data-example="largeCoordinatesRebase" title="Large WCS coords with rebase to origin; two MText blocks (\P\P); fonts via \Fname;">Large Coordinates (Rebase)</button>
+            <button class="example-btn" data-example="largeCoordinatesNoRebase" title="Same WCS coords without rebase — compare float32 behavior; \P\P separates blocks; fonts via \Fname;">Large Coordinates (No Rebase)</button>
         </div>
         <div id="status"></div>
     </div>
-    <div id="render-area"></div>
+    <div id="render-area">
+        <div id="wcs-coords" aria-live="polite"></div>
+    </div>
+    </div>
     <!-- Load bundled example -->
     <script type="module" src="./src/main.ts"></script>
 </body>

--- a/packages/example/src/debugOverlayManager.ts
+++ b/packages/example/src/debugOverlayManager.ts
@@ -1,0 +1,357 @@
+import {
+  CharBox,
+  CharBoxType,
+  LineLayout,
+  MTextData,
+  MTextObject,
+  TextStyle
+} from '@mlightcad/mtext-renderer'
+import * as THREE from 'three'
+
+import { LargeCoordinatesExample } from './exampleTestData'
+import { SceneBoundsHelper } from './sceneBoundsHelper'
+
+/** Options for {@link DebugOverlayManager.addMTextDebugOverlays}. */
+export type MTextDebugOverlayOptions = {
+  /** When true, green wireframe boxes are added for each MText object. */
+  showBoundingBox: boolean
+  /** Source test cases; required for attachment-grid and large-coordinate crosshairs. */
+  multiData?: { mtextData: MTextData; textStyle: TextStyle }[]
+}
+
+/**
+ * Creates and tracks visual debug overlays for the example renderer.
+ *
+ * @remarks
+ * Overlays include MText bounding boxes, DXF insertion crosshairs, per-character
+ * layout boxes, and per-line strip boxes. All overlay roots and descendants set
+ * `userData.excludeFromFit = true` so {@link SceneBoundsHelper.computeRenderableBounds}
+ * frames glyph geometry rather than debug decoration.
+ */
+export class DebugOverlayManager {
+  /** Most recently created single-entity bounding box (used by the checkbox toggle). */
+  private mtextBox: THREE.LineSegments | null = null
+  /** Char-box overlay groups attached during the current render pass. */
+  private charBoxOverlays: THREE.Object3D[] = []
+  /** Line-box overlay groups attached during the current render pass. */
+  private lineBoxOverlays: THREE.Object3D[] = []
+
+  /**
+   * @param boundsHelper - Supplies tight bounds for overlay placement after rebase.
+   */
+  constructor(private readonly boundsHelper: SceneBoundsHelper) {}
+
+  /** Discards overlay references when scene content is cleared. Does not dispose GPU resources. */
+  clear(): void {
+    this.mtextBox = null
+    this.charBoxOverlays = []
+    this.lineBoxOverlays = []
+  }
+
+  /**
+   * Returns the bounding-box overlay for the last single-entity render, if any.
+   *
+   * @returns Green wireframe box, or `null` when none was created.
+   */
+  getMtextBox(): THREE.LineSegments | null {
+    return this.mtextBox
+  }
+
+  /**
+   * Toggles visibility of the single-entity bounding box from {@link getMtextBox}.
+   *
+   * @param visible - Desired visibility state.
+   * @remarks Multi-entity debug boxes are not tracked individually; re-render to refresh them.
+   */
+  setBoundingBoxVisible(visible: boolean): void {
+    if (this.mtextBox) {
+      this.mtextBox.visible = visible
+    }
+  }
+
+  /** Shows or hides all char-box overlays from the current render pass. */
+  setCharBoxOverlayVisibility(visible: boolean): void {
+    this.charBoxOverlays.forEach(overlay => {
+      overlay.visible = visible
+    })
+  }
+
+  /** Shows or hides all line-box overlays from the current render pass. */
+  setLineBoxOverlayVisibility(visible: boolean): void {
+    this.lineBoxOverlays.forEach(overlay => {
+      overlay.visible = visible
+    })
+  }
+
+  /**
+   * Builds a green wireframe box from axis-aligned bounds.
+   *
+   * @param box - World- or local-space extents; geometry is built in local `[0,width]×[0,height]`.
+   * @returns Line segments positioned at `(box.min.x, box.min.y)` with `excludeFromFit` set.
+   *
+   * @remarks
+   * Also stores the result in {@link mtextBox} for checkbox toggling on single-entity renders.
+   */
+  createMTextBox(box: THREE.Box3): THREE.LineSegments {
+    const width = box.max.x - box.min.x
+    const height = box.max.y - box.min.y
+    const minZ = box.min.z
+    const maxZ = box.max.z
+
+    const vertices = [
+      0, 0, minZ, width, 0, minZ, width, 0, minZ, width, height, minZ,
+      width, height, minZ, 0, height, minZ, 0, height, minZ, 0, 0, minZ,
+      0, 0, maxZ, width, 0, maxZ, width, 0, maxZ, width, height, maxZ,
+      width, height, maxZ, 0, height, maxZ, 0, height, maxZ, 0, 0, maxZ,
+      0, 0, minZ, 0, 0, maxZ, width, 0, minZ, width, 0, maxZ,
+      width, height, minZ, width, height, maxZ, 0, height, minZ, 0, height, maxZ
+    ]
+
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute(
+      'position',
+      new THREE.Float32BufferAttribute(vertices, 3)
+    )
+    const material = new THREE.LineBasicMaterial({
+      color: 0x00ff00,
+      linewidth: 1
+    })
+    this.mtextBox = new THREE.LineSegments(geometry, material)
+    this.mtextBox.position.set(box.min.x, box.min.y, 0)
+    this.mtextBox.userData.excludeFromFit = true
+    return this.mtextBox
+  }
+
+  /**
+   * Builds a red insertion-point crosshair centered at `(x, y)`.
+   *
+   * @param x - Scene X of the DXF insertion / alignment anchor.
+   * @param y - Scene Y of the insertion anchor.
+   * @param arm - Half-length of each cross arm in drawing units (default `22`).
+   * @param z - Depth offset above glyph geometry (default `0.03`).
+   * @returns Line segments with depth test disabled for visibility over text.
+   */
+  createInsertionCrosshair(
+    x: number,
+    y: number,
+    arm = 22,
+    z = 0.03
+  ): THREE.LineSegments {
+    const vertices = new Float32Array([
+      -arm, 0, z, arm, 0, z, 0, -arm, z, 0, arm, z
+    ])
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3))
+    const material = new THREE.LineBasicMaterial({
+      color: 0xff3333,
+      depthTest: false,
+      transparent: true,
+      opacity: 0.95
+    })
+    const lines = new THREE.LineSegments(geometry, material)
+    lines.position.set(x, y, 0)
+    lines.renderOrder = 1000
+    lines.userData.excludeFromFit = true
+    return lines
+  }
+
+  /**
+   * Adds crosshairs and optional bounding boxes for a multi-entity MText render.
+   *
+   * @param group - Parent group receiving overlay children.
+   * @param mtextObjects - Rendered entities aligned with `multiData` indices.
+   * @param content - Example marker (`attachmentGrid`, large-coordinate keys, etc.).
+   * @param options - Visibility and source test-case metadata.
+   */
+  addMTextDebugOverlays(
+    group: THREE.Group,
+    mtextObjects: MTextObject[],
+    content: string,
+    options: MTextDebugOverlayOptions
+  ): void {
+    const { showBoundingBox, multiData } = options
+
+    if (
+      multiData &&
+      (content === 'attachmentGrid' || LargeCoordinatesExample.isExample(content))
+    ) {
+      multiData.forEach((_, index) => {
+        const { mtextData } = multiData[index]
+        const arm = LargeCoordinatesExample.isExample(content)
+          ? mtextData.height * 5
+          : undefined
+        const anchor = LargeCoordinatesExample.isExample(content)
+          ? this.boundsHelper.getRebasedAnchorPoint(mtextObjects[index])
+          : new THREE.Vector3(mtextData.position.x, mtextData.position.y, 0)
+        group.add(this.createInsertionCrosshair(anchor.x, anchor.y, arm))
+      })
+    }
+
+    if (!showBoundingBox) {
+      return
+    }
+
+    mtextObjects.forEach(mtextObj => {
+      if (mtextObj.box && !mtextObj.box.isEmpty()) {
+        group.add(
+          this.createMTextBox(
+            this.boundsHelper.getOverlayBounds(mtextObj, mtextObj.box)
+          )
+        )
+      }
+    })
+  }
+
+  /**
+   * Attaches a cyan char-box overlay derived from {@link MTextObject.createLayoutData}.
+   *
+   * @param mtextObj - Rendered entity to annotate.
+   * @param visible - Initial visibility (typically tied to the char-box checkbox).
+   */
+  attachCharBoxOverlay(mtextObj: MTextObject, visible: boolean): void {
+    const layout = mtextObj.createLayoutData()
+    if (!layout.chars || layout.chars.length === 0) return
+
+    const overlay = this.createCharBoxOverlay(layout.chars)
+    overlay.visible = visible
+    overlay.renderOrder = 999
+    overlay.userData.excludeFromFit = true
+    mtextObj.add(overlay)
+    this.charBoxOverlays.push(overlay)
+  }
+
+  /**
+   * Attaches a magenta line-strip overlay for each laid-out text line.
+   *
+   * @param mtextObj - Rendered entity with non-empty logical box and line layouts.
+   * @param visible - Initial visibility (typically tied to the line-box checkbox).
+   */
+  attachLineBoxOverlay(mtextObj: MTextObject, visible: boolean): void {
+    const layout = mtextObj.createLayoutData()
+    if (!layout.lines || layout.lines.length === 0) return
+    if (!mtextObj.box || mtextObj.box.isEmpty()) return
+
+    const overlay = this.createLineBoxOverlay(
+      layout.lines,
+      mtextObj.box.min.x,
+      mtextObj.box.max.x
+    )
+    overlay.visible = visible
+    overlay.renderOrder = 998
+    overlay.userData.excludeFromFit = true
+    mtextObj.add(overlay)
+    this.lineBoxOverlays.push(overlay)
+  }
+
+  /**
+   * Flattens nested char-box trees into leaf CHAR entries for outline rendering.
+   *
+   * @param charBoxes - Root char boxes from layout metadata (may contain stack/context children).
+   */
+  private flattenCharBoxes(charBoxes: CharBox[]): CharBox[] {
+    const flattened: CharBox[] = []
+    const stack = [...charBoxes]
+
+    while (stack.length > 0) {
+      const entry = stack.pop()!
+      if (entry.type === CharBoxType.CHAR) {
+        flattened.push(entry)
+      }
+
+      if (entry.children && entry.children.length > 0) {
+        for (let i = entry.children.length - 1; i >= 0; i--) {
+          stack.push(entry.children[i])
+        }
+      }
+    }
+
+    return flattened
+  }
+
+  /**
+   * Builds a group of cyan rectangles outlining individual character bounds.
+   *
+   * @param charBoxes - Layout char boxes (nested structures are flattened first).
+   */
+  private createCharBoxOverlay(charBoxes: CharBox[]): THREE.Group {
+    const overlay = new THREE.Group()
+    const renderableCharBoxes = this.flattenCharBoxes(charBoxes)
+
+    const charMaterial = new THREE.LineBasicMaterial({
+      color: 0x00cfff,
+      depthTest: false,
+      transparent: true,
+      opacity: 0.95
+    })
+
+    renderableCharBoxes.forEach(entry => {
+      const minX = entry.box.min.x
+      const minY = entry.box.min.y
+      const maxX = entry.box.max.x
+      const maxY = entry.box.max.y
+      const z = Math.max(entry.box.max.z, 0) + 0.001
+
+      const outlineVertices = [
+        minX, minY, z, maxX, minY, z, maxX, minY, z, maxX, maxY, z,
+        maxX, maxY, z, minX, maxY, z, minX, maxY, z, minX, minY, z
+      ]
+
+      const outlineGeometry = new THREE.BufferGeometry()
+      outlineGeometry.setAttribute(
+        'position',
+        new THREE.Float32BufferAttribute(outlineVertices, 3)
+      )
+
+      const outline = new THREE.LineSegments(outlineGeometry, charMaterial)
+      outline.userData.excludeFromFit = true
+      overlay.add(outline)
+    })
+
+    return overlay
+  }
+
+  /**
+   * Builds horizontal strip outlines spanning `[lineMinX, lineMaxX]` for each line layout.
+   *
+   * @param lineLayouts - Per-line Y/height metadata from the renderer.
+   * @param lineMinX - Left edge shared by all line strips (logical box minimum X).
+   * @param lineMaxX - Right edge shared by all line strips (logical box maximum X).
+   * @param z - Depth offset above glyphs (default `0.002`).
+   */
+  private createLineBoxOverlay(
+    lineLayouts: LineLayout[],
+    lineMinX: number,
+    lineMaxX: number,
+    z = 0.002
+  ): THREE.Group {
+    const overlay = new THREE.Group()
+    const material = new THREE.LineBasicMaterial({
+      color: 0xff2bd6,
+      depthTest: false,
+      depthWrite: false,
+      transparent: true,
+      opacity: 0.9
+    })
+
+    lineLayouts.forEach(line => {
+      const minY = line.y - line.height / 2
+      const maxY = line.y + line.height / 2
+      const outlineVertices = [
+        lineMinX, minY, z, lineMaxX, minY, z, lineMaxX, minY, z, lineMaxX, maxY, z,
+        lineMaxX, maxY, z, lineMinX, maxY, z, lineMinX, maxY, z, lineMinX, minY, z
+      ]
+      const outlineGeometry = new THREE.BufferGeometry()
+      outlineGeometry.setAttribute(
+        'position',
+        new THREE.Float32BufferAttribute(outlineVertices, 3)
+      )
+      const outline = new THREE.LineSegments(outlineGeometry, material)
+      outline.frustumCulled = false
+      outline.userData.excludeFromFit = true
+      overlay.add(outline)
+    })
+
+    overlay.userData.excludeFromFit = true
+    return overlay
+  }
+}

--- a/packages/example/src/exampleFontManager.ts
+++ b/packages/example/src/exampleFontManager.ts
@@ -1,0 +1,246 @@
+import {
+  DefaultFontsPreset,
+  FontInfo,
+  UnifiedRenderer
+} from '@mlightcad/mtext-renderer'
+
+/**
+ * Manages font discovery, preset application, local caching, and `<select>` UI
+ * for the interactive MText renderer example.
+ *
+ * @remarks
+ * Wraps {@link UnifiedRenderer} font APIs and synchronizes the text-style and SHAPE
+ * font dropdowns with {@link refreshAvailableFonts}. Status messages are written
+ * directly to the shared `#status` element passed at construction time.
+ */
+export class ExampleFontManager {
+  /** File extensions accepted by {@link cacheSelectedFontFile}. */
+  private readonly supportedFontExtensions = new Set([
+    '.shx',
+    '.ttf',
+    '.otf',
+    '.woff'
+  ])
+
+  /**
+   * @param unifiedRenderer - Renderer whose font registry is queried and updated.
+   * @param statusDiv - `#status` element for user-facing progress and error text.
+   * @param fontSelect - Text-style font `<select>` (`#font-select`).
+   * @param shapeFontSelect - SHAPE font `<select>` (`#shape-font-select`); SHX fonts only.
+   * @param defaultFontsPresetSelect - Default-fonts preset `<select>`.
+   * @param fontCacheInput - File input for local font caching.
+   * @param fontCacheBtn - Button that triggers {@link cacheSelectedFontFile}.
+   */
+  constructor(
+    private readonly unifiedRenderer: UnifiedRenderer,
+    private readonly statusDiv: HTMLDivElement,
+    private readonly fontSelect: HTMLSelectElement,
+    private readonly shapeFontSelect: HTMLSelectElement,
+    private readonly defaultFontsPresetSelect: HTMLSelectElement,
+    private readonly fontCacheInput: HTMLInputElement,
+    private readonly fontCacheBtn: HTMLButtonElement
+  ) {}
+
+  /** @returns Currently selected primary text font from `#font-select`. */
+  getSelectedTextFont(): string {
+    return this.fontSelect.value
+  }
+
+  /** @returns Currently selected SHX font for SHAPE rendering. */
+  getSelectedShapeFont(): string {
+    return this.shapeFontSelect.value
+  }
+
+  /** @returns Active default-fonts preset identifier from the UI. */
+  getSelectedDefaultFontsPreset(): DefaultFontsPreset {
+    return this.defaultFontsPresetSelect.value as DefaultFontsPreset
+  }
+
+  /**
+   * Bootstraps font lists and applies the current preset.
+   *
+   * @param isResetAvailableFonts - When true, repopulates selects from the renderer first.
+   * @throws Rethrows errors from font loading so the caller can show a fatal status message.
+   */
+  async initialize(isResetAvailableFonts = true): Promise<void> {
+    if (isResetAvailableFonts) {
+      await this.refreshAvailableFonts()
+    }
+    await this.applyDefaultFontsPreset()
+  }
+
+  /**
+   * Applies the selected preset, loads all fonts in the text and symbol chains, and
+   * updates the status line with the resolved fallback order.
+   */
+  async applyDefaultFontsPreset(): Promise<void> {
+    const preset = this.getSelectedDefaultFontsPreset()
+    await this.unifiedRenderer.setDefaultFonts(preset)
+    const textChain = this.unifiedRenderer.getDefaultFontsPreset(preset)
+    const symbolChain = this.unifiedRenderer.getSymbolFontsPreset(preset)
+    const fontsToLoad = [
+      ...new Set([
+        ...textChain,
+        ...symbolChain,
+        this.fontSelect.value,
+        this.shapeFontSelect.value
+      ])
+    ]
+    await this.unifiedRenderer.loadFonts(fontsToLoad)
+    this.statusDiv.textContent = `Preset "${preset}": text ${textChain.join(' → ')} | symbol ${symbolChain.join(' → ')}`
+    this.statusDiv.style.color = '#0f0'
+  }
+
+  /**
+   * Refreshes both font `<select>` elements from {@link UnifiedRenderer.getAvailableFonts}.
+   *
+   * @param selectedTextFont - Optional text font to preserve after repopulating.
+   * @param selectedShapeFont - Optional SHAPE font to preserve after repopulating.
+   * @returns Full font metadata list returned by the renderer.
+   */
+  async refreshAvailableFonts(
+    selectedTextFont?: string,
+    selectedShapeFont?: string
+  ): Promise<FontInfo[]> {
+    const result = await this.unifiedRenderer.getAvailableFonts()
+    const fonts = result.fonts as FontInfo[]
+    this.populateFontSelects(fonts, selectedTextFont, selectedShapeFont)
+    return fonts
+  }
+
+  /**
+   * Caches the file chosen in `#font-cache-input`, refreshes UI, and re-renders.
+   *
+   * @param onCached - Async callback invoked after a successful cache (typically re-render).
+   */
+  async cacheSelectedFontFile(onCached: () => Promise<void>): Promise<void> {
+    const file = this.fontCacheInput.files?.[0]
+    if (!file) {
+      this.statusDiv.textContent = 'Select a font file to cache'
+      this.statusDiv.style.color = '#f00'
+      return
+    }
+
+    if (!this.isSupportedFontFile(file)) {
+      this.statusDiv.textContent =
+        'Unsupported font type. Use .shx, .ttf, .otf, or .woff'
+      this.statusDiv.style.color = '#f00'
+      return
+    }
+
+    try {
+      this.statusDiv.textContent = `Caching ${file.name}...`
+      this.statusDiv.style.color = '#ffa500'
+      this.fontCacheBtn.disabled = true
+
+      const status = await this.unifiedRenderer.cacheFont(file)
+      if (status.status !== 'Success') {
+        this.statusDiv.textContent = `Failed to cache ${file.name}`
+        this.statusDiv.style.color = '#f00'
+        return
+      }
+
+      await this.refreshAvailableFonts(status.fontName, status.fontName)
+      await this.applyDefaultFontsPreset()
+      await onCached()
+
+      this.statusDiv.textContent = `Cached and loaded ${file.name} (${status.fontName})`
+      this.statusDiv.style.color = '#0f0'
+      this.fontCacheInput.value = ''
+    } catch (error) {
+      console.error('Error caching font:', error)
+      this.statusDiv.textContent = 'Error caching font'
+      this.statusDiv.style.color = '#f00'
+    } finally {
+      this.fontCacheBtn.disabled = !this.fontCacheInput.files?.[0]
+    }
+  }
+
+  /** Enables or disables the cache button based on whether a file is selected. */
+  updateCacheButtonState(): void {
+    this.fontCacheBtn.disabled = !this.fontCacheInput.files?.[0]
+  }
+
+  /** @returns Lowercase extension including the dot, or empty string when absent. */
+  private getFontExtension(fileName: string): string {
+    const dotIndex = fileName.lastIndexOf('.')
+    if (dotIndex < 0) {
+      return ''
+    }
+    return fileName.slice(dotIndex).toLowerCase()
+  }
+
+  /** @returns Whether `file` has an extension listed in {@link supportedFontExtensions}. */
+  private isSupportedFontFile(file: File): boolean {
+    return this.supportedFontExtensions.has(this.getFontExtension(file.name))
+  }
+
+  /**
+   * Formats a font entry for `<option>` display.
+   *
+   * @param font - Font metadata from the renderer registry.
+   * @returns Primary name, suffixed with `[cached]` when loaded from IndexedDB.
+   */
+  private formatFontLabel(font: FontInfo): string {
+    const label = font.name[0]
+    return font.source === 'cache' ? `${label} [cached]` : label
+  }
+
+  /**
+   * Rebuilds `#font-select` and `#shape-font-select` from available fonts.
+   *
+   * @param fonts - Complete font list from the renderer.
+   * @param selectedTextFont - Preferred text font; falls back to `simkai` when unmatched.
+   * @param selectedShapeFont - Preferred SHAPE font; falls back to `complex` when unmatched.
+   */
+  private populateFontSelects(
+    fonts: FontInfo[],
+    selectedTextFont?: string,
+    selectedShapeFont?: string
+  ): void {
+    const previousTextFont = selectedTextFont ?? this.fontSelect.value
+    const previousShapeFont = selectedShapeFont ?? this.shapeFontSelect.value
+
+    this.fontSelect.innerHTML = ''
+    this.shapeFontSelect.innerHTML = ''
+
+    let textFontMatched = false
+    let shapeFontMatched = false
+
+    const matchesSelection = (
+      font: FontInfo,
+      selectedName: string
+    ): boolean =>
+      font.name.some(
+        name => name.toLowerCase() === selectedName.toLowerCase()
+      )
+
+    fonts.forEach(font => {
+      const option = document.createElement('option')
+      option.value = font.name[0]
+      option.textContent = this.formatFontLabel(font)
+      if (matchesSelection(font, previousTextFont)) {
+        option.selected = true
+        textFontMatched = true
+      } else if (!textFontMatched && font.name[0] === 'simkai') {
+        option.selected = true
+        textFontMatched = true
+      }
+      this.fontSelect.appendChild(option)
+
+      if (font.type === 'shx' || font.file.toLowerCase().endsWith('.shx')) {
+        const shapeOption = document.createElement('option')
+        shapeOption.value = font.name[0]
+        shapeOption.textContent = this.formatFontLabel(font)
+        if (matchesSelection(font, previousShapeFont)) {
+          shapeOption.selected = true
+          shapeFontMatched = true
+        } else if (!shapeFontMatched && font.name[0] === 'complex') {
+          shapeOption.selected = true
+          shapeFontMatched = true
+        }
+        this.shapeFontSelect.appendChild(shapeOption)
+      }
+    })
+  }
+}

--- a/packages/example/src/exampleTestData.ts
+++ b/packages/example/src/exampleTestData.ts
@@ -1,0 +1,442 @@
+import {
+  MText,
+  MTextAttachmentPoint,
+  MTextData,
+  MTextFlowDirection,
+  MTextObject,
+  ShapeData,
+  TextStyle,
+  UnifiedRenderer
+} from '@mlightcad/mtext-renderer'
+import * as THREE from 'three'
+
+/**
+ * Pair of {@link MTextData} and {@link TextStyle} passed to {@link UnifiedRenderer.asyncRenderMText}.
+ */
+export type MTextTestCase = {
+  /** Entity geometry and format string. */
+  mtextData: MTextData
+  /** DXF-style text style applied during layout. */
+  textStyle: TextStyle
+}
+
+/**
+ * Pair of {@link ShapeData} and {@link TextStyle} passed to {@link UnifiedRenderer.asyncRenderShape}.
+ */
+export type ShapeTestCase = {
+  /** SHX shape lookup parameters and placement. */
+  shapeData: ShapeData
+  /** Style supplying the SHX font name and nominal height. */
+  textStyle: TextStyle
+}
+
+/** Input fields from the SHAPE panel in the example UI. */
+export type ShapeInputValues = {
+  /** Nominal shape height in drawing units. */
+  size: number
+  /** Horizontal width factor (DXF group 41 analog). */
+  widthFactor: number
+  /** Rotation in degrees; converted to radians in {@link buildShapeDataFromInputs}. */
+  rotationDeg: number
+  /** SHX shape number when numeric lookup is used. */
+  shapeNumber: number
+  /** SHX shape name when name lookup is used. */
+  shapeName: string
+}
+
+/**
+ * Builds a minimal AutoCAD-style {@link TextStyle} for example test cases.
+ *
+ * @param font - Primary font file name (without extension).
+ * @param height - Fixed text height (`fixedTextHeight` / `lastHeight`).
+ */
+function createStandardTextStyle(font: string, height: number): TextStyle {
+  return {
+    name: 'Standard',
+    standardFlag: 0,
+    fixedTextHeight: height,
+    widthFactor: 1,
+    obliqueAngle: 0,
+    textGenerationFlag: 0,
+    lastHeight: height,
+    font,
+    bigFont: ''
+  }
+}
+
+/**
+ * Creates twelve MText samples on a 3×4 grid exercising DXF attachment points 1–12.
+ *
+ * @param textFont - Font name applied to every cell's {@link TextStyle}.
+ * @returns One test case per attachment point, each with a red crosshair anchor at `mtextData.position`.
+ *
+ * @remarks
+ * Every entity shares the same insertion coordinates within a cell; only
+ * {@link MTextData.attachmentPoint} varies so alignment behavior can be compared visually.
+ */
+export function createAttachmentPointTestData(textFont: string): MTextTestCase[] {
+  const cellW = 330
+  const cellH = 175
+  const originX = 60
+  const originY = 610
+
+  const cells: {
+    attachmentPoint: MTextAttachmentPoint
+    title: string
+    subtitle: string
+    col: number
+    row: number
+  }[] = [
+    {
+      attachmentPoint: MTextAttachmentPoint.TopLeft,
+      title: '1 TopLeft',
+      subtitle: 'GC71=1',
+      col: 0,
+      row: 0
+    },
+    {
+      attachmentPoint: MTextAttachmentPoint.TopCenter,
+      title: '2 TopCenter',
+      subtitle: 'GC71=2',
+      col: 1,
+      row: 0
+    },
+    {
+      attachmentPoint: MTextAttachmentPoint.TopRight,
+      title: '3 TopRight',
+      subtitle: 'GC71=3',
+      col: 2,
+      row: 0
+    },
+    {
+      attachmentPoint: MTextAttachmentPoint.MiddleLeft,
+      title: '4 MiddleLeft',
+      subtitle: 'GC71=4',
+      col: 0,
+      row: 1
+    },
+    {
+      attachmentPoint: MTextAttachmentPoint.MiddleCenter,
+      title: '5 MiddleCenter',
+      subtitle: 'GC71=5',
+      col: 1,
+      row: 1
+    },
+    {
+      attachmentPoint: MTextAttachmentPoint.MiddleRight,
+      title: '6 MiddleRight',
+      subtitle: 'GC71=6',
+      col: 2,
+      row: 1
+    },
+    {
+      attachmentPoint: MTextAttachmentPoint.BottomLeft,
+      title: '7 BottomLeft',
+      subtitle: 'GC71=7',
+      col: 0,
+      row: 2
+    },
+    {
+      attachmentPoint: MTextAttachmentPoint.BottomCenter,
+      title: '8 BottomCenter',
+      subtitle: 'GC71=8',
+      col: 1,
+      row: 2
+    },
+    {
+      attachmentPoint: MTextAttachmentPoint.BottomRight,
+      title: '9 BottomRight',
+      subtitle: 'GC71=9',
+      col: 2,
+      row: 2
+    },
+    {
+      attachmentPoint: MTextAttachmentPoint.BaselineLeft,
+      title: '10 BaselineL',
+      subtitle: 'GC71=10',
+      col: 0,
+      row: 3
+    },
+    {
+      attachmentPoint: MTextAttachmentPoint.BaselineCenter,
+      title: '11 BaselineC',
+      subtitle: 'GC71=11',
+      col: 1,
+      row: 3
+    },
+    {
+      attachmentPoint: MTextAttachmentPoint.BaselineRight,
+      title: '12 BaselineR',
+      subtitle: 'GC71=12',
+      col: 2,
+      row: 3
+    }
+  ]
+
+  return cells.map(({ attachmentPoint, title, subtitle, col, row }) => {
+    const cx = originX + col * cellW + cellW / 2
+    const cy = originY - row * cellH - cellH / 2
+    const text = `{\\C1;${title}}\\P{\\C3;${subtitle}}\\P{\\C2;+ anchor}\\P{\\C7;sample}`
+
+    return {
+      mtextData: {
+        text,
+        height: 10,
+        width: 170,
+        position: new THREE.Vector3(cx, cy, 0),
+        attachmentPoint
+      },
+      textStyle: createStandardTextStyle(textFont, 10)
+    }
+  })
+}
+
+/**
+ * Creates ten MText entities arranged in a 3-column grid for batch-render demos.
+ *
+ * @param textFont - Font applied to each entity's {@link TextStyle}.
+ */
+export function createMultipleMTextData(textFont: string): MTextTestCase[] {
+  const texts = [
+    '\\H15.5{\\C1;Title Text 1}\\P{\\C2;Subtitle with different colors}',
+    '\\H15.5{\\C3;Title Text 2}\\P{\\C4;Subtitle with different colors}',
+    '\\H15.5{\\C5;Title Text 3}\\P{\\C6;Subtitle with different colors}',
+    '\\H15.5{\\C7;Title Text 4}\\P{\\C8;Subtitle with different colors}',
+    '\\H15.5{\\C9;Title Text 5}\\P{\\C10;Subtitle with different colors}',
+    '\\H15.5{\\C11;Title Text 6}\\P{\\C12;Subtitle with different colors}',
+    '\\H15.5{\\C13;Title Text 7}\\P{\\C14;Subtitle with different colors}',
+    '\\H15.5{\\C15;Title Text 8}\\P{\\C16;Subtitle with different colors}',
+    '\\H15.5{\\C17;Title Text 9}\\P{\\C18;Subtitle with different colors}',
+    '\\H15.5{\\C19;Title Text 10}\\P{\\C20;Subtitle with different colors}'
+  ]
+
+  return texts.map((text, index) => {
+    const col = index % 3
+    const row = Math.floor(index / 3)
+    const x = 70 + col * 300
+    const y = 530 - row * 120
+
+    return {
+      mtextData: {
+        text,
+        height: 24,
+        width: 240,
+        position: new THREE.Vector3(x, y, 0)
+      },
+      textStyle: createStandardTextStyle(textFont, 24)
+    }
+  })
+}
+
+/**
+ * Utilities for the large WCS coordinate regression example.
+ *
+ * @remarks
+ * Sample geometry is taken from a real DXF entity inserted near
+ * `(38425645.89, 4069531.44)`. Two MText blocks (SHX + mesh) are separated by
+ * {@link LargeCoordinatesExample.TEXT_DELIMITER} in the textarea. The rebase
+ * variant moves insertion to the origin; the no-rebase variant deliberately
+ * preserves survey coordinates to demonstrate float32 precision loss.
+ */
+export class LargeCoordinatesExample {
+  /** Paragraph break sequence separating two editable MText blocks in the textarea. */
+  static readonly TEXT_DELIMITER = '\\P\\P'
+
+  /** Default textarea content when either large-coordinate example button is clicked. */
+  static readonly DEFAULT_TEXT =
+    '{\\Ftxt;SHX (476.473)}\\P\\P{\\Fsimkai;Mesh 大坐标 (476.473)}'
+
+  /**
+   * @param content - Example marker from {@link EXAMPLE_TEXTS} or a render pipeline key.
+   * @returns Whether `content` selects a large-coordinate demo path.
+   */
+  static isExample(content: string): boolean {
+    return (
+      content === 'largeCoordinatesRebase' ||
+      content === 'largeCoordinatesNoRebase'
+    )
+  }
+
+  /**
+   * @param content - Example marker passed to the render pipeline.
+   * @returns `true` only for the rebase-enabled variant.
+   */
+  static shouldRebase(content: string): boolean {
+    return content === 'largeCoordinatesRebase'
+  }
+
+  /**
+   * Splits the textarea into individual MText format strings.
+   *
+   * @param input - Raw textarea value containing one or more blocks.
+   * @returns Non-empty trimmed segments separated by {@link TEXT_DELIMITER}.
+   */
+  static parseTexts(input: string): string[] {
+    return input
+      .split(LargeCoordinatesExample.TEXT_DELIMITER)
+      .map(part => part.trim())
+      .filter(part => part.length > 0)
+  }
+
+  /**
+   * Shared DXF-derived fields except the format `text` (height, width, WCS insert, rotation).
+   */
+  private static createSharedMTextData(): Omit<MTextData, 'text'> {
+    return {
+      height: 4.0222404674496,
+      width: 100,
+      position: new THREE.Vector3(38425645.890718, 4069531.4443921, 0),
+      attachmentPoint: MTextAttachmentPoint.MiddleCenter,
+      drawingDirection: MTextFlowDirection.BY_STYLE,
+      directionVector: new THREE.Vector3(
+        0.9995686730481862,
+        -0.02936780313009985,
+        0
+      ),
+      lineSpaceFactor: 1.0
+    }
+  }
+
+  /**
+   * Builds one {@link MTextTestCase} per parsed textarea segment.
+   *
+   * @param mtextInput - Full textarea contents (may contain {@link TEXT_DELIMITER}).
+   * @param textFont - Base style font; inline `\\F` switches may override per run.
+   */
+  static createTestData(
+    mtextInput: string,
+    textFont: string
+  ): MTextTestCase[] {
+    const texts = LargeCoordinatesExample.parseTexts(mtextInput)
+    const shared = LargeCoordinatesExample.createSharedMTextData()
+    const textStyle = createStandardTextStyle(textFont, shared.height)
+
+    return texts.map(text => ({
+      mtextData: {
+        ...shared,
+        text
+      },
+      textStyle
+    }))
+  }
+
+  /**
+   * Loads fonts referenced by inline `\\F` codes plus the base text font.
+   *
+   * @param unifiedRenderer - Renderer whose font registry receives the load request.
+   * @param texts - Parsed MText format strings from {@link parseTexts}.
+   * @param baseFont - Primary style font always included in the load set.
+   */
+  static async loadFonts(
+    unifiedRenderer: UnifiedRenderer,
+    texts: string[],
+    baseFont: string
+  ): Promise<void> {
+    const fonts = new Set<string>([baseFont])
+    for (const text of texts) {
+      for (const font of MText.getFonts(text, true)) {
+        fonts.add(font)
+      }
+    }
+    await unifiedRenderer.loadFonts([...fonts])
+  }
+
+  /**
+   * Vertically stacks rebased MText objects for side-by-side comparison in the viewport.
+   *
+   * @param mtextObjects - Rendered entities whose positions are rewritten in scene space.
+   *
+   * @remarks
+   * Uses a fixed row gap of 67 drawing units, centered around Y=0 when two blocks are present.
+   */
+  static layoutPair(mtextObjects: MTextObject[]): void {
+    const rowGap = 67
+    const startY = ((mtextObjects.length - 1) * rowGap) / 2
+    mtextObjects.forEach((obj, index) => {
+      obj.position.set(0, startY - index * rowGap, 0)
+      obj.updateMatrixWorld(true)
+    })
+  }
+}
+
+/**
+ * @param font - SHX font file name for SHAPE rendering.
+ * @param size - Nominal shape height.
+ */
+export function createShapeTextStyle(font: string, size: number): TextStyle {
+  return createStandardTextStyle(font, size)
+}
+
+/**
+ * Maps SHAPE panel inputs to a {@link ShapeData} instance at a fixed demo position.
+ *
+ * @param inputs - Parsed numeric and string fields from the example UI.
+ */
+export function buildShapeDataFromInputs(inputs: ShapeInputValues): ShapeData {
+  const shapeData: ShapeData = {
+    size: inputs.size,
+    widthFactor: inputs.widthFactor,
+    position: new THREE.Vector3(120, 420, 0),
+    rotation: (inputs.rotationDeg * Math.PI) / 180
+  }
+
+  if (inputs.shapeName) {
+    shapeData.name = inputs.shapeName
+  }
+  if (Number.isFinite(inputs.shapeNumber) && inputs.shapeNumber > 0) {
+    shapeData.shapeNumber = inputs.shapeNumber
+  }
+
+  return shapeData
+}
+
+/**
+ * Creates five SHAPE test cases (numbers 128–132) from `complex.shx` in a horizontal row.
+ *
+ * @param font - SHX font providing the shape definitions.
+ */
+export function createShapeTestData(font: string): ShapeTestCase[] {
+  const size = 28
+  const shapeNumbers = [128, 129, 130, 131, 132]
+  const originX = 90
+  const originY = 420
+  const gapX = 110
+
+  return shapeNumbers.map((shapeNumber, index) => ({
+    shapeData: {
+      shapeNumber,
+      size,
+      widthFactor: 1,
+      position: new THREE.Vector3(originX + index * gapX, originY, 0)
+    },
+    textStyle: createShapeTextStyle(font, size)
+  }))
+}
+
+/**
+ * Produces a user-facing error when a SHAPE render returns no geometry.
+ *
+ * @param shapeData - Requested shape lookup parameters.
+ * @param font - SHX font that was queried.
+ * @returns Error message, or `null` when inputs are incomplete (handled separately).
+ */
+export function validateShapeInputs(
+  shapeData: ShapeData,
+  font: string
+): string | null {
+  const name = shapeData.name?.trim()
+  const number = shapeData.shapeNumber
+  const hasName = Boolean(name)
+  const hasNumber = number != null && number > 0
+
+  if (!hasName && !hasNumber) {
+    return 'Provide a shape name or shape number'
+  }
+  if (hasName && !hasNumber) {
+    return `Shape name "${name}" not found in ${font}.shx`
+  }
+  if (!hasName && hasNumber) {
+    return `Shape number ${number} not found in ${font}.shx`
+  }
+  return `Shape name "${name}" and number ${number} not found in ${font}.shx`
+}

--- a/packages/example/src/exampleTexts.ts
+++ b/packages/example/src/exampleTexts.ts
@@ -1,0 +1,52 @@
+/**
+ * Built-in MText and SHAPE example content for the interactive demo.
+ *
+ * @remarks
+ * Keys match the `data-example` attribute on buttons in `index.html`.
+ * Most entries are raw MText format strings passed directly to the renderer.
+ * A few entries are **marker tokens** (e.g. `'multiple'`, `'shapes'`) that
+ * trigger specialized multi-entity render paths in {@link MTextRendererExample}.
+ */
+export const EXAMPLE_TEXTS = {
+  /** Basic formatting: colors, control codes, font switches, Unicode escapes. */
+  basic:
+    '\\P{\\C1;Hello World 材料 装车位置}\\P\\P{\\C2;Diameter: %%c50}\\P{\\C3;Temperature: 25%%d}\\P{\\C4;Tolerance: %%p0.1}\\P{\\C6;\\LUnderlined\\l, \\OOverlined\\o, \\KStriked\\k}\\P{\\C7;\\Q15;Oblique 15 deg}\\P{\\C8;\\FArial|b1;Bold Text}\\P{\\C9;\\FArial|i1;Italic Text}\\P{\\C10;\\FArial|b1|i1;Bold Italic Text}\\P{\\C11;Normal height \\H0.16;Absolute font height 0.16}\\PUnicode: \\U+4F60\\U+597D (should display 你好){\\P}',
+  /** Paragraph styles, width factors, and character spacing. */
+  complex:
+    '{\\C1;\\W2;Title}\\P{\\C2;This is a paragraph with different styles.}\\P{\\C3;\\W1.5;Subtitle}\\P{\\C4;• First item\\P• Second item\\P• Third item}\\P{\\T2;Absolute character spacing: 2, }{\\T0.2x;Relative character spacing: 0.2}\\P{\\W0.8;Footer text}',
+  /** AutoCAD percent control codes (`%%c`, `%%d`, toggles, etc.). */
+  controlCode:
+    '{Circle diameter dimensioning symbol: %%c},\\P{Degree symbol: %%d}\\P{Plus/minus tolerance symbol: %%p}\\P{A single percent sign: %%%}\\P{Unicode character: %%130 %%131 \\Ftssdeng;%%1326@600}\\P{Strikethrough toggle (%%k): %%kstruck%%k normal}\\P{Strikethrough explicit: %%konstruck%%koff normal}\\P{Overscore toggle (%%o): %%oover%%o normal}\\P{Overscore explicit: %%oonover%%ooff normal}\\P{Underscore toggle (%%u): %%uunder%%u normal}\\P{Underscore explicit: %%uonunder%%uoff normal}',
+  /** Indexed, true-color, ByLayer/ByBlock color contexts. */
+  color:
+    '{\\C0;By Block}\\P{\\C1;Red Text}\\P{\\C2;Yellow Text}\\P{\\C3;Green Text}\\P{\\C4;Cyan Text}\\P{\\C5;Blue Text}\\P{\\C6;Magenta Text}\\P{\\C7;White Text}\\P{\\C256;By Layer}\\P{\\c16761035;Pink (0x0FFC0CB)}\\PRestore ByLayer\\P\\C1;Old Context Color: Red, {\\C2; New Context Color: Yellow, } Restored Context Color: Red',
+  /** SHX, BigFont, and TrueType font switches with CJK samples. */
+  font: '{\\C1;\\W2;\\FSimSun;SimSun 宋体}\\P{\\F仿宋_gb2312;SimFang 仿宋（面积、材料、8、①④⑧⑩⑫㉔㉚）}\\P{\\C2;\\W0.5;\\FArial;Arial Text}\\P{\\C3;30;\\Faehalf.shx;SHX Text “250~280”}\\P{\\C4;\\Fgbcbig.shx;东亚字符集字体}\\P{\\C5;\\Q1;\\FSimHei;SimHei Text，黑体}\\P{\\C6;\\Q0.5;\\FSimKai;SimKai 楷体}',
+  /** Demonstrates default-font preset fallback chains (text + symbol). */
+  defaultFonts:
+    '{\\C1;Primary \\Ftxt;txt (SHX) — Latin: Hello %%c50}\\P{\\C2;CJK falls back via preset chain: 材料 装车 直径 你好}\\P{\\C3;Symbol %%c %%d %%p — may use gdt in chain}\\P{\\C4;Switch preset above and re-render to compare fallback order}',
+  /** Stacked fractions, subscripts, and superscripts (`\\S` codes). */
+  stacking:
+    '%%c30{\\C3;\\H0.7x;\\S+0.021^  0;}\\P{\\C1;Basic Fractions:}\\P{\\C2;The value is \\S1/2; and \\S3/4; of the total.}\\P{\\C3;\\H0.16;Stacked Fractions:}\\P{\\C4;\\S1 2/3 4; represents \\Sx^ y; in the equation \\S1#2;.}\\P{\\C5;Complex Fractions:}\\P{\\C6;The result \\S1/2/3; is between \\S1^ 2^ 3; and \\S1#2#3;.}\\P{\\C7;Subscript Examples:}\\P{\\C8;H\\S^ 2;O (Water)}\\P{\\C9;CO\\S^ 2; (Carbon Dioxide)}\\P{\\C10;x\\S^ 2; + y\\S^ 2;}\\P{\\C11;Superscript Examples:}\\P{\\C12;E = mc\\S2^ ; (Energy)}\\P{\\C13;x\\S2^ ; + y\\S2^ ; = r\\S2^ ; (Circle)}\\P{\\C14;Combined Examples:}\\P{\\C15;H\\S^ 2;O\\S2^ ; (Hydrogen Peroxide)}\\P{\\C16;Fe\\S^ 2;+\\S3^ ; (Iron Ion)}',
+  /** Paragraph alignment codes (`\\pql`, `\\pqc`, `\\pqr`). */
+  alignment:
+    '{\\pql;Left aligned paragraph.}\\P{\\pqc;Center aligned paragraph.}\\P{\\pqr;Right aligned paragraph.}\\P{\\pqc;Center again.}\\P{\\pql;Back to left.}',
+  /** Paragraph indent and margin control codes. */
+  paragraph:
+    '{\\pql;\\P{\\pqi;\\pxi2;\\pxl5;\\pxr5;This paragraph has an indent of 2 units, left margin of 5 units, and right margin of 5 units. The first line is indented.}\\P{\\pqi;\\pxi2;\\pxl5;\\pxr5;This is the second line of the same paragraph, showing the effect of margins.}}',
+  /** Marker: render ten MText entities in a 3×4 grid (see {@link createMultipleMTextData}). */
+  multiple: 'multiple',
+  /** Marker: render SHX shape numbers 128–132 from `complex.shx` (see {@link createShapeTestData}). */
+  shapes: 'shapes',
+  /** Marker: 3×4 attachment-point grid with insertion crosshairs (see {@link createAttachmentPointTestData}). */
+  attachmentGrid: 'attachmentGrid',
+  /** Marker: large WCS sample with insertion rebase enabled (see {@link LargeCoordinatesExample}). */
+  largeCoordinatesRebase: 'largeCoordinatesRebase',
+  /** Marker: same large WCS sample without rebase — exposes float32 precision issues. */
+  largeCoordinatesNoRebase: 'largeCoordinatesNoRebase'
+} as const
+
+/**
+ * Valid key for {@link EXAMPLE_TEXTS} and example-button `data-example` attributes.
+ */
+export type ExampleTextKey = keyof typeof EXAMPLE_TEXTS

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -1,116 +1,116 @@
 import {
-  CharBox,
-  CharBoxType,
-  DefaultFontsPreset,
-  FontInfo,
-  LineLayout,
-  MTextAttachmentPoint,
   MTextColor,
   MTextData,
   MTextObject,
   RenderMode,
-  ShapeData,
-  TextStyle,
   UnifiedRenderer
 } from '@mlightcad/mtext-renderer'
 import * as THREE from 'three'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 
+import { DebugOverlayManager } from './debugOverlayManager'
+import { ExampleFontManager } from './exampleFontManager'
+import {
+  buildShapeDataFromInputs,
+  createAttachmentPointTestData,
+  createMultipleMTextData,
+  createShapeTestData,
+  createShapeTextStyle,
+  LargeCoordinatesExample,
+  validateShapeInputs
+} from './exampleTestData'
+import { EXAMPLE_TEXTS, type ExampleTextKey } from './exampleTexts'
+import { SceneBoundsHelper } from './sceneBoundsHelper'
+import { SceneViewport } from './sceneViewport'
+import { WcsCoordinateDisplay } from './wcsCoordinateDisplay'
+
+/**
+ * Root controller for the interactive MText renderer example page.
+ *
+ * @remarks
+ * Wires DOM controls to {@link UnifiedRenderer}, delegates viewport and bounds work
+ * to {@link SceneViewport} / {@link SceneBoundsHelper}, and orchestrates MText and
+ * SHAPE render passes. Example-button content comes from {@link EXAMPLE_TEXTS}; specialized
+ * multi-entity scenarios use factories in {@link exampleTestData}.
+ */
 class MTextRendererExample {
-  private scene: THREE.Scene
-  private camera: THREE.OrthographicCamera
-  private renderer: THREE.WebGLRenderer
-  private controls: OrbitControls
-  private unifiedRenderer: UnifiedRenderer
+  /** Three.js viewport (scene, camera, renderer, controls). */
+  private readonly viewport: SceneViewport
+  /** Bounds, rebase, and zoom-to-fit helper. */
+  private readonly boundsHelper: SceneBoundsHelper
+  /** Mouse WCS coordinate HUD. */
+  private readonly wcsDisplay: WcsCoordinateDisplay
+  /** Debug bounding boxes, crosshairs, and layout overlays. */
+  private readonly debugOverlays: DebugOverlayManager
+  /** Font preset, cache, and select UI. */
+  private readonly fontManager: ExampleFontManager
+  /** Main-thread / worker rendering facade. */
+  private readonly unifiedRenderer: UnifiedRenderer
+  /** Currently displayed root object (single MText, group, or SHAPE batch). */
   private currentMText: MTextObject | null = null
-  private mtextBox: THREE.LineSegments | null = null
-  private charBoxOverlays: THREE.Object3D[] = []
-  private lineBoxOverlays: THREE.Object3D[] = []
+  /**
+   * When set, {@link renderCurrentContent} routes through large-coordinate test data
+   * even if the user clicks Render without re-selecting the example button.
+   */
+  private largeCoordinatesExampleKey: string | null = null
 
-  // DOM elements
-  private mtextInput: HTMLTextAreaElement
-  private renderBtn: HTMLButtonElement
-  private statusDiv: HTMLDivElement
-  private fontSelect: HTMLSelectElement
-  private defaultFontsPresetSelect: HTMLSelectElement
-  private contentTypeSelect: HTMLSelectElement
-  private mtextPanel: HTMLDivElement
-  private shapePanel: HTMLDivElement
-  private shapeFontSelect: HTMLSelectElement
-  private shapeNameInput: HTMLInputElement
-  private shapeNumberInput: HTMLInputElement
-  private shapeSizeInput: HTMLInputElement
-  private shapeWidthFactorInput: HTMLInputElement
-  private shapeRotationInput: HTMLInputElement
-  private showBoundingBoxCheckbox: HTMLInputElement
-  private showCharBoxesCheckbox: HTMLInputElement
-  private showLineBoxesCheckbox: HTMLInputElement
-  private renderModeSelect: HTMLSelectElement
-  private byLayerColorInput: HTMLInputElement
-  private byBlockColorInput: HTMLInputElement
-  private fontCacheInput: HTMLInputElement
-  private fontCacheBtn: HTMLButtonElement
+  /** `#mtext-input` — editable MText format string for manual renders. */
+  private readonly mtextInput: HTMLTextAreaElement
+  /** `#render-btn` — triggers {@link renderCurrentContent}. */
+  private readonly renderBtn: HTMLButtonElement
+  /** `#status` — timing, preset, and error messages. */
+  private readonly statusDiv: HTMLDivElement
+  /** `#content-type` — switches between MText and SHAPE modes. */
+  private readonly contentTypeSelect: HTMLSelectElement
+  /** `#mtext-panel` — MText-specific controls container. */
+  private readonly mtextPanel: HTMLDivElement
+  /** `#shape-panel` — SHAPE-specific controls container. */
+  private readonly shapePanel: HTMLDivElement
+  /** `#shape-name` — optional SHX shape name lookup. */
+  private readonly shapeNameInput: HTMLInputElement
+  /** `#shape-number` — optional SHX shape number lookup. */
+  private readonly shapeNumberInput: HTMLInputElement
+  /** `#shape-size` — nominal SHAPE height. */
+  private readonly shapeSizeInput: HTMLInputElement
+  /** `#shape-width-factor` — horizontal width factor for SHAPE. */
+  private readonly shapeWidthFactorInput: HTMLInputElement
+  /** `#shape-rotation` — rotation in degrees for SHAPE. */
+  private readonly shapeRotationInput: HTMLInputElement
+  /** `#shape-font-select` — SHX font used for SHAPE rendering. */
+  private readonly shapeFontSelect: HTMLSelectElement
+  /** `#show-bounding-box` — toggles green logical/geometry bounds overlay. */
+  private readonly showBoundingBoxCheckbox: HTMLInputElement
+  /** `#show-char-boxes` — toggles per-character layout boxes. */
+  private readonly showCharBoxesCheckbox: HTMLInputElement
+  /** `#show-line-boxes` — toggles per-line strip boxes. */
+  private readonly showLineBoxesCheckbox: HTMLInputElement
+  /** `#render-mode` — main thread vs Web Worker rendering. */
+  private readonly renderModeSelect: HTMLSelectElement
+  /** `#by-layer-color` — RGB hex for ByLayer (256) color resolution. */
+  private readonly byLayerColorInput: HTMLInputElement
+  /** `#by-block-color` — RGB hex for ByBlock (0) color resolution. */
+  private readonly byBlockColorInput: HTMLInputElement
+  /** `#font-cache-input` — local font file picker for IndexedDB caching. */
+  private readonly fontCacheInput: HTMLInputElement
+  /** `#font-cache-btn` — submits {@link ExampleFontManager.cacheSelectedFontFile}. */
+  private readonly fontCacheBtn: HTMLButtonElement
+  /** `#font-select` — primary text-style font. */
+  private readonly fontSelect: HTMLSelectElement
+  /** `#default-fonts-preset` — CJK / symbol fallback chain preset. */
+  private readonly defaultFontsPresetSelect: HTMLSelectElement
+  /** DXF layer name passed in {@link getColorSettings} for ByLayer color resolution. */
   private readonly defaultLayerName = '0'
-  private readonly supportedFontExtensions = new Set([
-    '.shx',
-    '.ttf',
-    '.otf',
-    '.woff'
-  ])
 
-  // Example texts
-  private readonly exampleTexts = {
-    basic:
-      '\\P{\\C1;Hello World 材料 装车位置}\\P\\P{\\C2;Diameter: %%c50}\\P{\\C3;Temperature: 25%%d}\\P{\\C4;Tolerance: %%p0.1}\\P{\\C6;\\LUnderlined\\l, \\OOverlined\\o, \\KStriked\\k}\\P{\\C7;\\Q15;Oblique 15 deg}\\P{\\C8;\\FArial|b1;Bold Text}\\P{\\C9;\\FArial|i1;Italic Text}\\P{\\C10;\\FArial|b1|i1;Bold Italic Text}\\P{\\C11;Normal height \\H0.16;Absolute font height 0.16}\\PUnicode: \\U+4F60\\U+597D (should display 你好){\\P}',
-    complex:
-      '{\\C1;\\W2;Title}\\P{\\C2;This is a paragraph with different styles.}\\P{\\C3;\\W1.5;Subtitle}\\P{\\C4;• First item\\P• Second item\\P• Third item}\\P{\\T2;Absolute character spacing: 2, }{\\T0.2x;Relative character spacing: 0.2}\\P{\\W0.8;Footer text}',
-    controlCode:
-      '{Circle diameter dimensioning symbol: %%c},\\P{Degree symbol: %%d}\\P{Plus/minus tolerance symbol: %%p}\\P{A single percent sign: %%%}\\P{Unicode character: %%130 %%131 \\Ftssdeng;%%1326@600}\\P{Strikethrough toggle (%%k): %%kstruck%%k normal}\\P{Strikethrough explicit: %%konstruck%%koff normal}\\P{Overscore toggle (%%o): %%oover%%o normal}\\P{Overscore explicit: %%oonover%%ooff normal}\\P{Underscore toggle (%%u): %%uunder%%u normal}\\P{Underscore explicit: %%uonunder%%uoff normal}',
-    color:
-      '{\\C0;By Block}\\P{\\C1;Red Text}\\P{\\C2;Yellow Text}\\P{\\C3;Green Text}\\P{\\C4;Cyan Text}\\P{\\C5;Blue Text}\\P{\\C6;Magenta Text}\\P{\\C7;White Text}\\P{\\C256;By Layer}\\P{\\c16761035;Pink (0x0FFC0CB)}\\PRestore ByLayer\\P\\C1;Old Context Color: Red, {\\C2; New Context Color: Yellow, } Restored Context Color: Red',
-    font: '{\\C1;\\W2;\\FSimSun;SimSun 宋体}\\P{\\F仿宋_gb2312;SimFang 仿宋（面积、材料、8、①④⑧⑩⑫㉔㉚）}\\P{\\C2;\\W0.5;\\FArial;Arial Text}\\P{\\C3;30;\\Faehalf.shx;SHX Text “250~280”}\\P{\\C4;\\Fgbcbig.shx;东亚字符集字体}\\P{\\C5;\\Q1;\\FSimHei;SimHei Text，黑体}\\P{\\C6;\\Q0.5;\\FSimKai;SimKai 楷体}',
-    defaultFonts:
-      '{\\C1;Primary \\Ftxt;txt (SHX) — Latin: Hello %%c50}\\P{\\C2;CJK falls back via preset chain: 材料 装车 直径 你好}\\P{\\C3;Symbol %%c %%d %%p — may use gdt in chain}\\P{\\C4;Switch preset above and re-render to compare fallback order}',
-    stacking:
-      '%%c30{\\C3;\\H0.7x;\\S+0.021^  0;}\\P{\\C1;Basic Fractions:}\\P{\\C2;The value is \\S1/2; and \\S3/4; of the total.}\\P{\\C3;\\H0.16;Stacked Fractions:}\\P{\\C4;\\S1 2/3 4; represents \\Sx^ y; in the equation \\S1#2;.}\\P{\\C5;Complex Fractions:}\\P{\\C6;The result \\S1/2/3; is between \\S1^ 2^ 3; and \\S1#2#3;.}\\P{\\C7;Subscript Examples:}\\P{\\C8;H\\S^ 2;O (Water)}\\P{\\C9;CO\\S^ 2; (Carbon Dioxide)}\\P{\\C10;x\\S^ 2; + y\\S^ 2;}\\P{\\C11;Superscript Examples:}\\P{\\C12;E = mc\\S2^ ; (Energy)}\\P{\\C13;x\\S2^ ; + y\\S2^ ; = r\\S2^ ; (Circle)}\\P{\\C14;Combined Examples:}\\P{\\C15;H\\S^ 2;O\\S2^ ; (Hydrogen Peroxide)}\\P{\\C16;Fe\\S^ 2;+\\S3^ ; (Iron Ion)}',
-    alignment:
-      '{\\pql;Left aligned paragraph.}\\P{\\pqc;Center aligned paragraph.}\\P{\\pqr;Right aligned paragraph.}\\P{\\pqc;Center again.}\\P{\\pql;Back to left.}',
-    paragraph:
-      '{\\pql;\\P{\\pqi;\\pxi2;\\pxl5;\\pxr5;This paragraph has an indent of 2 units, left margin of 5 units, and right margin of 5 units. The first line is indented.}\\P{\\pqi;\\pxi2;\\pxl5;\\pxr5;This is the second line of the same paragraph, showing the effect of margins.}}',
-    multiple: 'multiple', // Special marker for multiple MText rendering
-    /** Grid of SHX shape glyphs from complex.shx (shape numbers 128–132). */
-    shapes: 'shapes',
-    /** DXF group 71 attachment points 1–12; renders a grid with insertion crosshairs */
-    attachmentGrid: 'attachmentGrid'
-  }
-
+  /** Bootstraps viewport, helpers, DOM bindings, fonts, and the initial render. */
   constructor() {
-    // Initialize Three.js components
-    this.scene = new THREE.Scene()
-    this.scene.background = new THREE.Color(0x333333)
-
-    // Use orthographic camera for 2D rendering
     const renderArea = document.getElementById('render-area') as HTMLElement
+    this.viewport = new SceneViewport(renderArea)
+    this.boundsHelper = new SceneBoundsHelper(
+      this.viewport.camera,
+      this.viewport.controls,
+      () => this.viewport.getSize()
+    )
+    this.debugOverlays = new DebugOverlayManager(this.boundsHelper)
 
-    const width = renderArea.clientWidth
-    const height = renderArea.clientHeight
-    this.camera = new THREE.OrthographicCamera(0, width, height, 0, -1000, 1000)
-    this.camera.position.set(0, 0, 100)
-    this.camera.lookAt(new THREE.Vector3(0, 0, 0))
-
-    this.renderer = new THREE.WebGLRenderer({ antialias: true })
-    this.renderer.setPixelRatio(window.devicePixelRatio)
-    this.renderer.setSize(width, height, false)
-    renderArea.appendChild(this.renderer.domElement)
-
-    // Add orbit controls
-    this.controls = new OrbitControls(this.camera, this.renderer.domElement)
-    this.controls.enableRotate = false
-    this.controls.screenSpacePanning = true
-    this.controls.minZoom = 0.3
-    this.controls.maxZoom = 5
-
-    // Initialize unified renderer (default to main thread)
     this.unifiedRenderer = new UnifiedRenderer('main', {
       workerUrl: new URL(
         '../../mtext-renderer/src/worker/mtextWorker.ts',
@@ -118,18 +118,11 @@ class MTextRendererExample {
       )
     })
 
-    // Get DOM elements
     this.mtextInput = document.getElementById(
       'mtext-input'
     ) as HTMLTextAreaElement
     this.renderBtn = document.getElementById('render-btn') as HTMLButtonElement
     this.statusDiv = document.getElementById('status') as HTMLDivElement
-    this.fontSelect = document.getElementById(
-      'font-select'
-    ) as HTMLSelectElement
-    this.defaultFontsPresetSelect = document.getElementById(
-      'default-fonts-preset'
-    ) as HTMLSelectElement
     this.contentTypeSelect = document.getElementById(
       'content-type'
     ) as HTMLSelectElement
@@ -178,16 +171,34 @@ class MTextRendererExample {
       'font-cache-btn'
     ) as HTMLButtonElement
 
-    // Add lights
-    this.setupLights()
+    this.fontSelect = document.getElementById(
+      'font-select'
+    ) as HTMLSelectElement
+    this.defaultFontsPresetSelect = document.getElementById(
+      'default-fonts-preset'
+    ) as HTMLSelectElement
+    this.fontManager = new ExampleFontManager(
+      this.unifiedRenderer,
+      this.statusDiv,
+      this.fontSelect,
+      this.shapeFontSelect,
+      this.defaultFontsPresetSelect,
+      this.fontCacheInput,
+      this.fontCacheBtn
+    )
 
-    // Setup event listeners
+    const wcsCoordsDiv = document.getElementById('wcs-coords') as HTMLDivElement
+    this.wcsDisplay = new WcsCoordinateDisplay(
+      wcsCoordsDiv,
+      this.viewport,
+      this.boundsHelper
+    )
+    this.wcsDisplay.bind(this.viewport.renderer.domElement)
+
     this.setupEventListeners()
-
-    // Initialize fonts and UI, then render
-    this.initializeFonts(true)
+    this.fontManager
+      .initialize(true)
       .then(() => {
-        // Initial render after fonts are loaded
         void this.renderCurrentContent()
       })
       .catch(error => {
@@ -196,36 +207,20 @@ class MTextRendererExample {
         this.statusDiv.style.color = '#f00'
       })
 
-    // Start animation loop
-    this.animate()
+    this.viewport.startAnimationLoop()
   }
 
-  private setupLights(): void {
-    const ambientLight = new THREE.AmbientLight(0xffffff, 0.5)
-    this.scene.add(ambientLight)
-
-    const directionalLight = new THREE.DirectionalLight(0xffffff, 0.5)
-    directionalLight.position.set(1, 1, 1)
-    this.scene.add(directionalLight)
+  /** Releases worker threads and renderer resources on page unload. */
+  public destroy(): void {
+    this.unifiedRenderer.destroy()
   }
 
+  /** Registers all UI event handlers for controls, examples, and window resize. */
   private setupEventListeners(): void {
-    // Window resize
     window.addEventListener('resize', () => {
-      const renderArea = document.getElementById('render-area')
-      if (!renderArea) return
-
-      const width = renderArea.clientWidth
-      const height = renderArea.clientHeight
-      this.camera.left = 0
-      this.camera.right = width
-      this.camera.top = height
-      this.camera.bottom = 0
-      this.camera.updateProjectionMatrix()
-      this.renderer.setSize(width, height, false)
+      this.viewport.resize(() => this.fitView())
     })
 
-    // Render button
     this.renderBtn.addEventListener('click', async () => {
       await this.renderCurrentContent()
     })
@@ -251,76 +246,81 @@ class MTextRendererExample {
       })
     })
 
-    // Text style font selection
     this.fontSelect.addEventListener('change', async () => {
-      await this.applyDefaultFontsPreset()
+      await this.fontManager.applyDefaultFontsPreset()
       await this.renderCurrentContent()
     })
 
-    // Default fonts preset (fallback chain)
     this.defaultFontsPresetSelect.addEventListener('change', async () => {
-      await this.applyDefaultFontsPreset()
+      await this.fontManager.applyDefaultFontsPreset()
       await this.renderCurrentContent()
     })
 
-    // Example buttons
     document.querySelectorAll('.example-btn').forEach(button => {
       button.addEventListener('click', async () => {
-        const exampleType = (button as HTMLElement).dataset.example
-        if (
-          exampleType &&
-          this.exampleTexts[exampleType as keyof typeof this.exampleTexts]
-        ) {
-          const content =
-            this.exampleTexts[exampleType as keyof typeof this.exampleTexts]
+        const exampleType = (button as HTMLElement).dataset
+          .example as ExampleTextKey | undefined
+        if (!exampleType || !(exampleType in EXAMPLE_TEXTS)) {
+          return
+        }
 
-          if (content === 'shapes') {
-            this.contentTypeSelect.value = 'shape'
-            this.updateContentPanels()
-            await this.renderCurrentContent('shapes')
-          } else if (content === 'multiple' || content === 'attachmentGrid') {
-            this.contentTypeSelect.value = 'mtext'
-            this.updateContentPanels()
-            await this.renderCurrentContent(content)
+        const content = EXAMPLE_TEXTS[exampleType]
+
+        if (content === 'shapes') {
+          this.contentTypeSelect.value = 'shape'
+          this.updateContentPanels()
+          await this.renderCurrentContent('shapes')
+        } else if (
+          content === 'multiple' ||
+          content === 'attachmentGrid' ||
+          LargeCoordinatesExample.isExample(content)
+        ) {
+          this.contentTypeSelect.value = 'mtext'
+          this.updateContentPanels()
+          if (LargeCoordinatesExample.isExample(content)) {
+            this.mtextInput.value = LargeCoordinatesExample.DEFAULT_TEXT
+            this.largeCoordinatesExampleKey = content
           } else {
-            this.contentTypeSelect.value = 'mtext'
-            this.updateContentPanels()
-            this.mtextInput.value = content
-            await this.renderCurrentContent(content)
+            this.largeCoordinatesExampleKey = null
           }
+          await this.renderCurrentContent(content)
+        } else {
+          this.contentTypeSelect.value = 'mtext'
+          this.updateContentPanels()
+          this.largeCoordinatesExampleKey = null
+          this.mtextInput.value = content
+          await this.renderCurrentContent(content)
         }
       })
     })
 
-    // Bounding box toggle
     this.showBoundingBoxCheckbox.addEventListener('change', () => {
-      if (this.mtextBox) {
-        this.mtextBox.visible = this.showBoundingBoxCheckbox.checked
-      }
+      this.debugOverlays.setBoundingBoxVisible(
+        this.showBoundingBoxCheckbox.checked
+      )
     })
 
     this.showCharBoxesCheckbox.addEventListener('change', () => {
-      this.setCharBoxOverlayVisibility(this.showCharBoxesCheckbox.checked)
-    })
-    this.showLineBoxesCheckbox.addEventListener('change', () => {
-      this.setLineBoxOverlayVisibility(this.showLineBoxesCheckbox.checked)
+      this.debugOverlays.setCharBoxOverlayVisibility(
+        this.showCharBoxesCheckbox.checked
+      )
     })
 
-    // Render mode toggle
+    this.showLineBoxesCheckbox.addEventListener('change', () => {
+      this.debugOverlays.setLineBoxOverlayVisibility(
+        this.showLineBoxesCheckbox.checked
+      )
+    })
+
     this.renderModeSelect.addEventListener('change', async () => {
       const mode = this.renderModeSelect.value as RenderMode
       this.unifiedRenderer.setDefaultMode(mode)
       this.statusDiv.textContent = `Switched to ${mode} thread rendering`
       this.statusDiv.style.color = '#0f0'
-
-      // Call this function to guarantee default font is loaded
-      await this.initializeFonts(false)
-
-      // Re-render with current content to reflect the new mode
+      await this.fontManager.initialize(false)
       await this.renderCurrentContent()
     })
 
-    // Color settings
     this.byLayerColorInput.addEventListener('change', async () => {
       await this.renderCurrentContent()
     })
@@ -329,15 +329,17 @@ class MTextRendererExample {
     })
 
     this.fontCacheBtn.addEventListener('click', async () => {
-      await this.cacheSelectedFontFile()
+      await this.fontManager.cacheSelectedFontFile(() =>
+        this.renderCurrentContent()
+      )
     })
     this.fontCacheInput.addEventListener('change', () => {
-      const file = this.fontCacheInput.files?.[0]
-      this.fontCacheBtn.disabled = !file
+      this.fontManager.updateCacheButtonState()
     })
-    this.fontCacheBtn.disabled = !this.fontCacheInput.files?.[0]
+    this.fontManager.updateCacheButtonState()
   }
 
+  /** Toggles MText vs SHAPE panel visibility and related control enabled state. */
   private updateContentPanels(): void {
     const isShape = this.contentTypeSelect.value === 'shape'
     this.mtextPanel.classList.toggle('hidden', isShape)
@@ -347,665 +349,42 @@ class MTextRendererExample {
     this.showLineBoxesCheckbox.disabled = isShape
   }
 
+  /**
+   * Renders the active content type using optional explicit example content.
+   *
+   * @param content - Example marker or MText string; defaults to textarea or large-coordinate key.
+   */
   private async renderCurrentContent(content?: string): Promise<void> {
     if (this.contentTypeSelect.value === 'shape') {
       await this.renderShape(content)
       return
     }
-    await this.renderMText(content ?? this.mtextInput.value)
-  }
-
-  private getSelectedDefaultFontsPreset(): DefaultFontsPreset {
-    return this.defaultFontsPresetSelect.value as DefaultFontsPreset
-  }
-
-  private async applyDefaultFontsPreset(): Promise<void> {
-    const preset = this.getSelectedDefaultFontsPreset()
-    await this.unifiedRenderer.setDefaultFonts(preset)
-    const textChain = this.unifiedRenderer.getDefaultFontsPreset(preset)
-    const symbolChain = this.unifiedRenderer.getSymbolFontsPreset(preset)
-    const fontsToLoad = [
-      ...new Set([
-        ...textChain,
-        ...symbolChain,
-        this.fontSelect.value,
-        this.shapeFontSelect.value
-      ])
-    ]
-    await this.unifiedRenderer.loadFonts(fontsToLoad)
-    this.statusDiv.textContent = `Preset "${preset}": text ${textChain.join(' → ')} | symbol ${symbolChain.join(' → ')}`
-    this.statusDiv.style.color = '#0f0'
-  }
-
-  private getFontExtension(fileName: string): string {
-    const dotIndex = fileName.lastIndexOf('.')
-    if (dotIndex < 0) {
-      return ''
-    }
-    return fileName.slice(dotIndex).toLowerCase()
-  }
-
-  private isSupportedFontFile(file: File): boolean {
-    return this.supportedFontExtensions.has(this.getFontExtension(file.name))
-  }
-
-  private formatFontLabel(font: FontInfo): string {
-    const label = font.name[0]
-    return font.source === 'cache' ? `${label} [cached]` : label
-  }
-
-  private populateFontSelects(
-    fonts: FontInfo[],
-    selectedTextFont?: string,
-    selectedShapeFont?: string
-  ): void {
-    const previousTextFont = selectedTextFont ?? this.fontSelect.value
-    const previousShapeFont = selectedShapeFont ?? this.shapeFontSelect.value
-
-    this.fontSelect.innerHTML = ''
-    this.shapeFontSelect.innerHTML = ''
-
-    let textFontMatched = false
-    let shapeFontMatched = false
-
-    const matchesSelection = (
-      font: FontInfo,
-      selectedName: string
-    ): boolean =>
-      font.name.some(
-        name => name.toLowerCase() === selectedName.toLowerCase()
-      )
-
-    fonts.forEach(font => {
-      const option = document.createElement('option')
-      option.value = font.name[0]
-      option.textContent = this.formatFontLabel(font)
-      if (matchesSelection(font, previousTextFont)) {
-        option.selected = true
-        textFontMatched = true
-      } else if (!textFontMatched && font.name[0] === 'simkai') {
-        option.selected = true
-        textFontMatched = true
-      }
-      this.fontSelect.appendChild(option)
-
-      if (font.type === 'shx' || font.file.toLowerCase().endsWith('.shx')) {
-        const shapeOption = document.createElement('option')
-        shapeOption.value = font.name[0]
-        shapeOption.textContent = this.formatFontLabel(font)
-        if (matchesSelection(font, previousShapeFont)) {
-          shapeOption.selected = true
-          shapeFontMatched = true
-        } else if (!shapeFontMatched && font.name[0] === 'complex') {
-          shapeOption.selected = true
-          shapeFontMatched = true
-        }
-        this.shapeFontSelect.appendChild(shapeOption)
-      }
-    })
-  }
-
-  private async refreshAvailableFonts(
-    selectedTextFont?: string,
-    selectedShapeFont?: string
-  ): Promise<FontInfo[]> {
-    const result = await this.unifiedRenderer.getAvailableFonts()
-    const fonts = result.fonts as FontInfo[]
-    this.populateFontSelects(fonts, selectedTextFont, selectedShapeFont)
-    return fonts
-  }
-
-  private async cacheSelectedFontFile(): Promise<void> {
-    const file = this.fontCacheInput.files?.[0]
-    if (!file) {
-      this.statusDiv.textContent = 'Select a font file to cache'
-      this.statusDiv.style.color = '#f00'
-      return
-    }
-
-    if (!this.isSupportedFontFile(file)) {
-      this.statusDiv.textContent =
-        'Unsupported font type. Use .shx, .ttf, .otf, or .woff'
-      this.statusDiv.style.color = '#f00'
-      return
-    }
-
-    try {
-      this.statusDiv.textContent = `Caching ${file.name}...`
-      this.statusDiv.style.color = '#ffa500'
-      this.fontCacheBtn.disabled = true
-
-      const status = await this.unifiedRenderer.cacheFont(file)
-      if (status.status !== 'Success') {
-        this.statusDiv.textContent = `Failed to cache ${file.name}`
-        this.statusDiv.style.color = '#f00'
-        return
-      }
-
-      await this.refreshAvailableFonts(status.fontName, status.fontName)
-
-      await this.applyDefaultFontsPreset()
-      await this.renderCurrentContent()
-
-      this.statusDiv.textContent = `Cached and loaded ${file.name} (${status.fontName})`
-      this.statusDiv.style.color = '#0f0'
-      this.fontCacheInput.value = ''
-    } catch (error) {
-      console.error('Error caching font:', error)
-      this.statusDiv.textContent = 'Error caching font'
-      this.statusDiv.style.color = '#f00'
-    } finally {
-      this.fontCacheBtn.disabled = !this.fontCacheInput.files?.[0]
-    }
-  }
-
-  private async initializeFonts(isResetAvaiableFonts = true): Promise<void> {
-    try {
-      if (isResetAvaiableFonts) {
-        await this.refreshAvailableFonts()
-      }
-
-      await this.applyDefaultFontsPreset()
-    } catch (error) {
-      console.error('Error loading fonts:', error)
-      this.statusDiv.textContent = 'Error loading fonts'
-      this.statusDiv.style.color = '#f00'
-      throw error // Re-throw to handle in the constructor
-    }
-  }
-
-  /**
-   * Draws a bounding box from the renderer-computed MText extents.
-   */
-  private createMTextBox(box: THREE.Box3): THREE.LineSegments {
-    const minX = box.min.x
-    const maxX = box.max.x
-    const minY = box.min.y
-    const maxY = box.max.y
-    const minZ = box.min.z
-    const maxZ = box.max.z
-
-    const vertices = [
-      // Bottom face
-      minX,
-      minY,
-      minZ,
-      maxX,
-      minY,
-      minZ,
-      maxX,
-      minY,
-      minZ,
-      maxX,
-      maxY,
-      minZ,
-      maxX,
-      maxY,
-      minZ,
-      minX,
-      maxY,
-      minZ,
-      minX,
-      maxY,
-      minZ,
-      minX,
-      minY,
-      minZ,
-      // Top face
-      minX,
-      minY,
-      maxZ,
-      maxX,
-      minY,
-      maxZ,
-      maxX,
-      minY,
-      maxZ,
-      maxX,
-      maxY,
-      maxZ,
-      maxX,
-      maxY,
-      maxZ,
-      minX,
-      maxY,
-      maxZ,
-      minX,
-      maxY,
-      maxZ,
-      minX,
-      minY,
-      maxZ,
-      // Sides
-      minX,
-      minY,
-      minZ,
-      minX,
-      minY,
-      maxZ,
-      maxX,
-      minY,
-      minZ,
-      maxX,
-      minY,
-      maxZ,
-      maxX,
-      maxY,
-      minZ,
-      maxX,
-      maxY,
-      maxZ,
-      minX,
-      maxY,
-      minZ,
-      minX,
-      maxY,
-      maxZ
-    ]
-
-    const geometry = new THREE.BufferGeometry()
-    geometry.setAttribute(
-      'position',
-      new THREE.Float32BufferAttribute(vertices, 3)
+    await this.renderMText(
+      content ?? (this.largeCoordinatesExampleKey ?? this.mtextInput.value)
     )
-    const material = new THREE.LineBasicMaterial({
-      color: 0x00ff00,
-      linewidth: 1
-    })
-    this.mtextBox = new THREE.LineSegments(geometry, material)
-    return this.mtextBox
   }
 
-  /**
-   * Small cross at the insertion point (DXF alignment anchor) for visual checks.
-   */
-  private createInsertionCrosshair(
-    x: number,
-    y: number,
-    arm = 22,
-    z = 0.03
-  ): THREE.LineSegments {
-    const vertices = new Float32Array([
-      x - arm,
-      y,
-      z,
-      x + arm,
-      y,
-      z,
-      x,
-      y - arm,
-      z,
-      x,
-      y + arm,
-      z
-    ])
-    const geometry = new THREE.BufferGeometry()
-    geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3))
-    const material = new THREE.LineBasicMaterial({
-      color: 0xff3333,
-      depthTest: false,
-      transparent: true,
-      opacity: 0.95
-    })
-    const lines = new THREE.LineSegments(geometry, material)
-    lines.renderOrder = 1000
-    return lines
-  }
-
-  /**
-   * Twelve MText samples on a 3×4 grid (DXF attachment 1–9 then 10–12).
-   * Each entity shares the same insertion coordinates as the red crosshair;
-   * only {@link MTextData.attachmentPoint} changes so you can compare layout.
-   */
-  private createAttachmentPointTestData(): {
-    mtextData: MTextData
-    textStyle: TextStyle
-  }[] {
-    const cellW = 330
-    const cellH = 175
-    const originX = 60
-    const originY = 610
-
-    const cells: {
-      attachmentPoint: MTextAttachmentPoint
-      title: string
-      subtitle: string
-      col: number
-      row: number
-    }[] = [
-      {
-        attachmentPoint: MTextAttachmentPoint.TopLeft,
-        title: '1 TopLeft',
-        subtitle: 'GC71=1',
-        col: 0,
-        row: 0
-      },
-      {
-        attachmentPoint: MTextAttachmentPoint.TopCenter,
-        title: '2 TopCenter',
-        subtitle: 'GC71=2',
-        col: 1,
-        row: 0
-      },
-      {
-        attachmentPoint: MTextAttachmentPoint.TopRight,
-        title: '3 TopRight',
-        subtitle: 'GC71=3',
-        col: 2,
-        row: 0
-      },
-      {
-        attachmentPoint: MTextAttachmentPoint.MiddleLeft,
-        title: '4 MiddleLeft',
-        subtitle: 'GC71=4',
-        col: 0,
-        row: 1
-      },
-      {
-        attachmentPoint: MTextAttachmentPoint.MiddleCenter,
-        title: '5 MiddleCenter',
-        subtitle: 'GC71=5',
-        col: 1,
-        row: 1
-      },
-      {
-        attachmentPoint: MTextAttachmentPoint.MiddleRight,
-        title: '6 MiddleRight',
-        subtitle: 'GC71=6',
-        col: 2,
-        row: 1
-      },
-      {
-        attachmentPoint: MTextAttachmentPoint.BottomLeft,
-        title: '7 BottomLeft',
-        subtitle: 'GC71=7',
-        col: 0,
-        row: 2
-      },
-      {
-        attachmentPoint: MTextAttachmentPoint.BottomCenter,
-        title: '8 BottomCenter',
-        subtitle: 'GC71=8',
-        col: 1,
-        row: 2
-      },
-      {
-        attachmentPoint: MTextAttachmentPoint.BottomRight,
-        title: '9 BottomRight',
-        subtitle: 'GC71=9',
-        col: 2,
-        row: 2
-      },
-      {
-        attachmentPoint: MTextAttachmentPoint.BaselineLeft,
-        title: '10 BaselineL',
-        subtitle: 'GC71=10',
-        col: 0,
-        row: 3
-      },
-      {
-        attachmentPoint: MTextAttachmentPoint.BaselineCenter,
-        title: '11 BaselineC',
-        subtitle: 'GC71=11',
-        col: 1,
-        row: 3
-      },
-      {
-        attachmentPoint: MTextAttachmentPoint.BaselineRight,
-        title: '12 BaselineR',
-        subtitle: 'GC71=12',
-        col: 2,
-        row: 3
-      }
-    ]
-
-    return cells.map(({ attachmentPoint, title, subtitle, col, row }) => {
-      const cx = originX + col * cellW + cellW / 2
-      const cy = originY - row * cellH - cellH / 2
-      const text = `{\\C1;${title}}\\P{\\C3;${subtitle}}\\P{\\C2;+ anchor}\\P{\\C7;sample}`
-
-      return {
-        mtextData: {
-          text,
-          height: 10,
-          width: 170,
-          position: new THREE.Vector3(cx, cy, 0),
-          attachmentPoint
-        },
-        textStyle: {
-          name: 'Standard',
-          standardFlag: 0,
-          fixedTextHeight: 10,
-          widthFactor: 1,
-          obliqueAngle: 0,
-          textGenerationFlag: 0,
-          lastHeight: 10,
-          font: this.fontSelect.value,
-          bigFont: ''
-        }
-      }
-    })
-  }
-
-  private createMultipleMTextData(): {
-    mtextData: MTextData
-    textStyle: TextStyle
-  }[] {
-    const texts = [
-      '\\H15.5{\\C1;Title Text 1}\\P{\\C2;Subtitle with different colors}',
-      '\\H15.5{\\C3;Title Text 2}\\P{\\C4;Subtitle with different colors}',
-      '\\H15.5{\\C5;Title Text 3}\\P{\\C6;Subtitle with different colors}',
-      '\\H15.5{\\C7;Title Text 4}\\P{\\C8;Subtitle with different colors}',
-      '\\H15.5{\\C9;Title Text 5}\\P{\\C10;Subtitle with different colors}',
-      '\\H15.5{\\C11;Title Text 6}\\P{\\C12;Subtitle with different colors}',
-      '\\H15.5{\\C13;Title Text 7}\\P{\\C14;Subtitle with different colors}',
-      '\\H15.5{\\C15;Title Text 8}\\P{\\C16;Subtitle with different colors}',
-      '\\H15.5{\\C17;Title Text 9}\\P{\\C18;Subtitle with different colors}',
-      '\\H15.5{\\C19;Title Text 10}\\P{\\C20;Subtitle with different colors}'
-    ]
-
-    return texts.map((text, index) => {
-      const col = index % 3
-      const row = Math.floor(index / 3)
-      const x = 70 + col * 300
-      const y = 530 - row * 120
-
-      return {
-        mtextData: {
-          text,
-          height: 24,
-          width: 240,
-          position: new THREE.Vector3(x, y, 0)
-        },
-        textStyle: {
-          name: 'Standard',
-          standardFlag: 0,
-          fixedTextHeight: 24,
-          widthFactor: 1,
-          obliqueAngle: 0,
-          textGenerationFlag: 0,
-          lastHeight: 24,
-          font: this.fontSelect.value,
-          bigFont: ''
-        }
-      }
-    })
-  }
-
-  private setCharBoxOverlayVisibility(visible: boolean): void {
-    this.charBoxOverlays.forEach(overlay => {
-      overlay.visible = visible
-    })
-  }
-
-  private setLineBoxOverlayVisibility(visible: boolean): void {
-    this.lineBoxOverlays.forEach(overlay => {
-      overlay.visible = visible
-    })
-  }
-
-  private flattenCharBoxes(charBoxes: CharBox[]): CharBox[] {
-    const flattened: CharBox[] = []
-    const stack = [...charBoxes]
-
-    while (stack.length > 0) {
-      const entry = stack.pop()!
-      if (entry.type === CharBoxType.CHAR) {
-        flattened.push(entry)
-      }
-
-      if (entry.children && entry.children.length > 0) {
-        for (let i = entry.children.length - 1; i >= 0; i--) {
-          stack.push(entry.children[i])
-        }
-      }
+  /** Removes the current root object and resets overlay / WCS offset state. */
+  private clearSceneContent(): void {
+    if (this.currentMText) {
+      this.viewport.scene.remove(this.currentMText)
+      this.currentMText = null
     }
-
-    return flattened
+    this.debugOverlays.clear()
+    this.boundsHelper.resetOriginOffset()
   }
 
-  private createCharBoxOverlay(charBoxes: CharBox[]): THREE.Group {
-    const overlay = new THREE.Group()
-    const renderableCharBoxes = this.flattenCharBoxes(charBoxes)
-
-    const charMaterial = new THREE.LineBasicMaterial({
-      color: 0x00cfff,
-      depthTest: false,
-      transparent: true,
-      opacity: 0.95
-    })
-
-    renderableCharBoxes.forEach(entry => {
-      const minX = entry.box.min.x
-      const minY = entry.box.min.y
-      const maxX = entry.box.max.x
-      const maxY = entry.box.max.y
-      const z = Math.max(entry.box.max.z, 0) + 0.001
-
-      const outlineVertices = [
-        minX,
-        minY,
-        z,
-        maxX,
-        minY,
-        z,
-        maxX,
-        minY,
-        z,
-        maxX,
-        maxY,
-        z,
-        maxX,
-        maxY,
-        z,
-        minX,
-        maxY,
-        z,
-        minX,
-        maxY,
-        z,
-        minX,
-        minY,
-        z
-      ]
-
-      const outlineGeometry = new THREE.BufferGeometry()
-      outlineGeometry.setAttribute(
-        'position',
-        new THREE.Float32BufferAttribute(outlineVertices, 3)
-      )
-
-      const outline = new THREE.LineSegments(outlineGeometry, charMaterial)
-      overlay.add(outline)
-    })
-
-    return overlay
+  /** Frames {@link currentMText} in the orthographic viewport. */
+  private fitView(): void {
+    this.boundsHelper.zoomToFit(this.currentMText)
   }
 
-  private createLineBoxOverlay(
-    lineLayouts: LineLayout[],
-    lineMinX: number,
-    lineMaxX: number,
-    z = 0.002
-  ): THREE.Group {
-    const overlay = new THREE.Group()
-    const material = new THREE.LineBasicMaterial({
-      color: 0xff2bd6,
-      depthTest: false,
-      depthWrite: false,
-      transparent: true,
-      opacity: 0.9
-    })
-
-    lineLayouts.forEach(line => {
-      const minY = line.y - line.height / 2
-      const maxY = line.y + line.height / 2
-      const outlineVertices = [
-        lineMinX,
-        minY,
-        z,
-        lineMaxX,
-        minY,
-        z,
-        lineMaxX,
-        minY,
-        z,
-        lineMaxX,
-        maxY,
-        z,
-        lineMaxX,
-        maxY,
-        z,
-        lineMinX,
-        maxY,
-        z,
-        lineMinX,
-        maxY,
-        z,
-        lineMinX,
-        minY,
-        z
-      ]
-      const outlineGeometry = new THREE.BufferGeometry()
-      outlineGeometry.setAttribute(
-        'position',
-        new THREE.Float32BufferAttribute(outlineVertices, 3)
-      )
-      const outline = new THREE.LineSegments(outlineGeometry, material)
-      outline.frustumCulled = false
-      overlay.add(outline)
-    })
-
-    return overlay
-  }
-
-  private attachCharBoxOverlay(mtextObj: MTextObject): void {
-    const layout = mtextObj.createLayoutData()
-    if (!layout.chars || layout.chars.length === 0) return
-
-    const overlay = this.createCharBoxOverlay(layout.chars)
-    overlay.visible = this.showCharBoxesCheckbox.checked
-    overlay.renderOrder = 999
-    mtextObj.add(overlay)
-    this.charBoxOverlays.push(overlay)
-  }
-
-  private attachLineBoxOverlay(mtextObj: MTextObject): void {
-    const layout = mtextObj.createLayoutData()
-    if (!layout.lines || layout.lines.length === 0) return
-    if (!mtextObj.box || mtextObj.box.isEmpty()) return
-
-    const overlay = this.createLineBoxOverlay(
-      layout.lines,
-      mtextObj.box.min.x,
-      mtextObj.box.max.x
-    )
-    overlay.visible = this.showLineBoxesCheckbox.checked
-    overlay.renderOrder = 998
-    mtextObj.add(overlay)
-    this.lineBoxOverlays.push(overlay)
-  }
-
+  /**
+   * Parses a hex color field (`#RRGGBB` or `RRGGBB`).
+   *
+   * @param input - Color `<input type="color">` or text field.
+   * @param fallback - Value used when parsing fails.
+   */
   private parseColorInput(input: HTMLInputElement, fallback: number): number {
     const value = input.value?.trim()
     if (!value) return fallback
@@ -1015,6 +394,7 @@ class MTextRendererExample {
     return Number.isFinite(parsed) ? parsed : fallback
   }
 
+  /** Builds {@link import('@mlightcad/mtext-renderer').ColorSettings} from ByLayer / ByBlock inputs. */
   private getColorSettings() {
     return {
       byLayerColor: this.parseColorInput(this.byLayerColorInput, 0xffffff),
@@ -1024,101 +404,16 @@ class MTextRendererExample {
     }
   }
 
-  private createShapeTextStyle(font: string, size: number): TextStyle {
-    return {
-      name: 'Standard',
-      standardFlag: 0,
-      fixedTextHeight: size,
-      widthFactor: 1,
-      obliqueAngle: 0,
-      textGenerationFlag: 0,
-      lastHeight: size,
-      font,
-      bigFont: ''
-    }
-  }
-
-  private buildShapeDataFromInputs(): ShapeData {
-    const size = Number(this.shapeSizeInput.value) || 24
-    const widthFactor = Number(this.shapeWidthFactorInput.value) || 1
-    const rotationDeg = Number(this.shapeRotationInput.value) || 0
-    const shapeNumber = Number(this.shapeNumberInput.value)
-    const shapeName = this.shapeNameInput.value.trim()
-
-    const shapeData: ShapeData = {
-      size,
-      widthFactor,
-      position: new THREE.Vector3(120, 420, 0),
-      rotation: (rotationDeg * Math.PI) / 180
-    }
-
-    if (shapeName) {
-      shapeData.name = shapeName
-    }
-    if (Number.isFinite(shapeNumber) && shapeNumber > 0) {
-      shapeData.shapeNumber = shapeNumber
-    }
-
-    return shapeData
-  }
-
-  private createShapeTestData(): {
-    shapeData: ShapeData
-    textStyle: TextStyle
-  }[] {
-    const font = this.shapeFontSelect.value || 'complex'
-    const size = 28
-    const shapeNumbers = [128, 129, 130, 131, 132]
-    const originX = 90
-    const originY = 420
-    const gapX = 110
-
-    return shapeNumbers.map((shapeNumber, index) => ({
-      shapeData: {
-        shapeNumber,
-        size,
-        widthFactor: 1,
-        position: new THREE.Vector3(originX + index * gapX, originY, 0)
-      },
-      textStyle: this.createShapeTextStyle(font, size)
-    }))
-  }
-
-  private clearSceneContent(): void {
-    if (this.currentMText) {
-      this.scene.remove(this.currentMText)
-      this.currentMText = null
-    }
-    if (this.mtextBox) {
-      this.scene.remove(this.mtextBox)
-      this.mtextBox = null
-    }
-    this.charBoxOverlays = []
-    this.lineBoxOverlays = []
-  }
-
+  /** @returns Whether a SHAPE render produced no drawable geometry. */
   private isShapeRenderEmpty(shapeObj: MTextObject): boolean {
     return shapeObj.children.length === 0 || shapeObj.box.isEmpty()
   }
 
-  private validateShapeInputs(shapeData: ShapeData, font: string): string | null {
-    const name = shapeData.name?.trim()
-    const number = shapeData.shapeNumber
-    const hasName = Boolean(name)
-    const hasNumber = number != null && number > 0
-
-    if (!hasName && !hasNumber) {
-      return 'Provide a shape name or shape number'
-    }
-    if (hasName && !hasNumber) {
-      return `Shape name "${name}" not found in ${font}.shx`
-    }
-    if (!hasName && hasNumber) {
-      return `Shape number ${number} not found in ${font}.shx`
-    }
-    return `Shape name "${name}" and number ${number} not found in ${font}.shx`
-  }
-
+  /**
+   * Renders one SHAPE entity from panel inputs or the five-glyph `shapes` grid example.
+   *
+   * @param content - When `'shapes'`, renders shape numbers 128–132; otherwise uses panel fields.
+   */
   private async renderShape(content?: string): Promise<void> {
     try {
       const startTime = performance.now()
@@ -1127,13 +422,13 @@ class MTextRendererExample {
 
       this.clearSceneContent()
       const colorSettings = this.getColorSettings()
-      const shapeFont = this.shapeFontSelect.value || 'complex'
+      const shapeFont = this.fontManager.getSelectedShapeFont() || 'complex'
       await this.unifiedRenderer.loadFonts([shapeFont])
 
       const isGrid = content === 'shapes'
 
       if (!isGrid) {
-        const shapeData = this.buildShapeDataFromInputs()
+        const shapeData = this.readShapeDataFromInputs()
         const hasName = Boolean(shapeData.name?.trim())
         const hasNumber =
           shapeData.shapeNumber != null && shapeData.shapeNumber > 0
@@ -1145,11 +440,11 @@ class MTextRendererExample {
       }
 
       const items = isGrid
-        ? this.createShapeTestData()
+        ? createShapeTestData(shapeFont)
         : [
             {
-              shapeData: this.buildShapeDataFromInputs(),
-              textStyle: this.createShapeTextStyle(
+              shapeData: this.readShapeDataFromInputs(),
+              textStyle: createShapeTextStyle(
                 shapeFont,
                 Number(this.shapeSizeInput.value) || 24
               )
@@ -1169,7 +464,7 @@ class MTextRendererExample {
       if (!isGrid) {
         const shapeObj = shapeObjects[0]
         if (this.isShapeRenderEmpty(shapeObj)) {
-          this.statusDiv.textContent = this.validateShapeInputs(
+          this.statusDiv.textContent = validateShapeInputs(
             items[0].shapeData,
             shapeFont
           )
@@ -1184,7 +479,7 @@ class MTextRendererExample {
       if (isGrid) {
         items.forEach(({ shapeData }) => {
           group.add(
-            this.createInsertionCrosshair(
+            this.debugOverlays.createInsertionCrosshair(
               shapeData.position.x,
               shapeData.position.y,
               14
@@ -1194,7 +489,7 @@ class MTextRendererExample {
       } else {
         const { position } = items[0].shapeData
         group.add(
-          this.createInsertionCrosshair(position.x, position.y, 18)
+          this.debugOverlays.createInsertionCrosshair(position.x, position.y, 18)
         )
       }
 
@@ -1210,14 +505,14 @@ class MTextRendererExample {
             this.showBoundingBoxCheckbox.checked &&
             !shapeObj.box.isEmpty()
           ) {
-            group.add(this.createMTextBox(shapeObj.box))
+            group.add(this.debugOverlays.createMTextBox(shapeObj.box))
           }
         }
       })
 
       ;(group as unknown as MTextObject).box = combinedBox ?? new THREE.Box3()
       this.currentMText = group as unknown as MTextObject
-      this.scene.add(this.currentMText)
+      this.viewport.scene.add(this.currentMText)
 
       const renderTime = performance.now() - startTime
       const label = isGrid
@@ -1225,6 +520,8 @@ class MTextRendererExample {
         : `SHAPE #${items[0].shapeData.shapeNumber ?? items[0].shapeData.name ?? '?'}`
       this.statusDiv.textContent = `Rendered ${label} in ${renderTime.toFixed(2)}ms (main thread; SHAPE uses sync path)`
       this.statusDiv.style.color = '#0f0'
+      this.boundsHelper.rebaseSceneOrigin(this.currentMText)
+      this.fitView()
     } catch (error) {
       console.error('Error rendering SHAPE:', error)
       this.statusDiv.textContent = 'Error rendering SHAPE'
@@ -1232,59 +529,84 @@ class MTextRendererExample {
     }
   }
 
+  /** Reads numeric and string SHAPE panel fields into {@link ShapeData}. */
+  private readShapeDataFromInputs() {
+    return buildShapeDataFromInputs({
+      size: Number(this.shapeSizeInput.value) || 24,
+      widthFactor: Number(this.shapeWidthFactorInput.value) || 1,
+      rotationDeg: Number(this.shapeRotationInput.value) || 0,
+      shapeNumber: Number(this.shapeNumberInput.value),
+      shapeName: this.shapeNameInput.value.trim()
+    })
+  }
+
+  /**
+   * Renders MText from an example marker, multi-entity test batch, or raw format string.
+   *
+   * @param content - Example key (`multiple`, `attachmentGrid`, large-coordinate markers)
+   *   or literal MText passed to a single-entity render.
+   */
   private async renderMText(content: string): Promise<void> {
     try {
       const startTime = performance.now()
-
-      // Show loading status
       this.statusDiv.textContent = 'Rendering MText...'
       this.statusDiv.style.color = '#ffa500'
-
-      // Remove existing content if any
       this.clearSceneContent()
 
-      let renderTime: number
       const colorSettings = this.getColorSettings()
-
+      const textFont = this.fontManager.getSelectedTextFont()
       const multiData =
         content === 'multiple'
-          ? this.createMultipleMTextData()
+          ? createMultipleMTextData(textFont)
           : content === 'attachmentGrid'
-            ? this.createAttachmentPointTestData()
-            : null
+            ? createAttachmentPointTestData(textFont)
+            : LargeCoordinatesExample.isExample(content)
+              ? LargeCoordinatesExample.createTestData(
+                  this.mtextInput.value,
+                  textFont
+                )
+              : null
 
       if (multiData) {
-        const renderPromises = multiData.map(({ mtextData, textStyle }) => {
-          return this.unifiedRenderer.asyncRenderMText(
-            mtextData,
-            textStyle,
-            colorSettings
+        if (LargeCoordinatesExample.isExample(content)) {
+          const texts = LargeCoordinatesExample.parseTexts(this.mtextInput.value)
+          if (texts.length < 2) {
+            this.statusDiv.textContent =
+              'Large Coordinates expects two MText blocks separated by \\P\\P in the text area'
+            this.statusDiv.style.color = '#f00'
+            return
+          }
+          await LargeCoordinatesExample.loadFonts(
+            this.unifiedRenderer,
+            texts,
+            textFont
           )
-        })
+        }
 
-        const mtextObjects: MTextObject[] = await Promise.all(renderPromises)
+        const mtextObjects = await Promise.all(
+          multiData.map(({ mtextData, textStyle }) =>
+            this.unifiedRenderer.asyncRenderMText(
+              mtextData,
+              textStyle,
+              colorSettings
+            )
+          )
+        )
 
-        // Create a group to hold all MText objects
         const group = new THREE.Group()
         let combinedBox: THREE.Box3 | null = null
 
-        if (content === 'attachmentGrid') {
-          for (const { mtextData } of multiData) {
-            group.add(
-              this.createInsertionCrosshair(
-                mtextData.position.x,
-                mtextData.position.y
-              )
-            )
-          }
-        }
-
         mtextObjects.forEach(mtextObj => {
-          this.attachCharBoxOverlay(mtextObj)
-          this.attachLineBoxOverlay(mtextObj)
+          this.debugOverlays.attachCharBoxOverlay(
+            mtextObj,
+            this.showCharBoxesCheckbox.checked
+          )
+          this.debugOverlays.attachLineBoxOverlay(
+            mtextObj,
+            this.showLineBoxesCheckbox.checked
+          )
           group.add(mtextObj)
 
-          // Combine bounding boxes
           if (mtextObj.box && !mtextObj.box.isEmpty()) {
             if (combinedBox === null) {
               combinedBox = mtextObj.box.clone()
@@ -1292,34 +614,48 @@ class MTextRendererExample {
               combinedBox.union(mtextObj.box)
             }
           }
-
-          // Add bounding boxes if enabled
-          if (
-            this.showBoundingBoxCheckbox.checked &&
-            mtextObj.box &&
-            !mtextObj.box.isEmpty()
-          ) {
-            const box = this.createMTextBox(mtextObj.box)
-            group.add(box)
-          }
         })
 
-        // Add combined bounding box to the group
-        if (combinedBox) {
-          ;(group as unknown as MTextObject).box = combinedBox
-        } else {
-          ;(group as unknown as MTextObject).box = new THREE.Box3()
-        }
+        ;(group as unknown as MTextObject).box =
+          combinedBox ?? new THREE.Box3()
 
         this.currentMText = group as unknown as MTextObject
-        this.scene.add(this.currentMText)
+        this.viewport.scene.add(this.currentMText)
 
-        renderTime = performance.now() - startTime
+        if (LargeCoordinatesExample.isExample(content)) {
+          if (LargeCoordinatesExample.shouldRebase(content)) {
+            this.boundsHelper.rebaseInsertionToOrigin(this.currentMText)
+            LargeCoordinatesExample.layoutPair(mtextObjects)
+          }
+        } else {
+          this.boundsHelper.rebaseSceneOrigin(this.currentMText)
+        }
+
+        this.debugOverlays.addMTextDebugOverlays(
+          group,
+          mtextObjects,
+          content,
+          {
+            showBoundingBox: this.showBoundingBoxCheckbox.checked,
+            multiData
+          }
+        )
+
+        const renderTime = performance.now() - startTime
         const label =
-          content === 'attachmentGrid' ? 'attachment-point grid' : 'MText batch'
-        this.statusDiv.textContent = `Rendered ${mtextObjects.length}/${multiData.length} (${label}) in ${renderTime.toFixed(2)}ms (${this.renderModeSelect.value} thread)`
+          content === 'attachmentGrid'
+            ? 'attachment-point grid'
+            : content === 'largeCoordinatesRebase'
+              ? 'large-coordinates MText (rebase ON; fonts via \\F)'
+              : content === 'largeCoordinatesNoRebase'
+                ? 'large-coordinates MText (rebase OFF; fonts via \\F)'
+                : 'MText batch'
+        this.statusDiv.textContent = `Rendered ${mtextObjects.length}/${multiData.length} (${label}) in ${renderTime.toFixed(2)}ms (${this.renderModeSelect.value} thread)${
+          LargeCoordinatesExample.isExample(content)
+            ? ` · DXF WCS insertion (38425645.89, 4069531.44); example width 100 (DXF group 41 was 128307003)${LargeCoordinatesExample.shouldRebase(content) ? '' : ' · rebase OFF'}`
+            : ''
+        }`
       } else {
-        // Render single MText object
         const mtextContent: MTextData = {
           text: content,
           height: 24,
@@ -1327,69 +663,63 @@ class MTextRendererExample {
           position: new THREE.Vector3(70, 530, 0)
         }
 
-        const textStyle: TextStyle = {
-          name: 'Standard',
-          standardFlag: 0,
-          fixedTextHeight: 24,
-          widthFactor: 1,
-          obliqueAngle: 0,
-          textGenerationFlag: 0,
-          lastHeight: 24,
-          font: this.fontSelect.value,
-          bigFont: ''
-        }
-
-        // Render MText using unified renderer
         this.currentMText = await this.unifiedRenderer.asyncRenderMText(
           mtextContent,
-          textStyle,
+          {
+            name: 'Standard',
+            standardFlag: 0,
+            fixedTextHeight: 24,
+            widthFactor: 1,
+            obliqueAngle: 0,
+            textGenerationFlag: 0,
+            lastHeight: 24,
+            font: textFont,
+            bigFont: ''
+          },
           colorSettings
         )
-        this.attachCharBoxOverlay(this.currentMText)
-        this.attachLineBoxOverlay(this.currentMText)
-        this.scene.add(this.currentMText)
 
-        // Create box around MText using its bounding box only if checkbox is checked
+        this.debugOverlays.attachCharBoxOverlay(
+          this.currentMText,
+          this.showCharBoxesCheckbox.checked
+        )
+        this.debugOverlays.attachLineBoxOverlay(
+          this.currentMText,
+          this.showLineBoxesCheckbox.checked
+        )
+        this.viewport.scene.add(this.currentMText)
+        this.boundsHelper.rebaseSceneOrigin(this.currentMText)
+
         if (
           this.showBoundingBoxCheckbox.checked &&
-          this.currentMText &&
           this.currentMText.box &&
           !this.currentMText.box.isEmpty()
         ) {
-          const box = this.createMTextBox(this.currentMText.box)
-          this.scene.add(box)
+          const box = this.debugOverlays.createMTextBox(
+            this.boundsHelper.getOverlayBounds(
+              this.currentMText,
+              this.currentMText.box
+            )
+          )
+          this.currentMText.add(box)
         }
 
-        renderTime = performance.now() - startTime
+        const renderTime = performance.now() - startTime
         this.statusDiv.textContent = `MText rendered in ${renderTime.toFixed(2)}ms (${this.renderModeSelect.value} thread)`
       }
 
       this.statusDiv.style.color = '#0f0'
+      this.fitView()
     } catch (error) {
       console.error('Error rendering MText:', error)
       this.statusDiv.textContent = 'Error rendering MText'
       this.statusDiv.style.color = '#f00'
     }
   }
-
-  private animate(): void {
-    requestAnimationFrame(() => this.animate())
-    this.controls.update()
-    this.renderer.render(this.scene, this.camera)
-  }
-
-  /**
-   * Cleanup method to destroy the renderer
-   */
-  public destroy(): void {
-    this.unifiedRenderer.destroy()
-  }
 }
 
-// Create and start the example
 const app = new MTextRendererExample()
 
-// Cleanup on page unload
 window.addEventListener('beforeunload', () => {
   app.destroy()
 })

--- a/packages/example/src/sceneBoundsHelper.ts
+++ b/packages/example/src/sceneBoundsHelper.ts
@@ -1,0 +1,358 @@
+import * as THREE from 'three'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+
+/**
+ * Computes drawable bounds, rebases large world coordinates near the origin, and
+ * frames content in the orthographic viewport.
+ *
+ * @remarks
+ * WebGL uses float32 transforms; MText inserted at survey-scale WCS (tens of
+ * millions) loses sub-pixel detail unless geometry is shifted. This helper:
+ *
+ * 1. Unions **glyph geometry** bounds while skipping debug overlays tagged with
+ *    `userData.excludeFromFit`.
+ * 2. Records the shift in {@link wcsOriginOffset} so {@link WcsCoordinateDisplay}
+ *    can report true WCS coordinates.
+ * 3. Adjusts the orthographic frustum via {@link zoomToFit} instead of moving
+ *    the camera to large coordinates (which would reintroduce precision loss).
+ */
+export class SceneBoundsHelper {
+  /**
+   * Translation applied when content is rebased to the scene origin.
+   * World coordinates satisfy `WCS = scenePosition + wcsOriginOffset`.
+   */
+  readonly wcsOriginOffset = new THREE.Vector3(0, 0, 0)
+
+  /** Positions above this magnitude (|x| or |y|) are treated as large WCS inserts. */
+  private readonly largeWorldCoordinateThreshold = 1e5
+
+  /**
+   * @param camera - Orthographic camera whose frustum is updated by {@link zoomToFit}.
+   * @param controls - Orbit controls whose target is reset when framing content.
+   * @param getRenderAreaSize - Returns the current `#render-area` size in CSS pixels.
+   */
+  constructor(
+    private readonly camera: THREE.OrthographicCamera,
+    private readonly controls: OrbitControls,
+    private readonly getRenderAreaSize: () => { width: number; height: number }
+  ) {}
+
+  /** Clears {@link wcsOriginOffset} when scene content is removed. */
+  resetOriginOffset(): void {
+    this.wcsOriginOffset.set(0, 0, 0)
+  }
+
+  /**
+   * Returns whether `object` should contribute to renderable bounds unions.
+   *
+   * @param object - Candidate scene-graph node (typically a mesh or line primitive).
+   * @returns `false` if the node is invisible or has an ancestor with `userData.excludeFromFit`.
+   */
+  shouldIncludeInRenderableBounds(object: THREE.Object3D): boolean {
+    if (!object.visible) {
+      return false
+    }
+
+    let node: THREE.Object3D | null = object
+    while (node) {
+      if (node.userData?.excludeFromFit) {
+        return false
+      }
+      node = node.parent
+    }
+
+    return true
+  }
+
+  /**
+   * Unions world-space axis-aligned bounds of visible glyph geometry under `root`.
+   *
+   * @param root - Scene subgraph to traverse (usually the current MText group).
+   * @returns World-space bounding box; may be empty when no qualifying geometry exists.
+   */
+  computeRenderableBounds(root: THREE.Object3D): THREE.Box3 {
+    const bounds = new THREE.Box3()
+    const tempBox = new THREE.Box3()
+    root.updateWorldMatrix(true, true)
+
+    root.traverse(child => {
+      if (!this.shouldIncludeInRenderableBounds(child)) {
+        return
+      }
+
+      if (
+        child instanceof THREE.Line ||
+        child instanceof THREE.LineSegments ||
+        child instanceof THREE.Mesh
+      ) {
+        const geometry = child.geometry
+        if (!geometry || geometry.userData?.isDecoration) {
+          return
+        }
+        if (!geometry.boundingBox) {
+          geometry.computeBoundingBox()
+        }
+        if (!geometry.boundingBox || geometry.boundingBox.isEmpty()) {
+          return
+        }
+        tempBox.copy(geometry.boundingBox).applyMatrix4(child.matrixWorld)
+        bounds.union(tempBox)
+      }
+    })
+
+    return bounds
+  }
+
+  /**
+   * Chooses bounds for display/fit when the logical MText column is far wider than glyphs.
+   *
+   * @param source - Rendered MText object.
+   * @param logicalBox - Renderer-reported logical extents (may span huge DXF width).
+   * @returns Either `logicalBox` or glyph geometry bounds, whichever is more representative.
+   *
+   * @remarks
+   * When logical span exceeds `max(geometrySpan × 1000, 1e6)`, glyph bounds are preferred.
+   * This avoids empty-looking views for entities whose DXF group 41 width is astronomical
+   * while actual text occupies a small fraction of that column.
+   */
+  getDisplayBounds(source: THREE.Object3D, logicalBox: THREE.Box3): THREE.Box3 {
+    const renderable = this.computeRenderableBounds(source)
+    if (renderable.isEmpty()) {
+      return logicalBox.clone()
+    }
+
+    const logicalSpanX = logicalBox.max.x - logicalBox.min.x
+    const logicalSpanY = logicalBox.max.y - logicalBox.min.y
+    const geometrySpanX = renderable.max.x - renderable.min.x
+    const geometrySpanY = renderable.max.y - renderable.min.y
+    const geometrySpan = Math.max(geometrySpanX, geometrySpanY, 1)
+    const logicalSpan = Math.max(logicalSpanX, logicalSpanY)
+
+    if (logicalSpan > Math.max(geometrySpan * 1000, 1e6)) {
+      return renderable.clone()
+    }
+
+    return logicalBox.clone()
+  }
+
+  /**
+   * Bounds used when drawing debug bounding-box overlays.
+   *
+   * @param source - Rendered MText object.
+   * @param logicalBox - Fallback logical extents when no glyph geometry is found.
+   * @returns Tightest useful bounds for overlay placement.
+   */
+  getOverlayBounds(source: THREE.Object3D, logicalBox: THREE.Box3): THREE.Box3 {
+    const renderable = this.computeRenderableBounds(source)
+    if (!renderable.isEmpty()) {
+      return renderable.clone()
+    }
+    return this.getDisplayBounds(source, logicalBox)
+  }
+
+  /**
+   * Returns the world-space center of rendered glyph geometry for an MText object.
+   *
+   * @param mtextObj - Object whose drawable children are traversed.
+   * @returns Geometry center, or `(0, 0, 0)` when bounds are empty.
+   */
+  getRebasedAnchorPoint(mtextObj: THREE.Object3D): THREE.Vector3 {
+    const bounds = this.computeRenderableBounds(mtextObj)
+    if (!bounds.isEmpty()) {
+      return bounds.getCenter(new THREE.Vector3())
+    }
+    return new THREE.Vector3(0, 0, 0)
+  }
+
+  /**
+   * Shifts rendered content near the origin when its geometric center lies at large WCS.
+   *
+   * @param currentContent - Root group currently displayed in the scene.
+   *
+   * @remarks
+   * Large insertion transforms are rewritten on individual nodes (see
+   * {@link subtractWorldOffset}) rather than translating an outer group, which would
+   * still accumulate float32 error in child world matrices. No-op when center coordinates
+   * are below {@link largeWorldCoordinateThreshold}.
+   */
+  rebaseSceneOrigin(currentContent: THREE.Object3D | null): void {
+    if (!currentContent) {
+      return
+    }
+
+    currentContent.position.set(0, 0, 0)
+    currentContent.updateWorldMatrix(true, true)
+
+    const bounds = this.computeRenderableBounds(currentContent)
+    if (bounds.isEmpty()) {
+      return
+    }
+
+    const center = bounds.getCenter(new THREE.Vector3())
+    if (
+      Math.abs(center.x) <= this.largeWorldCoordinateThreshold &&
+      Math.abs(center.y) <= this.largeWorldCoordinateThreshold
+    ) {
+      return
+    }
+
+    this.wcsOriginOffset.copy(center)
+    this.subtractWorldOffset(currentContent, center)
+    currentContent.updateWorldMatrix(true, true)
+    this.refreshDrawableBounds(currentContent)
+  }
+
+  /**
+   * Moves large WCS insertion transforms to the origin while preserving local glyph geometry.
+   *
+   * @param currentContent - Root group whose descendants may carry survey-scale positions.
+   *
+   * @remarks
+   * The first node with |position| above the threshold supplies {@link wcsOriginOffset}.
+   * Used by the large-coordinates example when rebase is enabled.
+   */
+  rebaseInsertionToOrigin(currentContent: THREE.Object3D | null): void {
+    let capturedOffset = false
+    currentContent?.traverse(child => {
+      if (
+        Math.abs(child.position.x) > this.largeWorldCoordinateThreshold ||
+        Math.abs(child.position.y) > this.largeWorldCoordinateThreshold
+      ) {
+        if (!capturedOffset) {
+          this.wcsOriginOffset.set(child.position.x, child.position.y, 0)
+          capturedOffset = true
+        }
+        child.position.set(0, 0, child.position.z)
+        child.updateMatrix()
+      }
+    })
+    currentContent?.updateWorldMatrix(true, true)
+    this.refreshDrawableBounds(currentContent)
+  }
+
+  /**
+   * Frames `currentContent` in the viewport by adjusting the orthographic frustum.
+   *
+   * @param currentContent - Content to fit; when `null`, resets frustum to the full pane.
+   * @param paddingRatio - Fractional padding added on each side of the content bounds (default `0.08`).
+   *
+   * @remarks
+   * The camera stays at the origin; only `left`/`right`/`top`/`bottom` change. Aspect
+   * ratio is preserved by expanding the narrower axis when content and view aspects differ.
+   */
+  zoomToFit(
+    currentContent: THREE.Object3D | null,
+    paddingRatio = 0.08
+  ): void {
+    const { width: viewW, height: viewH } = this.getRenderAreaSize()
+
+    this.camera.zoom = 1
+    this.camera.position.set(0, 0, 100)
+    this.controls.target.set(0, 0, 0)
+
+    if (!currentContent) {
+      this.setDefaultFrustum(viewW, viewH)
+      return
+    }
+
+    const worldBox = this.computeRenderableBounds(currentContent)
+    if (worldBox.isEmpty()) {
+      this.setDefaultFrustum(viewW, viewH)
+      return
+    }
+
+    const minX = worldBox.min.x
+    const maxX = worldBox.max.x
+    const minY = worldBox.min.y
+    const maxY = worldBox.max.y
+    const padX = Math.max((maxX - minX) * paddingRatio, 1e-6)
+    const padY = Math.max((maxY - minY) * paddingRatio, 1e-6)
+    let fitMinX = minX - padX
+    let fitMaxX = maxX + padX
+    let fitMinY = minY - padY
+    let fitMaxY = maxY + padY
+
+    const fitW = fitMaxX - fitMinX
+    const fitH = fitMaxY - fitMinY
+    const viewAspect = viewW / viewH
+    const fitAspect = fitW / fitH
+
+    if (fitAspect > viewAspect) {
+      const expandedH = fitW / viewAspect
+      const centerY = (minY + maxY) / 2
+      fitMinY = centerY - expandedH / 2
+      fitMaxY = centerY + expandedH / 2
+    } else {
+      const expandedW = fitH * viewAspect
+      const centerX = (minX + maxX) / 2
+      fitMinX = centerX - expandedW / 2
+      fitMaxX = centerX + expandedW / 2
+    }
+
+    this.camera.left = fitMinX
+    this.camera.right = fitMaxX
+    this.camera.top = fitMaxY
+    this.camera.bottom = fitMinY
+    this.camera.updateProjectionMatrix()
+    this.controls.update()
+  }
+
+  /** Restores a pixel-aligned frustum covering the entire render pane. */
+  private setDefaultFrustum(viewW: number, viewH: number): void {
+    this.camera.left = 0
+    this.camera.right = viewW
+    this.camera.top = viewH
+    this.camera.bottom = 0
+    this.camera.updateProjectionMatrix()
+    this.controls.update()
+  }
+
+  /**
+   * Subtracts `offset` from local positions of nodes whose coordinates exceed the threshold.
+   *
+   * @param root - Subtree to rewrite.
+   * @param offset - World-space center captured before rebase.
+   */
+  private subtractWorldOffset(
+    root: THREE.Object3D,
+    offset: THREE.Vector3
+  ): void {
+    root.traverse(child => {
+      if (
+        Math.abs(child.position.x) > this.largeWorldCoordinateThreshold ||
+        Math.abs(child.position.y) > this.largeWorldCoordinateThreshold
+      ) {
+        child.position.x -= offset.x
+        child.position.y -= offset.y
+        child.updateMatrix()
+      }
+    })
+  }
+
+  /**
+   * Recomputes geometry bounding volumes and disables frustum culling after a rebase.
+   *
+   * @param root - Subtree whose drawable primitives should be refreshed.
+   */
+  private refreshDrawableBounds(root: THREE.Object3D | null): void {
+    if (!root) {
+      return
+    }
+
+    root.traverse(child => {
+      if (
+        child instanceof THREE.Line ||
+        child instanceof THREE.LineSegments ||
+        child instanceof THREE.Mesh
+      ) {
+        child.frustumCulled = false
+        const geometry = child.geometry as THREE.BufferGeometry | undefined
+        if (!geometry) {
+          return
+        }
+        geometry.computeBoundingBox()
+        geometry.computeBoundingSphere()
+      }
+    })
+  }
+}

--- a/packages/example/src/sceneViewport.ts
+++ b/packages/example/src/sceneViewport.ts
@@ -1,0 +1,107 @@
+import * as THREE from 'three'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+
+/**
+ * Owns the Three.js scene graph, orthographic camera, WebGL renderer, and
+ * 2D pan/zoom controls for the example application's render pane.
+ *
+ * @remarks
+ * The camera uses a Y-down orthographic frustum matching CSS pixel coordinates
+ * (`left=0`, `top=0`, `right=width`, `bottom=height`). Rotation is disabled on
+ * {@link OrbitControls}; only pan and zoom are available. The animation loop
+ * runs for the lifetime of the page and is started once via
+ * {@link SceneViewport.startAnimationLoop}.
+ */
+export class SceneViewport {
+  /** Root scene containing all rendered MText, SHAPE, and debug geometry. */
+  readonly scene: THREE.Scene
+  /** Orthographic camera; frustum is adjusted by {@link SceneBoundsHelper.zoomToFit}. */
+  readonly camera: THREE.OrthographicCamera
+  /** WebGL renderer whose canvas is appended to `#render-area`. */
+  readonly renderer: THREE.WebGLRenderer
+  /** Pan/zoom controls bound to {@link renderer.domElement}. */
+  readonly controls: OrbitControls
+  /** DOM container (`#render-area`) that defines the drawable size. */
+  private readonly renderArea: HTMLElement
+
+  /**
+   * Creates the viewport and mounts the renderer canvas into `renderArea`.
+   *
+   * @param renderArea - Host element; must already exist in the document.
+   */
+  constructor(renderArea: HTMLElement) {
+    this.renderArea = renderArea
+
+    this.scene = new THREE.Scene()
+    this.scene.background = new THREE.Color(0x333333)
+
+    const { width, height } = this.getSize()
+    this.camera = new THREE.OrthographicCamera(0, width, height, 0, -1000, 1000)
+    this.camera.position.set(0, 0, 100)
+    this.camera.lookAt(new THREE.Vector3(0, 0, 0))
+
+    this.renderer = new THREE.WebGLRenderer({ antialias: true })
+    this.renderer.setPixelRatio(window.devicePixelRatio)
+    this.renderer.setSize(width, height, false)
+    renderArea.appendChild(this.renderer.domElement)
+
+    this.controls = new OrbitControls(this.camera, this.renderer.domElement)
+    this.controls.enableRotate = false
+    this.controls.screenSpacePanning = true
+    this.controls.minZoom = 0.01
+    this.controls.maxZoom = 50
+
+    this.setupLights()
+  }
+
+  /**
+   * Returns the current drawable size of `#render-area` in CSS pixels.
+   *
+   * @returns Width and height used for camera and renderer sizing.
+   */
+  getSize(): { width: number; height: number } {
+    return {
+      width: this.renderArea.clientWidth,
+      height: this.renderArea.clientHeight
+    }
+  }
+
+  /**
+   * Resizes the renderer and resets the camera frustum to the full render area.
+   *
+   * @param onResized - Optional callback invoked after resize (e.g. to refit content).
+   */
+  resize(onResized?: () => void): void {
+    const { width, height } = this.getSize()
+    this.camera.left = 0
+    this.camera.right = width
+    this.camera.top = height
+    this.camera.bottom = 0
+    this.camera.updateProjectionMatrix()
+    this.renderer.setSize(width, height, false)
+    onResized?.()
+  }
+
+  /**
+   * Starts a perpetual `requestAnimationFrame` loop that updates controls and renders.
+   *
+   * @remarks
+   * Intended to be called exactly once during application bootstrap.
+   */
+  startAnimationLoop(): void {
+    const tick = (): void => {
+      requestAnimationFrame(tick)
+      this.controls.update()
+      this.renderer.render(this.scene, this.camera)
+    }
+    tick()
+  }
+
+  /** Adds ambient and directional lights required by mesh-based glyph rendering. */
+  private setupLights(): void {
+    this.scene.add(new THREE.AmbientLight(0xffffff, 0.5))
+    const directionalLight = new THREE.DirectionalLight(0xffffff, 0.5)
+    directionalLight.position.set(1, 1, 1)
+    this.scene.add(directionalLight)
+  }
+}

--- a/packages/example/src/wcsCoordinateDisplay.ts
+++ b/packages/example/src/wcsCoordinateDisplay.ts
@@ -1,0 +1,104 @@
+import * as THREE from 'three'
+
+import { SceneBoundsHelper } from './sceneBoundsHelper'
+import { SceneViewport } from './sceneViewport'
+
+/**
+ * Displays live World Coordinate System (WCS) X/Y values under the mouse cursor.
+ *
+ * @remarks
+ * Scene coordinates reflect rebased geometry near the origin. {@link SceneBoundsHelper.wcsOriginOffset}
+ * is added so the overlay reports the original survey coordinates after a rebase.
+ * The HUD element (`#wcs-coords`) uses `pointer-events: none` and is toggled via CSS
+ * `visibility` rather than `display` to avoid layout shifts.
+ */
+export class WcsCoordinateDisplay {
+  /** Reused buffer for unprojected scene coordinates (avoids per-frame allocations). */
+  private readonly pointerScene = new THREE.Vector3()
+  /** Reused buffer for WCS coordinates shown in the overlay. */
+  private readonly pointerWcs = new THREE.Vector3()
+
+  /**
+   * @param wcsCoordsDiv - Overlay element in `#render-area` that shows formatted coordinates.
+   * @param viewport - Source of camera and canvas for client-to-scene mapping.
+   * @param boundsHelper - Supplies {@link SceneBoundsHelper.wcsOriginOffset} after rebase.
+   */
+  constructor(
+    private readonly wcsCoordsDiv: HTMLDivElement,
+    private readonly viewport: SceneViewport,
+    private readonly boundsHelper: SceneBoundsHelper
+  ) {}
+
+  /**
+   * Attaches mouse listeners to the render canvas.
+   *
+   * @param canvas - Typically {@link SceneViewport.renderer.domElement}.
+   */
+  bind(canvas: HTMLCanvasElement): void {
+    canvas.addEventListener('mousemove', event => {
+      this.update(event.clientX, event.clientY)
+    })
+    canvas.addEventListener('mouseleave', () => {
+      this.hide()
+    })
+  }
+
+  /** Hides the coordinate overlay without clearing its last text. */
+  hide(): void {
+    this.wcsCoordsDiv.style.visibility = 'hidden'
+  }
+
+  /**
+   * Updates the overlay from a client-space pointer position.
+   *
+   * @param clientX - Viewport X in CSS pixels.
+   * @param clientY - Viewport Y in CSS pixels.
+   */
+  private update(clientX: number, clientY: number): void {
+    const wcs = this.sceneToWcs(this.clientToScene(clientX, clientY))
+    this.wcsCoordsDiv.textContent = `WCS: X ${this.formatWcsValue(wcs.x)}, Y ${this.formatWcsValue(wcs.y)}`
+    this.wcsCoordsDiv.style.visibility = 'visible'
+  }
+
+  /**
+   * Converts client coordinates to a point on the Z=0 plane in scene space.
+   *
+   * @param clientX - Pointer X relative to the viewport.
+   * @param clientY - Pointer Y relative to the viewport.
+   * @returns Unprojected scene position (same space as rendered geometry).
+   */
+  private clientToScene(clientX: number, clientY: number): THREE.Vector3 {
+    const rect = this.viewport.renderer.domElement.getBoundingClientRect()
+    const ndcX = ((clientX - rect.left) / rect.width) * 2 - 1
+    const ndcY = -((clientY - rect.top) / rect.height) * 2 + 1
+    this.pointerScene.set(ndcX, ndcY, 0).unproject(this.viewport.camera)
+    return this.pointerScene
+  }
+
+  /**
+   * Applies {@link SceneBoundsHelper.wcsOriginOffset} to recover WCS from scene space.
+   *
+   * @param scene - Point in rebased scene coordinates.
+   * @returns Equivalent WCS point (`scene + wcsOriginOffset`).
+   */
+  private sceneToWcs(scene: THREE.Vector3): THREE.Vector3 {
+    return this.pointerWcs.copy(scene).add(this.boundsHelper.wcsOriginOffset)
+  }
+
+  /**
+   * Formats a coordinate for human-readable display with magnitude-dependent precision.
+   *
+   * @param value - Coordinate component in drawing units.
+   * @returns Fixed-point string (4 decimals for very large/small values, otherwise 2–3).
+   */
+  private formatWcsValue(value: number): string {
+    const abs = Math.abs(value)
+    if (abs >= 1e6 || (abs > 0 && abs < 1e-3)) {
+      return value.toFixed(4)
+    }
+    if (abs >= 1000) {
+      return value.toFixed(3)
+    }
+    return value.toFixed(2)
+  }
+}

--- a/packages/mtext-renderer/src/worker/mtextWorker.ts
+++ b/packages/mtext-renderer/src/worker/mtextWorker.ts
@@ -294,7 +294,7 @@ function serializeChildren(root: THREE.Object3D): {
   rootWorldInverse.copy(root.matrixWorld).invert()
 
   root.traverse(child => {
-    if (child instanceof THREE.Mesh || child instanceof THREE.Line) {
+    if (child instanceof THREE.Mesh || child instanceof THREE.LineSegments) {
       const geometry = child.geometry
       const material = child.material
 

--- a/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
+++ b/packages/mtext-renderer/src/worker/webWorkerRenderer.ts
@@ -783,7 +783,10 @@ export class WebWorkerRenderer implements MTextBaseRenderer {
       return
     }
 
-    if (object instanceof THREE.Line || object instanceof THREE.Mesh) {
+    if (
+      object instanceof THREE.LineSegments ||
+      object instanceof THREE.Mesh
+    ) {
       const geometry = object.geometry
       if (!geometry.userData?.isDecoration) {
         if (geometry.boundingBox === null) {

--- a/packages/mtext-renderer/test/renderer/shxSymbolControlCodes.test.ts
+++ b/packages/mtext-renderer/test/renderer/shxSymbolControlCodes.test.ts
@@ -1,41 +1,42 @@
-import type { PercentSymbolData } from '@mlightcad/mtext-parser'
-import { describe, expect, it } from 'vitest'
-
-import {
-  AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES,
-  getPercentSymbolLookupCodes
-} from '../../src/renderer/shxSymbolControlCodes'
-
-describe('shxSymbolControlCodes', () => {
-  it('maps all named AutoCAD percent symbols to SHX control-code candidates', () => {
-    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.c).toEqual([129])
-    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.d).toEqual([126, 176])
-    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.p).toEqual([177])
-  })
-
-  it('returns ordered lookup codes for named percent-symbol tokens', () => {
-    const diameter: PercentSymbolData = { kind: 'named', code: 'c', char: 'Ø' }
-    const degree: PercentSymbolData = { kind: 'named', code: 'd', char: '°' }
-    const plusMinus: PercentSymbolData = { kind: 'named', code: 'p', char: '±' }
-
-    expect(getPercentSymbolLookupCodes(diameter)).toEqual([129, 0x2205])
-    expect(getPercentSymbolLookupCodes(degree)).toEqual([126, 176])
-    expect(getPercentSymbolLookupCodes(plusMinus)).toEqual([177])
-  })
-
-  it('returns lookup code for numeric percent-symbol tokens', () => {
-    const ch132: PercentSymbolData = {
-      kind: 'numeric',
-      charCode: 132,
-      char: String.fromCharCode(132)
-    }
-
-    expect(getPercentSymbolLookupCodes(ch132)).toEqual([132])
-  })
-
-  it('returns no symbol-font lookups for literal percent tokens', () => {
-    const literal: PercentSymbolData = { kind: 'literal', char: '%' }
-    expect(getPercentSymbolLookupCodes(literal)).toEqual([])
-  })
-})
-
+import type { PercentSymbolData } from '@mlightcad/mtext-parser'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES,
+  getPercentSymbolLookupCodes
+} from '../../src/renderer/shxSymbolControlCodes'
+
+describe('shxSymbolControlCodes', () => {
+  it('maps all named AutoCAD percent symbols to SHX control-code candidates', () => {
+    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.c).toEqual([129])
+    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.d).toEqual([126, 176])
+    expect(AUTOCAD_PERCENT_SYMBOL_CONTROL_CODES.p).toEqual([177])
+  })
+
+  it('returns ordered lookup codes for named percent-symbol tokens', () => {
+    const diameter: PercentSymbolData = { kind: 'named', code: 'c', char: 'Ø' }
+    const degree: PercentSymbolData = { kind: 'named', code: 'd', char: '°' }
+    const plusMinus: PercentSymbolData = { kind: 'named', code: 'p', char: '±' }
+
+    expect(getPercentSymbolLookupCodes(diameter)).toEqual([129, 0x2205])
+    expect(getPercentSymbolLookupCodes(degree)).toEqual([126, 176])
+    expect(getPercentSymbolLookupCodes(plusMinus)).toEqual([177])
+  })
+
+  it('returns lookup code for numeric percent-symbol tokens', () => {
+    const ch132: PercentSymbolData = {
+      kind: 'numeric',
+      charCode: 132,
+      char: String.fromCharCode(132)
+    }
+
+    expect(getPercentSymbolLookupCodes(ch132)).toEqual([132])
+  })
+
+  it('returns no symbol-font lookups for literal percent tokens', () => {
+    const literal: PercentSymbolData = { kind: 'literal', char: '%' }
+
+    expect(getPercentSymbolLookupCodes(literal)).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- Refactor the interactive example into focused modules (viewport, bounds/rebase, debug overlays, font manager, test data) and adopt a split-pane layout with a WCS coordinate overlay.
- Add large-coordinate example cases (rebase ON/OFF) to demonstrate float32 precision issues at survey-scale WCS and the rebase mitigation.
- Fix web worker serialization to handle \THREE.LineSegments\ (SHX line glyphs) instead of \THREE.Line\, so char/line layout metadata is preserved across the worker boundary.

## Test plan

- [x] \
pm test\ — 137 tests pass
- [ ] Open example app; verify split layout and pan/zoom in render pane
- [ ] Toggle char boxes / line boxes / bounding box overlays
- [ ] Run **Large Coordinates (Rebase)** and **Large Coordinates (No Rebase)** examples; compare glyph quality
- [ ] Hover render area; confirm WCS coords display original survey coordinates after rebase
- [ ] Switch to Web Worker render mode and confirm SHX text renders correctly

Made with [Cursor](https://cursor.com)