### PR TITLE
fix: reject absurd MTEXT wrap widths from corrupt DXF group-code 41

### DIFF
--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-renderer",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "AutoCAD MText renderer based on Three.js",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",

--- a/packages/mtext-renderer/src/renderer/mtextDataUtils.ts
+++ b/packages/mtext-renderer/src/renderer/mtextDataUtils.ts
@@ -13,6 +13,19 @@ export const MIN_REASONABLE_MTEXT_WIDTH_HEIGHT_RATIO = 1.5
 export const CJK_MTEXT_CHAR_WIDTH_HEIGHT_RATIO = 0.8
 
 /**
+ * Maximum width-to-height ratio for a declared MTEXT wrap box. Values above this
+ * are treated as corrupt DXF group-code 41 data (often coordinate-scale garbage)
+ * rather than an intentional column width.
+ */
+export const MAX_REASONABLE_MTEXT_WIDTH_HEIGHT_RATIO = 1_000_000
+
+/**
+ * Maximum ratio between declared wrap width and the content-estimated width.
+ * Catches absurd widths even when text height is also very large.
+ */
+export const MAX_REASONABLE_MTEXT_WIDTH_CONTENT_EXCESS = 10_000
+
+/**
  * Estimates a usable MTEXT wrap width from the longest explicit line in the raw
  * MTEXT string while preserving explicit line breaks such as `\P`.
  */
@@ -37,21 +50,39 @@ export function estimateMTextWrapWidth(text: string, height: number): number {
  * the word-wrap width forces CJK text to wrap one character per line. When the
  * width is clearly impossible as a layout width, estimate a usable width from
  * the longest explicit MTEXT line and preserve explicit line breaks such as `\P`.
+ *
+ * Other exports carry absurdly large group-code 41 values. Using those widths for
+ * middle/center attachment shifts glyph geometry by tens of millions of drawing
+ * units and destroys float32 precision. Replace those with the same content-based
+ * estimate when the declared width far exceeds the rendered text.
  */
 export function resolveMTextWrapWidth(
   mtextData: Pick<MTextData, 'text' | 'height' | 'width'>
 ): number {
   const width = mtextData.width
   const height = mtextData.height
-  if (
-    !Number.isFinite(width) ||
-    !Number.isFinite(height) ||
-    width <= 0 ||
-    height <= 0 ||
-    width >= height * MIN_REASONABLE_MTEXT_WIDTH_HEIGHT_RATIO
-  ) {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || height <= 0) {
     return width
   }
 
-  return estimateMTextWrapWidth(mtextData.text, height)
+  if (width <= 0) {
+    return width
+  }
+
+  const minReasonable = height * MIN_REASONABLE_MTEXT_WIDTH_HEIGHT_RATIO
+  if (width < minReasonable) {
+    return estimateMTextWrapWidth(mtextData.text, height)
+  }
+
+  const estimated = estimateMTextWrapWidth(mtextData.text, height)
+  const widthToHeight = width / height
+  const widthToContent = width / Math.max(estimated, Number.EPSILON)
+  if (
+    widthToHeight > MAX_REASONABLE_MTEXT_WIDTH_HEIGHT_RATIO ||
+    widthToContent > MAX_REASONABLE_MTEXT_WIDTH_CONTENT_EXCESS
+  ) {
+    return estimated
+  }
+
+  return width
 }

--- a/packages/mtext-renderer/test/renderer/mtext.wrapWidth.test.ts
+++ b/packages/mtext-renderer/test/renderer/mtext.wrapWidth.test.ts
@@ -46,6 +46,20 @@ describe('resolveMTextWrapWidth', () => {
 
     expect(resolveMTextWrapWidth(mtextData)).toBe(Number.POSITIVE_INFINITY)
   })
+
+  it('replaces absurdly large declared widths with a content estimate', () => {
+    const mtextData = {
+      text: '{(474.410)}',
+      height: 4.0222404674496,
+      width: 128_307_003.20375
+    }
+
+    const estimated = estimateMTextWrapWidth(mtextData.text, mtextData.height)
+
+    expect(resolveMTextWrapWidth(mtextData)).toBe(estimated)
+    expect(resolveMTextWrapWidth(mtextData)).toBeLessThan(1_000)
+    expect(mtextData.width).toBe(128_307_003.20375)
+  })
 })
 
 describe('estimateMTextWrapWidth', () => {


### PR DESCRIPTION
## Summary
- Detect unreasonably large MTEXT wrap widths from corrupt DXF group-code 41 values and fall back to a content-based width estimate.
- Prevents middle/center attachment from shifting glyph geometry by tens of millions of drawing units and destroying float32 precision.
- Bump package version to 0.11.4.

## Test plan
- [x] pm test -- --run mtext.wrapWidth\ passes (6 tests)
- [ ] Verify MTEXT with absurd declared widths renders with correct center/middle alignment in the example app
