### PR TITLE
fix: frame large WCS MText via camera centering instead of insertion rebase

### DIFF
--- a/packages/example/index.html
+++ b/packages/example/index.html
@@ -316,8 +316,7 @@
             <button class="example-btn" data-example="stacking">Stacking</button>
             <button class="example-btn" data-example="multiple">Multiple MText</button>
             <button class="example-btn" data-example="attachmentGrid">Attachment Points</button>
-            <button class="example-btn" data-example="largeCoordinatesRebase" title="Large WCS coords with rebase to origin; two MText blocks (\P\P); fonts via \Fname;">Large Coordinates (Rebase)</button>
-            <button class="example-btn" data-example="largeCoordinatesNoRebase" title="Same WCS coords without rebase — compare float32 behavior; \P\P separates blocks; fonts via \Fname;">Large Coordinates (No Rebase)</button>
+            <button class="example-btn" data-example="largeCoordinates" title="Large WCS coords; two MText blocks (\P\P); fonts via \Fname;">Large Coordinates</button>
         </div>
         <div id="status"></div>
     </div>

--- a/packages/example/src/exampleTestData.ts
+++ b/packages/example/src/exampleTestData.ts
@@ -234,15 +234,14 @@ export function createMultipleMTextData(textFont: string): MTextTestCase[] {
  * @remarks
  * Sample geometry is taken from a real DXF entity inserted near
  * `(38425645.89, 4069531.44)`. Two MText blocks (SHX + mesh) are separated by
- * {@link LargeCoordinatesExample.TEXT_DELIMITER} in the textarea. The rebase
- * variant moves insertion to the origin; the no-rebase variant deliberately
- * preserves survey coordinates to demonstrate float32 precision loss.
+ * {@link LargeCoordinatesExample.TEXT_DELIMITER} in the textarea. Insertion stays at
+ * survey coordinates; the two blocks are stacked vertically for comparison.
  */
 export class LargeCoordinatesExample {
   /** Paragraph break sequence separating two editable MText blocks in the textarea. */
   static readonly TEXT_DELIMITER = '\\P\\P'
 
-  /** Default textarea content when either large-coordinate example button is clicked. */
+  /** Default textarea content when the large-coordinate example button is clicked. */
   static readonly DEFAULT_TEXT =
     '{\\Ftxt;SHX (476.473)}\\P\\P{\\Fsimkai;Mesh 大坐标 (476.473)}'
 
@@ -251,18 +250,7 @@ export class LargeCoordinatesExample {
    * @returns Whether `content` selects a large-coordinate demo path.
    */
   static isExample(content: string): boolean {
-    return (
-      content === 'largeCoordinatesRebase' ||
-      content === 'largeCoordinatesNoRebase'
-    )
-  }
-
-  /**
-   * @param content - Example marker passed to the render pipeline.
-   * @returns `true` only for the rebase-enabled variant.
-   */
-  static shouldRebase(content: string): boolean {
-    return content === 'largeCoordinatesRebase'
+    return content === 'largeCoordinates'
   }
 
   /**
@@ -342,18 +330,40 @@ export class LargeCoordinatesExample {
   }
 
   /**
-   * Vertically stacks rebased MText objects for side-by-side comparison in the viewport.
+   * Vertically stacks MText objects while preserving their large WCS insertion points.
    *
-   * @param mtextObjects - Rendered entities whose positions are rewritten in scene space.
+   * @param mtextObjects - Rendered entities whose insertion transform lives on the
+   *   render root (or another node with survey-scale coordinates).
    *
    * @remarks
-   * Uses a fixed row gap of 67 drawing units, centered around Y=0 when two blocks are present.
+   * Prevents SHX and mesh samples from overlapping at the exact same insertion point.
+   * Uses a fixed row gap of 67 drawing units, centered around the insertion Y.
    */
   static layoutPair(mtextObjects: MTextObject[]): void {
     const rowGap = 67
     const startY = ((mtextObjects.length - 1) * rowGap) / 2
+    const threshold = 1e5
+
     mtextObjects.forEach((obj, index) => {
-      obj.position.set(0, startY - index * rowGap, 0)
+      const offsetY = startY - index * rowGap
+      let applied = false
+
+      obj.traverse(child => {
+        if (
+          Math.abs(child.position.x) > threshold ||
+          Math.abs(child.position.y) > threshold
+        ) {
+          child.position.y += offsetY
+          child.updateMatrix()
+          applied = true
+        }
+      })
+
+      if (!applied) {
+        obj.position.y += offsetY
+        obj.updateMatrix()
+      }
+
       obj.updateMatrixWorld(true)
     })
   }

--- a/packages/example/src/exampleTexts.ts
+++ b/packages/example/src/exampleTexts.ts
@@ -40,10 +40,8 @@ export const EXAMPLE_TEXTS = {
   shapes: 'shapes',
   /** Marker: 3×4 attachment-point grid with insertion crosshairs (see {@link createAttachmentPointTestData}). */
   attachmentGrid: 'attachmentGrid',
-  /** Marker: large WCS sample with insertion rebase enabled (see {@link LargeCoordinatesExample}). */
-  largeCoordinatesRebase: 'largeCoordinatesRebase',
-  /** Marker: same large WCS sample without rebase — exposes float32 precision issues. */
-  largeCoordinatesNoRebase: 'largeCoordinatesNoRebase'
+  /** Marker: large WCS sample with survey-scale insertion (see {@link LargeCoordinatesExample}). */
+  largeCoordinates: 'largeCoordinates'
 } as const
 
 /**

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -623,10 +623,8 @@ class MTextRendererExample {
         this.viewport.scene.add(this.currentMText)
 
         if (LargeCoordinatesExample.isExample(content)) {
-          if (LargeCoordinatesExample.shouldRebase(content)) {
-            this.boundsHelper.rebaseInsertionToOrigin(this.currentMText)
-            LargeCoordinatesExample.layoutPair(mtextObjects)
-          }
+          LargeCoordinatesExample.layoutPair(mtextObjects)
+          this.boundsHelper.refreshDrawableBounds(this.currentMText)
         } else {
           this.boundsHelper.rebaseSceneOrigin(this.currentMText)
         }
@@ -645,14 +643,12 @@ class MTextRendererExample {
         const label =
           content === 'attachmentGrid'
             ? 'attachment-point grid'
-            : content === 'largeCoordinatesRebase'
-              ? 'large-coordinates MText (rebase ON; fonts via \\F)'
-              : content === 'largeCoordinatesNoRebase'
-                ? 'large-coordinates MText (rebase OFF; fonts via \\F)'
-                : 'MText batch'
+            : content === 'largeCoordinates'
+              ? 'large-coordinates MText (fonts via \\F)'
+              : 'MText batch'
         this.statusDiv.textContent = `Rendered ${mtextObjects.length}/${multiData.length} (${label}) in ${renderTime.toFixed(2)}ms (${this.renderModeSelect.value} thread)${
           LargeCoordinatesExample.isExample(content)
-            ? ` · DXF WCS insertion (38425645.89, 4069531.44); example width 100 (DXF group 41 was 128307003)${LargeCoordinatesExample.shouldRebase(content) ? '' : ' · rebase OFF'}`
+            ? ' · DXF WCS insertion (38425645.89, 4069531.44); example width 100 (DXF group 41 was 128307003)'
             : ''
         }`
       } else {

--- a/packages/example/src/sceneBoundsHelper.ts
+++ b/packages/example/src/sceneBoundsHelper.ts
@@ -13,8 +13,8 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
  *    `userData.excludeFromFit`.
  * 2. Records the shift in {@link wcsOriginOffset} so {@link WcsCoordinateDisplay}
  *    can report true WCS coordinates.
- * 3. Adjusts the orthographic frustum via {@link zoomToFit} instead of moving
- *    the camera to large coordinates (which would reintroduce precision loss).
+ * 3. Frames content with a camera centered on its bounds so large WCS insertions
+ *    cancel in modelView before local glyph vertices are projected.
  */
 export class SceneBoundsHelper {
   /**
@@ -203,42 +203,15 @@ export class SceneBoundsHelper {
   }
 
   /**
-   * Moves large WCS insertion transforms to the origin while preserving local glyph geometry.
-   *
-   * @param currentContent - Root group whose descendants may carry survey-scale positions.
-   *
-   * @remarks
-   * The first node with |position| above the threshold supplies {@link wcsOriginOffset}.
-   * Used by the large-coordinates example when rebase is enabled.
-   */
-  rebaseInsertionToOrigin(currentContent: THREE.Object3D | null): void {
-    let capturedOffset = false
-    currentContent?.traverse(child => {
-      if (
-        Math.abs(child.position.x) > this.largeWorldCoordinateThreshold ||
-        Math.abs(child.position.y) > this.largeWorldCoordinateThreshold
-      ) {
-        if (!capturedOffset) {
-          this.wcsOriginOffset.set(child.position.x, child.position.y, 0)
-          capturedOffset = true
-        }
-        child.position.set(0, 0, child.position.z)
-        child.updateMatrix()
-      }
-    })
-    currentContent?.updateWorldMatrix(true, true)
-    this.refreshDrawableBounds(currentContent)
-  }
-
-  /**
    * Frames `currentContent` in the viewport by adjusting the orthographic frustum.
    *
    * @param currentContent - Content to fit; when `null`, resets frustum to the full pane.
    * @param paddingRatio - Fractional padding added on each side of the content bounds (default `0.08`).
    *
    * @remarks
-   * The camera stays at the origin; only `left`/`right`/`top`/`bottom` change. Aspect
-   * ratio is preserved by expanding the narrower axis when content and view aspects differ.
+   * The camera moves to the content center and uses a symmetric local frustum so
+   * survey-scale insertions cancel in modelView before local glyph vertices are
+   * projected. Aspect ratio is preserved by expanding the narrower axis.
    */
   zoomToFit(
     currentContent: THREE.Object3D | null,
@@ -247,52 +220,45 @@ export class SceneBoundsHelper {
     const { width: viewW, height: viewH } = this.getRenderAreaSize()
 
     this.camera.zoom = 1
-    this.camera.position.set(0, 0, 100)
-    this.controls.target.set(0, 0, 0)
 
     if (!currentContent) {
+      this.camera.position.set(0, 0, 100)
+      this.controls.target.set(0, 0, 0)
       this.setDefaultFrustum(viewW, viewH)
       return
     }
 
     const worldBox = this.computeRenderableBounds(currentContent)
     if (worldBox.isEmpty()) {
+      this.camera.position.set(0, 0, 100)
+      this.controls.target.set(0, 0, 0)
       this.setDefaultFrustum(viewW, viewH)
       return
     }
 
-    const minX = worldBox.min.x
-    const maxX = worldBox.max.x
-    const minY = worldBox.min.y
-    const maxY = worldBox.max.y
-    const padX = Math.max((maxX - minX) * paddingRatio, 1e-6)
-    const padY = Math.max((maxY - minY) * paddingRatio, 1e-6)
-    let fitMinX = minX - padX
-    let fitMaxX = maxX + padX
-    let fitMinY = minY - padY
-    let fitMaxY = maxY + padY
+    const center = worldBox.getCenter(new THREE.Vector3())
+    this.camera.position.set(center.x, center.y, 100)
+    this.controls.target.set(center.x, center.y, 0)
 
-    const fitW = fitMaxX - fitMinX
-    const fitH = fitMaxY - fitMinY
+    const spanX = Math.max(worldBox.max.x - worldBox.min.x, 1e-6)
+    const spanY = Math.max(worldBox.max.y - worldBox.min.y, 1e-6)
+    let fitW = spanX * (1 + paddingRatio * 2)
+    let fitH = spanY * (1 + paddingRatio * 2)
     const viewAspect = viewW / viewH
     const fitAspect = fitW / fitH
 
     if (fitAspect > viewAspect) {
-      const expandedH = fitW / viewAspect
-      const centerY = (minY + maxY) / 2
-      fitMinY = centerY - expandedH / 2
-      fitMaxY = centerY + expandedH / 2
+      fitH = fitW / viewAspect
     } else {
-      const expandedW = fitH * viewAspect
-      const centerX = (minX + maxX) / 2
-      fitMinX = centerX - expandedW / 2
-      fitMaxX = centerX + expandedW / 2
+      fitW = fitH * viewAspect
     }
 
-    this.camera.left = fitMinX
-    this.camera.right = fitMaxX
-    this.camera.top = fitMaxY
-    this.camera.bottom = fitMinY
+    // Frame in camera-local coordinates so large WCS insertions cancel in
+    // modelView before local glyph vertices are transformed.
+    this.camera.left = -fitW / 2
+    this.camera.right = fitW / 2
+    this.camera.top = fitH / 2
+    this.camera.bottom = -fitH / 2
     this.camera.updateProjectionMatrix()
     this.controls.update()
   }
@@ -334,7 +300,7 @@ export class SceneBoundsHelper {
    *
    * @param root - Subtree whose drawable primitives should be refreshed.
    */
-  private refreshDrawableBounds(root: THREE.Object3D | null): void {
+  refreshDrawableBounds(root: THREE.Object3D | null): void {
     if (!root) {
       return
     }

--- a/packages/mtext-renderer/test/renderer/large-coordinates.integration.test.ts
+++ b/packages/mtext-renderer/test/renderer/large-coordinates.integration.test.ts
@@ -1,0 +1,332 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+
+import { FontManager } from '../../src/font/fontManager'
+import {
+  createDefaultColorSettings,
+  MTextAttachmentPoint,
+  MTextFlowDirection
+} from '../../src/renderer/types'
+import { MainThreadRenderer } from '../../src/worker/mainThreadRenderer'
+import { WebWorkerRenderer } from '../../src/worker/webWorkerRenderer'
+
+function getGeometryPositionMaxAbs(object: THREE.Object3D) {
+  let maxAbs = 0
+
+  object.traverse(child => {
+    if (!('geometry' in child)) return
+
+    const position = (child.geometry as THREE.BufferGeometry).getAttribute(
+      'position'
+    )
+    if (!position) return
+
+    for (let i = 0; i < position.count; i++) {
+      maxAbs = Math.max(
+        maxAbs,
+        Math.abs(position.getX(i)),
+        Math.abs(position.getY(i)),
+        Math.abs(position.getZ(i))
+      )
+    }
+  })
+
+  return maxAbs
+}
+
+function getWorldVertexSpread(object: THREE.Object3D) {
+  const min = new THREE.Vector3(Infinity, Infinity, Infinity)
+  const max = new THREE.Vector3(-Infinity, -Infinity, -Infinity)
+  const point = new THREE.Vector3()
+
+  object.updateWorldMatrix(true, true)
+  object.traverse(child => {
+    if (!('geometry' in child)) return
+
+    const position = (child.geometry as THREE.BufferGeometry).getAttribute(
+      'position'
+    )
+    if (!position) return
+
+    child.updateWorldMatrix(true, false)
+    for (let i = 0; i < position.count; i++) {
+      point.fromBufferAttribute(position, i).applyMatrix4(child.matrixWorld)
+      min.min(point)
+      max.max(point)
+    }
+  })
+
+  return { min, max }
+}
+
+const sharedMTextData = {
+  height: 4.0222404674496,
+  width: 100,
+  position: new THREE.Vector3(38425645.890718, 4069531.4443921, 0),
+  attachmentPoint: MTextAttachmentPoint.MiddleCenter,
+  drawingDirection: MTextFlowDirection.BY_STYLE,
+  directionVector: new THREE.Vector3(
+    0.9995686730481862,
+    -0.02936780313009985,
+    0
+  ),
+  lineSpaceFactor: 1.0
+}
+
+const textStyle = {
+  name: 'Standard',
+  standardFlag: 0,
+  fixedTextHeight: 4.0222404674496,
+  widthFactor: 1,
+  obliqueAngle: 0,
+  textGenerationFlag: 0,
+  lastHeight: 4.0222404674496,
+  font: 'txt',
+  bigFont: ''
+}
+
+describe('large coordinates integration', () => {
+  it('keeps glyph geometry local on main thread with real fonts', async () => {
+    FontManager.instance.setDefaultFonts('minimal')
+    const renderer = new MainThreadRenderer()
+    await renderer.loadFonts(['txt', 'simkai'])
+
+    const shx = await renderer.asyncRenderMText(
+      { ...sharedMTextData, text: '{\\Ftxt;SHX (476.473)}' },
+      textStyle
+    )
+    const mesh = await renderer.asyncRenderMText(
+      {
+        ...sharedMTextData,
+        text: '{\\Fsimkai;Mesh 大坐标 (476.473)}'
+      },
+      { ...textStyle, font: 'simkai' }
+    )
+
+    expect(getGeometryPositionMaxAbs(shx)).toBeLessThan(200)
+    expect(getGeometryPositionMaxAbs(mesh)).toBeLessThan(200)
+
+    const shxSpread = getWorldVertexSpread(shx)
+    expect(shxSpread.min.x).toBeGreaterThan(sharedMTextData.position.x - 200)
+    expect(shxSpread.max.x).toBeLessThan(sharedMTextData.position.x + 200)
+
+    shx.traverse(child => {
+      if (!('geometry' in child)) return
+      const position = (child.geometry as THREE.BufferGeometry).getAttribute(
+        'position'
+      )
+      if (!position) return
+      for (let i = 0; i < position.count; i++) {
+        expect(Number.isFinite(position.getX(i))).toBe(true)
+        expect(Number.isFinite(position.getY(i))).toBe(true)
+      }
+    })
+  }, 60_000)
+
+  it('preserves local geometry through manual worker-style reconstruction', async () => {
+    FontManager.instance.setDefaultFonts('minimal')
+    const main = new MainThreadRenderer()
+    await main.loadFonts(['txt'])
+
+    const source = await main.asyncRenderMText(
+      { ...sharedMTextData, text: '{\\Ftxt;SHX (476.473)}' },
+      textStyle
+    )
+
+    const renderRoot = source.children[0] as THREE.Object3D
+    renderRoot.updateWorldMatrix(true, true)
+    const rootWorldInverse = new THREE.Matrix4()
+      .copy(renderRoot.matrixWorld)
+      .invert()
+    const childRelativeMatrix = new THREE.Matrix4()
+
+    const children: Array<{
+      type: 'mesh' | 'line'
+      position: { x: number; y: number; z: number }
+      rotation: { x: number; y: number; z: number; w: number }
+      scale: { x: number; y: number; z: number }
+      geometry: {
+        attributes: Record<string, unknown>
+        index: null
+      }
+      material: { type: string; color: number; transparent: boolean; opacity: number }
+    }> = []
+
+    renderRoot.traverse(child => {
+      if (!(child instanceof THREE.Mesh || child instanceof THREE.LineSegments)) {
+        return
+      }
+
+      const position = new THREE.Vector3()
+      const quaternion = new THREE.Quaternion()
+      const scale = new THREE.Vector3()
+      childRelativeMatrix.multiplyMatrices(rootWorldInverse, child.matrixWorld)
+      childRelativeMatrix.decompose(position, quaternion, scale)
+
+      const attr = child.geometry.getAttribute('position')
+      const arrayBuffer = (attr.array as Float32Array).slice().buffer
+      children.push({
+        type: child instanceof THREE.Mesh ? 'mesh' : 'line',
+        position: { x: position.x, y: position.y, z: position.z },
+        rotation: {
+          x: quaternion.x,
+          y: quaternion.y,
+          z: quaternion.z,
+          w: quaternion.w
+        },
+        scale: { x: scale.x, y: scale.y, z: scale.z },
+        geometry: {
+          attributes: {
+            position: {
+              arrayBuffer,
+              byteOffset: 0,
+              length: attr.array.length,
+              itemSize: 3,
+              normalized: false
+            }
+          },
+          index: null
+        },
+        material: {
+          type: 'MeshBasicMaterial',
+          color: 0xffffff,
+          transparent: false,
+          opacity: 1
+        }
+      })
+    })
+
+    const position = new THREE.Vector3()
+    const quaternion = new THREE.Quaternion()
+    const scale = new THREE.Vector3()
+    renderRoot.matrixWorld.decompose(position, quaternion, scale)
+
+    const workerRenderer = new WebWorkerRenderer({ poolSize: 0 })
+    const reconstructed = workerRenderer.reconstructMText(
+      {
+        type: 'MText',
+        position: { x: position.x, y: position.y, z: position.z },
+        rotation: {
+          x: quaternion.x,
+          y: quaternion.y,
+          z: quaternion.z,
+          w: quaternion.w
+        },
+        scale: { x: scale.x, y: scale.y, z: scale.z },
+        box: {
+          min: {
+            x: source.box.min.x,
+            y: source.box.min.y,
+            z: source.box.min.z
+          },
+          max: {
+            x: source.box.max.x,
+            y: source.box.max.y,
+            z: source.box.max.z
+          }
+        },
+        children
+      },
+      createDefaultColorSettings()
+    )
+
+    expect(getGeometryPositionMaxAbs(reconstructed)).toBeLessThan(200)
+    expect(reconstructed.position.x).toBeCloseTo(sharedMTextData.position.x, 3)
+
+    const sourceSpread = getWorldVertexSpread(source)
+    const reconstructedSpread = getWorldVertexSpread(reconstructed)
+    expect(reconstructedSpread.min.x).toBeCloseTo(sourceSpread.min.x, 1)
+    expect(reconstructedSpread.max.x).toBeCloseTo(sourceSpread.max.x, 1)
+
+    workerRenderer.destroy()
+  }, 60_000)
+
+  it('projects all glyph vertices into clip space when framed like the example viewer', async () => {
+    FontManager.instance.setDefaultFonts('minimal')
+    const renderer = new MainThreadRenderer()
+    await renderer.loadFonts(['txt', 'simkai'])
+
+    const shx = await renderer.asyncRenderMText(
+      { ...sharedMTextData, text: '{\\Ftxt;SHX (476.473)}' },
+      textStyle
+    )
+    const mesh = await renderer.asyncRenderMText(
+      {
+        ...sharedMTextData,
+        text: '{\\Fsimkai;Mesh 大坐标 (476.473)}'
+      },
+      { ...textStyle, font: 'simkai' }
+    )
+
+    const group = new THREE.Group()
+    group.add(shx, mesh)
+
+    group.updateWorldMatrix(true, true)
+    const bounds = new THREE.Box3()
+    const tempBox = new THREE.Box3()
+    group.traverse(child => {
+      if (
+        child instanceof THREE.LineSegments ||
+        child instanceof THREE.Mesh
+      ) {
+        const geometry = child.geometry as THREE.BufferGeometry
+        if (!geometry.boundingBox) geometry.computeBoundingBox()
+        if (!geometry.boundingBox || geometry.boundingBox.isEmpty()) return
+        tempBox.copy(geometry.boundingBox).applyMatrix4(child.matrixWorld)
+        bounds.union(tempBox)
+      }
+    })
+
+    const camera = new THREE.OrthographicCamera(0, 800, 600, 0, -1000, 1000)
+    camera.position.set(0, 0, 100)
+    camera.zoom = 1
+    const paddingRatio = 0.08
+    const minX = bounds.min.x
+    const maxX = bounds.max.x
+    const minY = bounds.min.y
+    const maxY = bounds.max.y
+    const padX = Math.max((maxX - minX) * paddingRatio, 1e-6)
+    const padY = Math.max((maxY - minY) * paddingRatio, 1e-6)
+    camera.left = minX - padX
+    camera.right = maxX + padX
+    camera.top = maxY + padY
+    camera.bottom = minY - padY
+    camera.updateProjectionMatrix()
+    camera.updateMatrixWorld(true)
+
+    const mvp = new THREE.Matrix4().multiplyMatrices(
+      camera.projectionMatrix,
+      camera.matrixWorldInverse
+    )
+    const clip = new THREE.Vector4()
+    let outOfRange = 0
+    let maxAbsClip = 0
+    group.traverse(child => {
+      if (!('geometry' in child)) return
+      const position = (child.geometry as THREE.BufferGeometry).getAttribute(
+        'position'
+      )
+      if (!position) return
+      child.updateWorldMatrix(true, false)
+      const world = new THREE.Matrix4().multiplyMatrices(
+        mvp,
+        child.matrixWorld
+      )
+      for (let i = 0; i < position.count; i++) {
+        clip.set(
+          position.getX(i),
+          position.getY(i),
+          position.getZ(i),
+          1
+        ).applyMatrix4(world)
+        const ndcX = clip.x / clip.w
+        const ndcY = clip.y / clip.w
+        maxAbsClip = Math.max(maxAbsClip, Math.abs(ndcX), Math.abs(ndcY))
+        if (Math.abs(ndcX) > 1.5 || Math.abs(ndcY) > 1.5) outOfRange++
+      }
+    })
+
+    expect(outOfRange).toBe(0)
+    expect(maxAbsClip).toBeLessThanOrEqual(1.05)
+  }, 60_000)
+})


### PR DESCRIPTION
## Summary
- Consolidate the large-coordinates example into a single demo that keeps survey-scale WCS insertion points instead of offering separate rebase / no-rebase variants.
- Update `SceneBoundsHelper.zoomToFit` to move the orthographic camera to content bounds and use a symmetric local frustum, so large insertions cancel in modelView before local glyph vertices are projected.
- Remove `rebaseInsertionToOrigin` and adjust `LargeCoordinatesExample.layoutPair` to stack SHX/mesh blocks without rewriting insertion transforms.
- Add integration tests covering local glyph geometry, worker-style reconstruction, and clip-space projection at large coordinates.

## Test plan
- [ ] Open the example app and run the **Large Coordinates** demo; verify SHX and mesh text render correctly at survey-scale insertion.
- [ ] Confirm orbit/pan controls and fit-to-view still behave for other examples.
- [ ] Run `nx test mtext-renderer` and verify `large-coordinates.integration.test.ts` passes.

Made with [Cursor](https://cursor.com)