### PR TITLE
chore: switch npm publish to Trusted Publishing and release v0.11.5

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    environment: release
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -26,13 +28,17 @@ jobs:
 
       - uses: pnpm/action-setup@v6
 
-      # Cache node_modules
-      - uses: actions/setup-node@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org
-       
+          scope: '@mlightcad'
+
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
     
@@ -45,13 +51,22 @@ jobs:
       - name: Build the package
         run: pnpm build
 
+      # Authenticates via npm Trusted Publishing (OIDC); no NPM_TOKEN needed.
+      # Configure on npmjs.com → @mlightcad/mtext-renderer → Settings → Trusted publishing:
+      #   Provider: GitHub Actions
+      #   Repository: mlightcad/mtext-renderer
+      #   Workflow filename: ci-cd.yml
+      #   Environment: release  (must match the job environment above)
       - name: Publish packages to npm
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           cp README.md packages/mtext-renderer/README.md
+          npm --version
+          # setup-node writes an empty _authToken line that blocks OIDC fallback
+          if [ -f "$HOME/.npmrc" ]; then
+            sed -i '/_authToken/d' "$HOME/.npmrc"
+          fi
           pnpm publish:renderer
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub release
         if: startsWith(github.ref, 'refs/tags/')

--- a/packages/mtext-renderer/package.json
+++ b/packages/mtext-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/mtext-renderer",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "AutoCAD MText renderer based on Three.js",
   "license": "MIT",
   "author": "MLight Lee <mlight.lee@outlook.com>",
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@mlightcad/mtext-parser": "^1.5.0",
-    "@mlightcad/shx-parser": "^1.3.4",
+    "@mlightcad/shx-parser": "^1.3.5",
     "iconv-lite": "^0.7.0",
     "idb": "^8.0.3",
     "opentype.js": "^2.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@mlightcad/shx-parser':
-        specifier: ^1.3.4
-        version: 1.3.4
+        specifier: ^1.3.5
+        version: 1.3.5
       iconv-lite:
         specifier: ^0.7.0
         version: 0.7.0
@@ -998,8 +998,8 @@ packages:
   '@mlightcad/mtext-parser@1.5.0':
     resolution: {integrity: sha512-Yl/IQmSIGV1UUl/TyUptoOpNBunywcEE7yh4k9SFDXljHDTTI92VmqkVFxf4eYzhoWF4MNXIl4qgQV1P1Rbn6g==}
 
-  '@mlightcad/shx-parser@1.3.4':
-    resolution: {integrity: sha512-y0clXQIBslAOwTMFtUnQqzZqhtD5lxUCiJA7lYTYvzO2dzBtsd2LVhUYdyA6R6DwjygOzjegXcP/4oCIsDiZhg==}
+  '@mlightcad/shx-parser@1.3.5':
+    resolution: {integrity: sha512-svlplug902g9dZWARFbpwjRpIoMFDmoCqmjTDx0QGHxdPv7pcQz/5WB5IIfYXyRyGobVSK6YQWVdm+LolPnWsA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4470,7 +4470,7 @@ snapshots:
 
   '@mlightcad/mtext-parser@1.5.0': {}
 
-  '@mlightcad/shx-parser@1.3.4': {}
+  '@mlightcad/shx-parser@1.3.5': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary

- Switch CI npm publish from `NPM_TOKEN` to npm Trusted Publishing (OIDC): add `release` environment, configure `@mlightcad` scope, upgrade npm, and strip `_authToken` from `.npmrc` so OIDC fallback works.
- Bump `@mlightcad/mtext-renderer` to v0.11.5.
- Update `@mlightcad/shx-parser` dependency to ^1.3.5.

## Test plan

- [ ] Confirm npm Trusted Publishing is configured on npmjs.com for `@mlightcad/mtext-renderer` (workflow: `ci-cd.yml`, environment: `release`).
- [ ] Verify CI passes on this PR (build + test).
- [ ] After merge, tag release and confirm publish succeeds without `NPM_TOKEN`.